### PR TITLE
feat(samples): add from-url command for YouTube voice sampling

### DIFF
--- a/src/voicecli/cli.py
+++ b/src/voicecli/cli.py
@@ -124,6 +124,31 @@ def samples_remove(
         raise typer.Exit(1)
 
 
+@samples_app.command("from-url")
+def samples_from_url(
+    url: Annotated[str, typer.Argument(help="YouTube (or other yt-dlp supported) URL")],
+    name: Annotated[str, typer.Argument(help="Name for the sample (without .wav)")],
+    start: Annotated[
+        float, typer.Option("--start", "-s", help="Start time in seconds (skip intro)")
+    ] = 10.0,
+    duration: Annotated[float, typer.Option("--duration", "-d", help="Duration in seconds")] = 30.0,
+    use: Annotated[bool, typer.Option("--use", help="Set as active sample after download")] = False,
+):
+    """Download audio from a URL, extract and normalize a voice sample."""
+    from voicecli.samples import from_url, set_active
+
+    try:
+        dest = from_url(url, name, start=start, duration=duration)
+        typer.echo(f"Added {dest}")
+        if use:
+            wav_name = dest.name
+            set_active(wav_name)
+            typer.echo(f"Active sample set to: {wav_name}")
+    except RuntimeError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
+
+
 # ── CUDA error formatting (moved from engine.py cuda_guard) ──────────────────
 
 

--- a/src/voicecli/cli.py
+++ b/src/voicecli/cli.py
@@ -144,7 +144,7 @@ def samples_from_url(
             wav_name = dest.name
             set_active(wav_name)
             typer.echo(f"Active sample set to: {wav_name}")
-    except RuntimeError as e:
+    except (RuntimeError, ValueError) as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
 

--- a/src/voicecli/samples.py
+++ b/src/voicecli/samples.py
@@ -62,7 +62,6 @@ def get_active_path() -> Path | None:
 def _play_wav(samples, samplerate: int = 44100) -> None:
     """Play a numpy int16 array via paplay."""
     import struct
-    import subprocess
     import tempfile
 
     with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
@@ -156,11 +155,23 @@ def from_url(
 ) -> Path:
     """Download audio from a URL (YouTube etc.) via yt-dlp, extract and normalize a segment."""
     import tempfile
+    from urllib.parse import urlparse
+
+    if start < 0:
+        raise ValueError(f"start must be non-negative, got {start}")
+    if duration <= 0:
+        raise ValueError(f"duration must be positive, got {duration}")
+
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"Only http/https URLs are supported, got '{parsed.scheme}://'")
 
     _check_tool("yt-dlp")
     _check_tool("ffmpeg")
 
     ensure_dir()
+    # Sanitize name to a bare filename (prevent path traversal)
+    name = Path(name).name
     if not name.endswith(".wav"):
         name = f"{name}.wav"
     dest = SAMPLES_DIR / name
@@ -169,47 +180,57 @@ def from_url(
         raw_audio = Path(tmpdir) / "raw.%(ext)s"
         # Download best audio
         print(f"Downloading audio from {url}...")
-        subprocess.run(
-            [
-                "yt-dlp",
-                "-x",
-                "--audio-format",
-                "wav",
-                "-o",
-                str(raw_audio),
-                url,
-            ],
-            check=True,
-        )
+        try:
+            subprocess.run(
+                [
+                    "yt-dlp",
+                    "--no-config",
+                    "-x",
+                    "--audio-format",
+                    "wav",
+                    "-o",
+                    str(raw_audio),
+                    "--",
+                    url,
+                ],
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(f"yt-dlp failed (exit {e.returncode}). Check the URL.") from e
 
-        # Find the downloaded file (yt-dlp replaces %(ext)s)
-        downloaded = list(Path(tmpdir).glob("raw.*"))
+        # Find the downloaded .wav file (yt-dlp replaces %(ext)s)
+        downloaded = [p for p in Path(tmpdir).glob("raw.*") if p.suffix == ".wav"]
         if not downloaded:
-            raise RuntimeError("yt-dlp did not produce an output file")
+            raise RuntimeError("yt-dlp did not produce a WAV output file")
         raw_file = downloaded[0]
 
         # Extract segment + normalize to mono 24kHz with loudnorm
         print(f"Extracting {duration}s segment from {start}s, normalizing...")
-        subprocess.run(
-            [
-                "ffmpeg",
-                "-y",
-                "-ss",
-                str(start),
-                "-t",
-                str(duration),
-                "-i",
-                str(raw_file),
-                "-ac",
-                "1",
-                "-ar",
-                "24000",
-                "-af",
-                "loudnorm=I=-16:TP=-1.5:LRA=11",
-                str(dest),
-            ],
-            check=True,
-        )
+        try:
+            subprocess.run(
+                [
+                    "ffmpeg",
+                    "-y",
+                    "-ss",
+                    str(start),
+                    "-t",
+                    str(duration),
+                    "-i",
+                    str(raw_file),
+                    "-ac",
+                    "1",
+                    "-ar",
+                    "24000",
+                    "-af",
+                    "loudnorm=I=-16:TP=-1.5:LRA=11",
+                    str(dest),
+                ],
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(
+                f"ffmpeg failed (exit {e.returncode}). The audio may be corrupted."
+            ) from e
 
     print(f"Saved sample to {dest}")
     return dest

--- a/src/voicecli/samples.py
+++ b/src/voicecli/samples.py
@@ -1,6 +1,7 @@
-"""Sample management: list, add, record, use, active, remove."""
+"""Sample management: list, add, record, use, active, remove, from-url."""
 
 import shutil
+import subprocess
 from pathlib import Path
 
 SAMPLES_DIR = Path("TTS/samples")
@@ -133,6 +134,85 @@ def _chime(kind: str = "start", samplerate: int = 44100) -> None:
     signal = np.clip(signal, -1, 1)
     signal = (signal * 32767).astype(np.int16)
     _play_wav(signal, samplerate)
+
+
+def _check_tool(name: str) -> None:
+    """Raise RuntimeError if an external tool is not installed."""
+    if not shutil.which(name):
+        hints = {
+            "yt-dlp": "Install with: uv tool install yt-dlp",
+            "ffmpeg": "Install with: sudo apt install ffmpeg",
+        }
+        hint = hints.get(name, f"Please install {name}")
+        raise RuntimeError(f"'{name}' not found on PATH. {hint}")
+
+
+def from_url(
+    url: str,
+    name: str,
+    *,
+    start: float = 10.0,
+    duration: float = 30.0,
+) -> Path:
+    """Download audio from a URL (YouTube etc.) via yt-dlp, extract and normalize a segment."""
+    import tempfile
+
+    _check_tool("yt-dlp")
+    _check_tool("ffmpeg")
+
+    ensure_dir()
+    if not name.endswith(".wav"):
+        name = f"{name}.wav"
+    dest = SAMPLES_DIR / name
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        raw_audio = Path(tmpdir) / "raw.%(ext)s"
+        # Download best audio
+        print(f"Downloading audio from {url}...")
+        subprocess.run(
+            [
+                "yt-dlp",
+                "-x",
+                "--audio-format",
+                "wav",
+                "-o",
+                str(raw_audio),
+                url,
+            ],
+            check=True,
+        )
+
+        # Find the downloaded file (yt-dlp replaces %(ext)s)
+        downloaded = list(Path(tmpdir).glob("raw.*"))
+        if not downloaded:
+            raise RuntimeError("yt-dlp did not produce an output file")
+        raw_file = downloaded[0]
+
+        # Extract segment + normalize to mono 24kHz with loudnorm
+        print(f"Extracting {duration}s segment from {start}s, normalizing...")
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-ss",
+                str(start),
+                "-t",
+                str(duration),
+                "-i",
+                str(raw_file),
+                "-ac",
+                "1",
+                "-ar",
+                "24000",
+                "-af",
+                "loudnorm=I=-16:TP=-1.5:LRA=11",
+                str(dest),
+            ],
+            check=True,
+        )
+
+    print(f"Saved sample to {dest}")
+    return dest
 
 
 def record_sample(name: str, duration: float = 10.0, samplerate: int = 24000) -> Path:

--- a/tests/test_samples_from_url.py
+++ b/tests/test_samples_from_url.py
@@ -2,109 +2,337 @@
 
 import subprocess
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import patch
 
 import pytest
 
 from voicecli.samples import _check_tool, from_url
 
 
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def samples_env(tmp_path, monkeypatch):
+    """Set up a temporary samples directory and return (samples_dir, fake_run_factory)."""
+    samples_dir = tmp_path / "samples"
+    samples_dir.mkdir()
+    monkeypatch.setattr("voicecli.samples.SAMPLES_DIR", samples_dir)
+    monkeypatch.setattr("voicecli.samples.ACTIVE_FILE", samples_dir / ".active")
+
+    def make_fake_run(*, also_write_dest: bool = False):
+        """Return a fake subprocess.run that simulates yt-dlp creating a file."""
+
+        def fake_run(cmd, *, check=False):
+            if cmd[0] == "yt-dlp":
+                o_idx = cmd.index("-o")
+                pattern = cmd[o_idx + 1]
+                fake_path = Path(pattern.replace("%(ext)s", "wav"))
+                fake_path.write_bytes(b"fake audio data")
+            elif cmd[0] == "ffmpeg" and also_write_dest:
+                # Write a fake dest file (last positional arg)
+                Path(cmd[-1]).write_bytes(b"fake wav")
+
+        return fake_run
+
+    return samples_dir, make_fake_run
+
+
+# ── _check_tool ──────────────────────────────────────────────────────────────
+
+
 class TestCheckTool:
     def test_found(self):
-        with patch("shutil.which", return_value="/usr/bin/git"):
+        # Arrange / Act / Assert
+        with patch("voicecli.samples.shutil.which", return_value="/usr/bin/git"):
             _check_tool("git")  # should not raise
 
     def test_not_found_yt_dlp(self):
-        with patch("shutil.which", return_value=None):
+        # Arrange / Act / Assert
+        with patch("voicecli.samples.shutil.which", return_value=None):
             with pytest.raises(RuntimeError, match="yt-dlp.*not found"):
                 _check_tool("yt-dlp")
 
     def test_not_found_ffmpeg(self):
-        with patch("shutil.which", return_value=None):
+        # Arrange / Act / Assert
+        with patch("voicecli.samples.shutil.which", return_value=None):
             with pytest.raises(RuntimeError, match="ffmpeg.*not found"):
                 _check_tool("ffmpeg")
+
+
+# ── from_url unit tests ─────────────────────────────────────────────────────
 
 
 class TestFromUrl:
     @patch("voicecli.samples.subprocess.run")
     @patch("voicecli.samples.shutil.which", return_value="/usr/bin/ok")
-    def test_downloads_extracts_and_normalizes(self, mock_which, mock_run, tmp_path, monkeypatch):
-        """Verify yt-dlp and ffmpeg are called with correct args."""
-        samples_dir = tmp_path / "samples"
-        samples_dir.mkdir()
-        monkeypatch.setattr("voicecli.samples.SAMPLES_DIR", samples_dir)
-        monkeypatch.setattr("voicecli.samples.ACTIVE_FILE", samples_dir / ".active")
+    def test_downloads_extracts_and_normalizes(self, _mock_which, mock_run, samples_env):
+        # Arrange
+        samples_dir, make_fake_run = samples_env
+        mock_run.side_effect = make_fake_run(also_write_dest=True)
 
-        # yt-dlp creates a file in the temp dir — simulate this
-        def fake_run(cmd, *, check=False):
-            if cmd[0] == "yt-dlp":
-                # Find the -o arg to know where to create the fake file
-                o_idx = cmd.index("-o")
-                pattern = cmd[o_idx + 1]
-                # yt-dlp replaces %(ext)s with wav
-                fake_path = Path(pattern.replace("%(ext)s", "wav"))
-                fake_path.write_bytes(b"fake audio data")
-
-        mock_run.side_effect = fake_run
-
+        # Act
         dest = from_url("https://youtube.com/watch?v=test", "mysample", start=5.0, duration=20.0)
 
+        # Assert
         assert dest == samples_dir / "mysample.wav"
+        assert dest.exists()
         assert mock_run.call_count == 2
 
-        # First call: yt-dlp
-        yt_call = mock_run.call_args_list[0]
-        assert yt_call[0][0][0] == "yt-dlp"
-        assert "-x" in yt_call[0][0]
-        assert "https://youtube.com/watch?v=test" in yt_call[0][0]
+        yt_args = mock_run.call_args_list[0][0][0]
+        assert yt_args[0] == "yt-dlp"
+        assert "--no-config" in yt_args
+        assert "--" in yt_args
+        assert "https://youtube.com/watch?v=test" in yt_args
 
-        # Second call: ffmpeg
-        ff_call = mock_run.call_args_list[1]
-        ff_args = ff_call[0][0]
+        ff_args = mock_run.call_args_list[1][0][0]
         assert ff_args[0] == "ffmpeg"
-        assert "-ss" in ff_args
         ss_idx = ff_args.index("-ss")
         assert ff_args[ss_idx + 1] == "5.0"
         t_idx = ff_args.index("-t")
         assert ff_args[t_idx + 1] == "20.0"
-        assert "-ac" in ff_args
         assert "24000" in ff_args
 
     @patch("voicecli.samples.shutil.which", return_value=None)
-    def test_missing_yt_dlp(self, mock_which):
+    def test_missing_yt_dlp(self, _mock_which):
+        # Act / Assert
         with pytest.raises(RuntimeError, match="yt-dlp"):
+            from_url("https://youtube.com/watch?v=test", "sample")
+
+    @patch("voicecli.samples.shutil.which")
+    def test_missing_ffmpeg_only(self, mock_which):
+        # Arrange — yt-dlp found, ffmpeg not
+        mock_which.side_effect = lambda name: "/usr/bin/yt-dlp" if name == "yt-dlp" else None
+
+        # Act / Assert
+        with pytest.raises(RuntimeError, match="ffmpeg.*not found"):
             from_url("https://youtube.com/watch?v=test", "sample")
 
     @patch("voicecli.samples.subprocess.run")
     @patch("voicecli.samples.shutil.which", return_value="/usr/bin/ok")
-    def test_appends_wav_extension(self, mock_which, mock_run, tmp_path, monkeypatch):
-        samples_dir = tmp_path / "samples"
-        samples_dir.mkdir()
-        monkeypatch.setattr("voicecli.samples.SAMPLES_DIR", samples_dir)
-        monkeypatch.setattr("voicecli.samples.ACTIVE_FILE", samples_dir / ".active")
+    def test_appends_wav_extension(self, _mock_which, mock_run, samples_env):
+        # Arrange
+        _samples_dir, make_fake_run = samples_env
+        mock_run.side_effect = make_fake_run()
 
-        def fake_run(cmd, *, check=False):
-            if cmd[0] == "yt-dlp":
-                o_idx = cmd.index("-o")
-                pattern = cmd[o_idx + 1]
-                fake_path = Path(pattern.replace("%(ext)s", "wav"))
-                fake_path.write_bytes(b"fake")
+        # Act
+        dest = from_url("https://example.com/video", "no_ext")
 
-        mock_run.side_effect = fake_run
-
-        dest = from_url("https://example.com", "no_ext")
+        # Assert
         assert dest.name == "no_ext.wav"
 
     @patch("voicecli.samples.subprocess.run")
     @patch("voicecli.samples.shutil.which", return_value="/usr/bin/ok")
-    def test_no_output_from_ytdlp_raises(self, mock_which, mock_run, tmp_path, monkeypatch):
-        samples_dir = tmp_path / "samples"
-        samples_dir.mkdir()
-        monkeypatch.setattr("voicecli.samples.SAMPLES_DIR", samples_dir)
-        monkeypatch.setattr("voicecli.samples.ACTIVE_FILE", samples_dir / ".active")
-
-        # yt-dlp runs but doesn't create any file
+    def test_no_output_from_ytdlp_raises(self, _mock_which, mock_run, samples_env):
+        # Arrange — yt-dlp runs but creates no file
         mock_run.return_value = None
 
+        # Act / Assert
         with pytest.raises(RuntimeError, match="did not produce"):
-            from_url("https://example.com", "sample")
+            from_url("https://example.com/video", "sample")
+
+    @patch("voicecli.samples.subprocess.run")
+    @patch("voicecli.samples.shutil.which", return_value="/usr/bin/ok")
+    def test_ytdlp_failure_raises_runtime_error(self, _mock_which, mock_run, samples_env):
+        # Arrange
+        mock_run.side_effect = subprocess.CalledProcessError(1, "yt-dlp")
+
+        # Act / Assert
+        with pytest.raises(RuntimeError, match="yt-dlp failed"):
+            from_url("https://example.com/video", "sample")
+
+    @patch("voicecli.samples.subprocess.run")
+    @patch("voicecli.samples.shutil.which", return_value="/usr/bin/ok")
+    def test_ffmpeg_failure_raises_runtime_error(self, _mock_which, mock_run, samples_env):
+        # Arrange — yt-dlp succeeds, ffmpeg fails
+        _samples_dir, make_fake_run = samples_env
+        call_count = 0
+
+        def ytdlp_ok_ffmpeg_fail(cmd, *, check=False):
+            nonlocal call_count
+            call_count += 1
+            if cmd[0] == "yt-dlp":
+                make_fake_run()(cmd, check=check)
+            else:
+                raise subprocess.CalledProcessError(1, "ffmpeg")
+
+        mock_run.side_effect = ytdlp_ok_ffmpeg_fail
+
+        # Act / Assert
+        with pytest.raises(RuntimeError, match="ffmpeg failed"):
+            from_url("https://example.com/video", "sample")
+
+    def test_negative_start_raises(self):
+        # Act / Assert
+        with pytest.raises(ValueError, match="start must be non-negative"):
+            from_url("https://example.com/video", "sample", start=-5.0)
+
+    def test_zero_duration_raises(self):
+        # Act / Assert
+        with pytest.raises(ValueError, match="duration must be positive"):
+            from_url("https://example.com/video", "sample", duration=0)
+
+    def test_non_http_url_raises(self):
+        # Act / Assert
+        with pytest.raises(ValueError, match="Only http/https"):
+            from_url("file:///etc/passwd", "sample")
+
+    @patch("voicecli.samples.subprocess.run")
+    @patch("voicecli.samples.shutil.which", return_value="/usr/bin/ok")
+    def test_path_traversal_stripped(self, _mock_which, mock_run, samples_env):
+        # Arrange
+        samples_dir, make_fake_run = samples_env
+        mock_run.side_effect = make_fake_run()
+
+        # Act
+        dest = from_url("https://example.com/video", "../../../tmp/evil")
+
+        # Assert — name is sanitized to bare filename
+        assert dest.parent == samples_dir
+        assert dest.name == "evil.wav"
+
+    @patch("voicecli.samples.subprocess.run")
+    @patch("voicecli.samples.shutil.which", return_value="/usr/bin/ok")
+    def test_uses_default_start_and_duration(self, _mock_which, mock_run, samples_env):
+        # Arrange
+        _samples_dir, make_fake_run = samples_env
+        mock_run.side_effect = make_fake_run()
+
+        # Act
+        from_url("https://example.com/video", "defaults")
+
+        # Assert — ffmpeg gets default start=10.0, duration=30.0
+        ff_args = mock_run.call_args_list[1][0][0]
+        ss_idx = ff_args.index("-ss")
+        assert ff_args[ss_idx + 1] == "10.0"
+        t_idx = ff_args.index("-t")
+        assert ff_args[t_idx + 1] == "30.0"
+
+
+# ── CLI command tests ────────────────────────────────────────────────────────
+
+
+class TestSamplesFromUrlCommand:
+    def test_happy_path(self):
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        # Arrange
+        runner = CliRunner()
+        fake_dest = Path("TTS/samples/myvoice.wav")
+
+        with patch("voicecli.samples.from_url", return_value=fake_dest) as mock_from_url:
+            # Act
+            result = runner.invoke(app, ["samples", "from-url", "https://yt.com/v", "myvoice"])
+
+            # Assert
+            assert result.exit_code == 0
+            assert "Added" in result.stdout
+            mock_from_url.assert_called_once_with(
+                "https://yt.com/v", "myvoice", start=10.0, duration=30.0
+            )
+
+    def test_use_flag_sets_active(self):
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        # Arrange
+        runner = CliRunner()
+        fake_dest = Path("TTS/samples/myvoice.wav")
+
+        with (
+            patch("voicecli.samples.from_url", return_value=fake_dest),
+            patch("voicecli.samples.set_active") as mock_set_active,
+        ):
+            # Act
+            result = runner.invoke(
+                app, ["samples", "from-url", "https://yt.com/v", "myvoice", "--use"]
+            )
+
+            # Assert
+            assert result.exit_code == 0
+            assert "Active sample set to: myvoice.wav" in result.stdout
+            mock_set_active.assert_called_once_with("myvoice.wav")
+
+    def test_use_flag_absent_does_not_set_active(self):
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        # Arrange
+        runner = CliRunner()
+        fake_dest = Path("TTS/samples/myvoice.wav")
+
+        with (
+            patch("voicecli.samples.from_url", return_value=fake_dest),
+            patch("voicecli.samples.set_active") as mock_set_active,
+        ):
+            # Act
+            result = runner.invoke(app, ["samples", "from-url", "https://yt.com/v", "myvoice"])
+
+            # Assert
+            assert result.exit_code == 0
+            mock_set_active.assert_not_called()
+
+    def test_runtime_error_exits_1(self):
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        # Arrange
+        runner = CliRunner()
+
+        with patch("voicecli.samples.from_url", side_effect=RuntimeError("yt-dlp not found")):
+            # Act
+            result = runner.invoke(app, ["samples", "from-url", "https://yt.com/v", "myvoice"])
+
+            # Assert
+            assert result.exit_code == 1
+
+    def test_value_error_exits_1(self):
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        # Arrange
+        runner = CliRunner()
+
+        with patch("voicecli.samples.from_url", side_effect=ValueError("Only http/https URLs")):
+            # Act
+            result = runner.invoke(app, ["samples", "from-url", "file:///etc/passwd", "evil"])
+
+            # Assert
+            assert result.exit_code == 1
+
+    def test_custom_start_and_duration(self):
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        # Arrange
+        runner = CliRunner()
+        fake_dest = Path("TTS/samples/myvoice.wav")
+
+        with patch("voicecli.samples.from_url", return_value=fake_dest) as mock_from_url:
+            # Act
+            result = runner.invoke(
+                app,
+                [
+                    "samples",
+                    "from-url",
+                    "https://yt.com/v",
+                    "myvoice",
+                    "--start",
+                    "5",
+                    "--duration",
+                    "20",
+                ],
+            )
+
+            # Assert
+            assert result.exit_code == 0
+            mock_from_url.assert_called_once_with(
+                "https://yt.com/v", "myvoice", start=5.0, duration=20.0
+            )

--- a/tests/test_samples_from_url.py
+++ b/tests/test_samples_from_url.py
@@ -1,0 +1,110 @@
+"""Tests for samples from-url command."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from voicecli.samples import _check_tool, from_url
+
+
+class TestCheckTool:
+    def test_found(self):
+        with patch("shutil.which", return_value="/usr/bin/git"):
+            _check_tool("git")  # should not raise
+
+    def test_not_found_yt_dlp(self):
+        with patch("shutil.which", return_value=None):
+            with pytest.raises(RuntimeError, match="yt-dlp.*not found"):
+                _check_tool("yt-dlp")
+
+    def test_not_found_ffmpeg(self):
+        with patch("shutil.which", return_value=None):
+            with pytest.raises(RuntimeError, match="ffmpeg.*not found"):
+                _check_tool("ffmpeg")
+
+
+class TestFromUrl:
+    @patch("voicecli.samples.subprocess.run")
+    @patch("voicecli.samples.shutil.which", return_value="/usr/bin/ok")
+    def test_downloads_extracts_and_normalizes(self, mock_which, mock_run, tmp_path, monkeypatch):
+        """Verify yt-dlp and ffmpeg are called with correct args."""
+        samples_dir = tmp_path / "samples"
+        samples_dir.mkdir()
+        monkeypatch.setattr("voicecli.samples.SAMPLES_DIR", samples_dir)
+        monkeypatch.setattr("voicecli.samples.ACTIVE_FILE", samples_dir / ".active")
+
+        # yt-dlp creates a file in the temp dir — simulate this
+        def fake_run(cmd, *, check=False):
+            if cmd[0] == "yt-dlp":
+                # Find the -o arg to know where to create the fake file
+                o_idx = cmd.index("-o")
+                pattern = cmd[o_idx + 1]
+                # yt-dlp replaces %(ext)s with wav
+                fake_path = Path(pattern.replace("%(ext)s", "wav"))
+                fake_path.write_bytes(b"fake audio data")
+
+        mock_run.side_effect = fake_run
+
+        dest = from_url("https://youtube.com/watch?v=test", "mysample", start=5.0, duration=20.0)
+
+        assert dest == samples_dir / "mysample.wav"
+        assert mock_run.call_count == 2
+
+        # First call: yt-dlp
+        yt_call = mock_run.call_args_list[0]
+        assert yt_call[0][0][0] == "yt-dlp"
+        assert "-x" in yt_call[0][0]
+        assert "https://youtube.com/watch?v=test" in yt_call[0][0]
+
+        # Second call: ffmpeg
+        ff_call = mock_run.call_args_list[1]
+        ff_args = ff_call[0][0]
+        assert ff_args[0] == "ffmpeg"
+        assert "-ss" in ff_args
+        ss_idx = ff_args.index("-ss")
+        assert ff_args[ss_idx + 1] == "5.0"
+        t_idx = ff_args.index("-t")
+        assert ff_args[t_idx + 1] == "20.0"
+        assert "-ac" in ff_args
+        assert "24000" in ff_args
+
+    @patch("voicecli.samples.shutil.which", return_value=None)
+    def test_missing_yt_dlp(self, mock_which):
+        with pytest.raises(RuntimeError, match="yt-dlp"):
+            from_url("https://youtube.com/watch?v=test", "sample")
+
+    @patch("voicecli.samples.subprocess.run")
+    @patch("voicecli.samples.shutil.which", return_value="/usr/bin/ok")
+    def test_appends_wav_extension(self, mock_which, mock_run, tmp_path, monkeypatch):
+        samples_dir = tmp_path / "samples"
+        samples_dir.mkdir()
+        monkeypatch.setattr("voicecli.samples.SAMPLES_DIR", samples_dir)
+        monkeypatch.setattr("voicecli.samples.ACTIVE_FILE", samples_dir / ".active")
+
+        def fake_run(cmd, *, check=False):
+            if cmd[0] == "yt-dlp":
+                o_idx = cmd.index("-o")
+                pattern = cmd[o_idx + 1]
+                fake_path = Path(pattern.replace("%(ext)s", "wav"))
+                fake_path.write_bytes(b"fake")
+
+        mock_run.side_effect = fake_run
+
+        dest = from_url("https://example.com", "no_ext")
+        assert dest.name == "no_ext.wav"
+
+    @patch("voicecli.samples.subprocess.run")
+    @patch("voicecli.samples.shutil.which", return_value="/usr/bin/ok")
+    def test_no_output_from_ytdlp_raises(self, mock_which, mock_run, tmp_path, monkeypatch):
+        samples_dir = tmp_path / "samples"
+        samples_dir.mkdir()
+        monkeypatch.setattr("voicecli.samples.SAMPLES_DIR", samples_dir)
+        monkeypatch.setattr("voicecli.samples.ACTIVE_FILE", samples_dir / ".active")
+
+        # yt-dlp runs but doesn't create any file
+        mock_run.return_value = None
+
+        with pytest.raises(RuntimeError, match="did not produce"):
+            from_url("https://example.com", "sample")


### PR DESCRIPTION
## Summary
- Add `voicecli samples from-url <url> <name>` command that downloads audio via yt-dlp, extracts a timed segment with ffmpeg, and normalizes to mono 24kHz WAV
- Supports `--start`, `--duration`, and `--use` flags for extraction control and auto-activation

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #21: feat(samples): add `samples from-url` command for YouTube voice sampling | Open |
| Implementation | 1 commit on `feat/21-samples-from-url` | Complete |
| Verification | Lint ✅ Format ✅ Tests ✅ (7 new, 80 total) | Passed |

## Test Plan
- [ ] `voicecli samples from-url "https://youtube.com/watch?v=..." myvoice` downloads, extracts, normalizes
- [ ] `--start 5 --duration 20` controls extraction window
- [ ] `--use` sets new sample as active
- [ ] Missing `yt-dlp` or `ffmpeg` shows install instructions
- [ ] Intermediate files cleaned up after extraction

Closes #21

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`