### PR TITLE
test(stt): add parecord fallback coverage for stt_daemon

### DIFF
--- a/artifacts/frames/7-dictate-toggle-hotkey-frame.mdx
+++ b/artifacts/frames/7-dictate-toggle-hotkey-frame.mdx
@@ -1,0 +1,55 @@
+---
+title: "feat: dictate toggle command + global hotkey listener"
+issue: 7
+status: approved
+tier: F-lite
+date: 2026-03-10
+---
+
+## Problem
+
+Users need a way to trigger STT recording from anywhere on the desktop — not just from the terminal where the daemon runs. Currently, once `voicecli stt-serve` is running (issue #6), there is no client command to toggle recording on/off or check status.
+
+The dictate command bridges this gap: a thin socket client that can be triggered from anywhere — including native Windows apps via a Windows keyboard shortcut running `wsl voicecli dictate`. Visual feedback (notify-send) and clipboard sharing complete the hands-free dictation workflow.
+
+## WSL / Windows Interaction Model
+
+Everything runs inside WSL2. The interaction with the Windows host works through three layers:
+
+1. **Trigger:** A Windows keyboard shortcut (Settings > Keyboard, or AutoHotkey) runs `wsl voicecli dictate` — this works from any focused Windows app. Alternatively, `voicecli dictate --listen` (pynput) provides a built-in hotkey listener, but only captures keys when an X11/WSLg window has focus.
+2. **Clipboard:** WSL2 shares clipboard with Windows — transcribed text copied via `xclip`/`wl-copy` is instantly available for Ctrl+V in any Windows app. This is the default and most reliable path.
+3. **Notifications:** `notify-send` shows in the WSLg notification area, which appears in the Windows system tray.
+4. **Auto-paste (`xdotool type`):** Only works in X11/WSLg windows. For Windows apps, falls back to clipboard silently. This is why clipboard-only is the default.
+
+## Who
+
+- **Primary:** The developer/user who wants push-to-talk dictation from any app on the desktop (WSL2 via WSLg).
+- **Secondary:** Anyone scripting VoiceCLI into automation pipelines who needs programmatic toggle/status access.
+
+## Constraints
+
+- Blocked by #6 — STT daemon must exist and expose the Unix socket protocol first.
+- Primary trigger path: Windows keyboard shortcut → `wsl voicecli dictate` (works from any app).
+- Fallback trigger: `--listen` (pynput) requires X11/XWayland — only captures keys when WSLg window focused.
+- 300ms debounce on hotkey to prevent double-trigger.
+- Auto-paste (`xdotool type`) is opt-in (`--paste` flag), clipboard-only by default.
+- Hotkey configurable via `voicecli.toml` `[stt] hotkey` (default: `alt+space`).
+
+## Out of Scope
+
+- The STT daemon itself (that's #6).
+- Wayland-native hotkey listener (pynput + XWayland is sufficient for now).
+- GUI or tray icon — notifications via `notify-send` only.
+- Native Windows app for hotkey capture (Windows shortcut → `wsl` is sufficient).
+- macOS support.
+
+## Complexity
+
+**Tier: F-lite** — Clear scope, single domain (STT client), 3 files touched, well-defined protocol.
+
+Signals:
+- 3 files: `cli.py` (add command group), `stt_client.py` (new, thin socket client), `docs/dictation-setup.md` (new)
+- Single domain: STT client / hotkey input
+- No new architecture — follows existing socket pattern from daemon
+- One dependency (#6) but no unknowns
+- Complexity score: 5 (from issue)

--- a/artifacts/specs/7-dictate-toggle-hotkey-spec.mdx
+++ b/artifacts/specs/7-dictate-toggle-hotkey-spec.mdx
@@ -1,0 +1,154 @@
+---
+title: "feat: dictate toggle command + global hotkey listener"
+issue: 7
+status: approved
+tier: F-lite
+promoted_from: artifacts/frames/7-dictate-toggle-hotkey-frame.mdx
+date: 2026-03-10
+---
+
+## Context
+
+Promoted from [frame](../frames/7-dictate-toggle-hotkey-frame.mdx). Blocked by #6 (STT daemon).
+
+The STT daemon (#6) is already implemented in `src/voicecli/stt_daemon.py` with a Unix socket protocol supporting `ping`, `status`, and `toggle` actions. Clipboard writing (`wl-copy`/`xclip`/`xsel`) is already handled server-side. This spec covers the **client** side: a thin CLI command that talks to the daemon and adds hotkey listening, notifications, and optional auto-paste.
+
+## Goal
+
+Provide a `voicecli dictate` command that toggles STT recording via the daemon socket, with optional built-in global hotkey listener, desktop notifications, and auto-paste — enabling hands-free dictation from any application.
+
+## Users
+
+- **Primary:** Developer using WSL2 who wants push-to-talk dictation bound to a keyboard shortcut (Windows shortcut → `wsl voicecli dictate`, or pynput `--listen` mode).
+- **Secondary:** Scripters who need programmatic toggle/status access for automation.
+
+## Expected Behavior
+
+### Toggle flow (single shot)
+
+User presses a Windows keyboard shortcut bound to `wsl voicecli dictate`:
+
+1. Client connects to `~/.local/share/voicecli/stt-daemon.sock`
+2. Sends `{"action": "toggle"}`
+3. If daemon was **idle** → starts recording. Client prints `response["state"]` (`recording`) and sends a persistent notification ("Recording..."). Exits 0.
+4. If daemon was **recording** → stops + transcribes. Client receives `{"status": "ok", "state": "idle", "text": "...", "language": "fr"}`. `language` may be `null` on transcription failure. Prints text to stdout. Sends notification with transcription preview. Exits 0.
+5. If daemon was **transcribing** → queues next recording. Client receives `{"status": "ok", "state": "queued"}`. Prints `queued` to stdout. Sends notification ("Queued — will record after current transcription"). Exits 0.
+6. If daemon was **queued** → no-op. Client prints `queued`. Exits 0.
+7. If daemon unreachable → prints error, sends error notification, exits 1.
+
+### Status check
+
+`voicecli dictate status` → sends `{"action": "status"}` → prints `idle` / `recording` / `transcribing` / `queued`. Exits 0.
+
+### Hotkey listener mode
+
+`voicecli dictate --listen` → stays alive, listens for global hotkey (default `alt+space`, configurable in `voicecli.toml`). On hotkey press: sends toggle to daemon (same as single-shot). 300ms debounce. Ctrl+C to exit. **This is a secondary/convenience path** — pynput only captures keys when an X11/WSLg window has focus. For cross-app dictation, the recommended path is a Windows keyboard shortcut bound to `wsl voicecli dictate`.
+
+### Auto-paste
+
+`voicecli dictate --paste` → after receiving transcription, attempts `xdotool type --clearmodifiers -- "<text>"` with 150ms focus delay. Falls back silently to clipboard-only if `xdotool` not found. **Known limitation:** `xdotool` targets X11 windows only — under pure Wayland sessions (no XWayland) it will fail and fall back to clipboard. Clipboard is always written (by daemon).
+
+### Notifications
+
+All modes send `notify-send` feedback. Use `--replace-id=voicecli-dictate` (or `-r` on libnotify 0.8+) so each notification replaces the previous one instead of stacking:
+- Recording start: `notify-send -r voicecli-dictate "VoiceCLI" "Recording..." -t 0` (persistent until replaced)
+- Queued: `notify-send -r voicecli-dictate "VoiceCLI" "Queued..." -t 3000`
+- Transcription done: `notify-send -r voicecli-dictate "VoiceCLI" "[fr]: Bonjour tout le..." -t 3000` (truncated to ~50 chars)
+- Error: `notify-send -r voicecli-dictate "VoiceCLI" "STT daemon not running" -t 3000`
+- If `notify-send` is unavailable or doesn't support `-r`, skip/fall back silently (no crash).
+
+## Data Model & Consumers
+
+```mermaid
+classDiagram
+    class DictateRequest {
+        +str action  "toggle" | "status" | "ping"
+    }
+    class DaemonResponse {
+        +str status  "ok" | "error"
+        +str state   "idle" | "recording" | "transcribing" | "queued"
+        +str text    (only on transcription complete)
+        +str|null language (on transcription; null if detection failed)
+        +str message  (only on error)
+    }
+    class STTConfig {
+        +str hotkey  default "alt+space"
+    }
+    DictateRequest --> DaemonResponse : socket request/response
+    STTConfig --> DictateClient : configures hotkey
+```
+
+```mermaid
+flowchart LR
+    CLI["cli.py\ndictate command"] -->|"creates"| Client["stt_client.py\nDictateClient"]
+    Client -->|"sends JSON"| Daemon["stt_daemon.py\n(issue #6)"]
+    Daemon -->|"JSON response"| Client
+    Client -->|"notify-send"| Desktop["Desktop\nNotifications"]
+    Client -->|"xdotool type"| Paste["Auto-paste\n(optional)"]
+    TOML["voicecli.toml\n[stt] hotkey"] -.->|"configures"| Client
+```
+
+| Consumer | Fields | When | Status |
+|----------|--------|------|--------|
+| `cli.py` dictate commands | all DaemonResponse fields | on toggle/status response | this issue |
+| `notify-send` | state, text, language | after each toggle | this issue |
+| `xdotool` auto-paste | text | after transcription (--paste) | this issue |
+| `voicecli.toml` | `[stt] hotkey` | on `--listen` startup | this issue |
+
+## Breadboard
+
+### Affordances
+
+| ID | Element | Location |
+|----|---------|----------|
+| U1 | `voicecli dictate` command | cli.py |
+| U2 | `voicecli dictate status` subcommand | cli.py |
+| U3 | `--listen` flag | cli.py |
+| U4 | `--paste` flag | cli.py |
+| N1 | `send_toggle()` | stt_client.py |
+| N2 | `send_status()` | stt_client.py |
+| N3 | `notify()` | stt_client.py |
+| N4 | `auto_paste()` | stt_client.py |
+| N5 | `hotkey_loop()` | stt_client.py |
+| S1 | `[stt] hotkey` config | voicecli.toml |
+
+### Wiring
+
+| From | To | Trigger |
+|------|----|---------|
+| U1 | N1 | user runs `voicecli dictate` |
+| U2 | N2 | user runs `voicecli dictate status` |
+| U3 | N5 → N1 | `--listen` starts hotkey loop, each hotkey press triggers toggle |
+| N1 | N3 | after daemon response, send notification |
+| N1 | N4 | if `--paste` and text received, attempt xdotool |
+| S1 | N5 | hotkey_loop reads configured shortcut |
+
+## Slices
+
+| # | Slice | Affordances | Demo |
+|---|-------|-------------|------|
+| 1 | Socket client + toggle | N1, N2, U1, U2 | `voicecli dictate` toggles recording, `voicecli dictate status` prints state |
+| 2 | Notifications + auto-paste | N3, N4, U4 | Toggle shows notify-send popup, `--paste` types into focused window |
+| 3 | Hotkey listener | N5, U3, S1 | `voicecli dictate --listen` captures alt+space, sends toggle. Prereq: add `[stt]` table support to `config.py`, add `pynput` to `pyproject.toml` |
+
+## Implementation Notes
+
+- **Wire protocol:** `_send_json`/`_recv_json` are currently duplicated between `daemon.py` and `stt_daemon.py`. The client needs the same helpers — consider factoring into a shared `wire.py` module (or at minimum, duplicate into `stt_client.py` with a comment).
+- **Config:** `config.py` currently only reads `[defaults]`. Slice 3 requires reading `[stt] hotkey` — extend `load_defaults()` or add a `load_stt_config()` helper.
+- **Dependency:** Slice 3 adds `pynput` as a new optional dependency in `pyproject.toml`.
+
+## Success Criteria
+
+- [ ] `voicecli dictate` connects to STT daemon socket and sends `{"action": "toggle"}`
+- [ ] Toggle response is printed to stdout (`response["state"]` on start/queue, `response["text"]` on transcription)
+- [ ] Toggling during transcription prints `queued` and sends appropriate notification
+- [ ] `voicecli dictate status` prints current daemon state (`idle`/`recording`/`transcribing`/`queued`)
+- [ ] Exit code 0 on success, 1 on daemon unreachable or error
+- [ ] `notify-send` is called on recording start, transcription done, queued, and error
+- [ ] Notifications use replace-id to avoid stacking
+- [ ] Notifications degrade gracefully (no crash if `notify-send` missing)
+- [ ] `--paste` flag triggers `xdotool type` after transcription; falls back to clipboard if unavailable
+- [ ] `--listen` starts pynput global hotkey listener with 300ms debounce
+- [ ] Hotkey is configurable via `voicecli.toml` `[stt] hotkey` (default: `alt+space`)
+- [ ] `--listen` mode exits cleanly on Ctrl+C
+- [ ] `docs/dictation-setup.md` documents Windows shortcut + KDE/GNOME setup

--- a/tests/test_stt_daemon.py
+++ b/tests/test_stt_daemon.py
@@ -485,3 +485,101 @@ class TestQueueSupport:
 
         monkeypatch.setattr(transcribe_mod, "transcribe", lambda *a, **kw: _MOCK_TRANSCRIPTION)
         send("toggle")  # N4 on the auto-started recording
+
+
+# ---------------------------------------------------------------------------
+# S5 — PaRecord fallback path
+# ---------------------------------------------------------------------------
+
+
+class TestPaRecordFallback:
+    """Tests for the parecord fallback path (_probe_pyaudio returns False).
+
+    Separate from the main tests to avoid doubling run time for tests that
+    don't touch recording (ping, status, etc.).
+    """
+
+    @pytest.fixture()
+    def parecord_send(self, tmp_path):
+        """Daemon fixture with parecord fallback: _probe_pyaudio=False."""
+        sock_path = tmp_path / "stt-test-parecord.sock"
+
+        def mock_record_parecord(stop_event: threading.Event) -> bytes:
+            stop_event.wait()
+            return b"RIFF\x00\x00\x00\x00WAVEfmt "
+
+        mock_chime = MagicMock()
+        mock_write_clipboard = MagicMock()
+        mock_warmup = MagicMock()
+
+        with (
+            patch("voicecli.stt_daemon._probe_pyaudio", return_value=False),
+            patch("voicecli.stt_daemon._record_parecord", mock_record_parecord),
+            patch("voicecli.stt_daemon._chime", mock_chime),
+            patch("voicecli.stt_daemon._write_clipboard", mock_write_clipboard),
+            patch("voicecli.stt_daemon.warmup", mock_warmup),
+            patch("voicecli.transcribe.transcribe", return_value=_MOCK_TRANSCRIPTION),
+        ):
+            from voicecli.stt_daemon import SttDaemon
+
+            daemon = SttDaemon(model="large-v3-turbo", socket_path=sock_path)
+            t = threading.Thread(target=daemon.serve, daemon=True)
+            t.start()
+
+            deadline = time.monotonic() + 3.0
+            while not sock_path.exists():
+                if time.monotonic() > deadline:
+                    raise RuntimeError(f"Daemon socket never appeared at {sock_path}")
+                time.sleep(0.02)
+
+            def send(action: str, **kwargs) -> dict:
+                payload = {"action": action, **kwargs}
+                sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                sock.settimeout(5.0)
+                sock.connect(str(sock_path))
+                try:
+                    sock.sendall((json.dumps(payload) + "\n").encode())
+                    buf = bytearray()
+                    while True:
+                        chunk = sock.recv(65536)
+                        if not chunk:
+                            break
+                        buf.extend(chunk)
+                        if b"\n" in buf:
+                            break
+                    return json.loads(buf.split(b"\n")[0])
+                finally:
+                    sock.close()
+
+            yield send, mock_chime, mock_write_clipboard
+
+            daemon.stop()
+            t.join(timeout=2.0)
+
+    def test_toggle_starts_recording(self, parecord_send):
+        """Toggle from idle → state=recording (parecord path)."""
+        send, _, _ = parecord_send
+        resp = send("toggle")
+        assert resp["status"] == "ok"
+        assert resp["state"] == "recording"
+
+    def test_toggle_stops_and_transcribes(self, parecord_send):
+        """Toggle stop → state=idle, transcription proceeds via parecord WAV."""
+        send, _, mock_clipboard = parecord_send
+        send("toggle")  # idle → recording
+        resp = send("toggle")  # recording → transcribing → idle
+        assert resp["status"] == "ok"
+        assert resp["state"] == "idle"
+        assert resp["text"] == "hello world"
+        assert resp["language"] == "en"
+        mock_clipboard.assert_called_once_with("hello world")
+
+    def test_no_level_callback_crash(self, parecord_send):
+        """Parecord path has no level callback — full cycle completes without crash."""
+        send, _, _ = parecord_send
+        send("toggle")  # idle → recording
+        resp = send("status")
+        assert resp["state"] == "recording"
+        resp = send("toggle")  # recording → idle
+        assert resp["status"] == "ok"
+        assert resp["state"] == "idle"

--- a/tests/test_stt_daemon.py
+++ b/tests/test_stt_daemon.py
@@ -505,9 +505,10 @@ class TestPaRecordFallback:
         sock_path = tmp_path / "stt-test-parecord.sock"
 
         def mock_record_parecord(stop_event: threading.Event) -> bytes:
-            stop_event.wait()
+            stop_event.wait(timeout=5.0)
             return b"RIFF\x00\x00\x00\x00WAVEfmt "
 
+        mock_recording_thread_cls = MagicMock()
         mock_chime = MagicMock()
         mock_write_clipboard = MagicMock()
         mock_warmup = MagicMock()
@@ -515,6 +516,7 @@ class TestPaRecordFallback:
         with (
             patch("voicecli.stt_daemon._probe_pyaudio", return_value=False),
             patch("voicecli.stt_daemon._record_parecord", mock_record_parecord),
+            patch("voicecli.stt_daemon.RecordingThread", mock_recording_thread_cls),
             patch("voicecli.stt_daemon._chime", mock_chime),
             patch("voicecli.stt_daemon._write_clipboard", mock_write_clipboard),
             patch("voicecli.stt_daemon.warmup", mock_warmup),
@@ -551,21 +553,23 @@ class TestPaRecordFallback:
                 finally:
                     sock.close()
 
-            yield send, mock_chime, mock_write_clipboard
+            mock_warmup.assert_called_once()
+
+            yield send, mock_chime, mock_write_clipboard, mock_recording_thread_cls
 
             daemon.stop()
             t.join(timeout=2.0)
 
     def test_toggle_starts_recording(self, parecord_send):
         """Toggle from idle → state=recording (parecord path)."""
-        send, _, _ = parecord_send
+        send, _, _, _ = parecord_send
         resp = send("toggle")
         assert resp["status"] == "ok"
         assert resp["state"] == "recording"
 
     def test_toggle_stops_and_transcribes(self, parecord_send):
         """Toggle stop → state=idle, transcription proceeds via parecord WAV."""
-        send, _, mock_clipboard = parecord_send
+        send, _, mock_clipboard, _ = parecord_send
         send("toggle")  # idle → recording
         resp = send("toggle")  # recording → transcribing → idle
         assert resp["status"] == "ok"
@@ -576,10 +580,12 @@ class TestPaRecordFallback:
 
     def test_no_level_callback_crash(self, parecord_send):
         """Parecord path has no level callback — full cycle completes without crash."""
-        send, _, _ = parecord_send
+        send, _, _, mock_rt_cls = parecord_send
         send("toggle")  # idle → recording
         resp = send("status")
         assert resp["state"] == "recording"
         resp = send("toggle")  # recording → idle
         assert resp["status"] == "ok"
         assert resp["state"] == "idle"
+        # RecordingThread (which carries level_callback) was never instantiated
+        mock_rt_cls.assert_not_called()


### PR DESCRIPTION
## Summary
- Add `TestPaRecordFallback` class (S5) with dedicated `parecord_send` fixture where `_probe_pyaudio` returns `False` and `_record_parecord` is mocked
- 3 focused tests: toggle start → recording, toggle stop → idle + transcription, level callback absence (no crash)
- Separate class avoids doubling run time for tests that don't touch recording

Closes #10

## Test plan
- [x] All 3 new tests pass (`pytest tests/test_stt_daemon.py::TestPaRecordFallback -v`)
- [x] All 20 tests pass (`pytest tests/test_stt_daemon.py -v`) — no regressions
- [x] Pre-commit hooks (lint + format) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)