### PR TITLE
feat(dictate): add dictate toggle command + global hotkey listener (#7)

### DIFF
--- a/artifacts/plans/7-dictate-toggle-hotkey-plan.mdx
+++ b/artifacts/plans/7-dictate-toggle-hotkey-plan.mdx
@@ -1,0 +1,440 @@
+---
+title: "Plan: dictate toggle command + global hotkey listener"
+issue: 7
+spec: artifacts/specs/7-dictate-toggle-hotkey-spec.mdx
+complexity: 5/10
+tier: F-lite
+generated: 2026-03-10
+---
+
+## Summary
+
+Add `voicecli dictate` command group — a thin socket client that talks to the STT daemon (#6), with desktop notifications, optional auto-paste, and a pynput global hotkey listener. 3 slices, 13 success criteria, 3 agents.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph cli["src/voicecli/cli.py"]
+        dictate_cmd["dictate()"]
+        dictate_status["dictate_status()"]
+    end
+    subgraph client["src/voicecli/stt_client.py"]
+        send_toggle["send_toggle()"]
+        send_status["send_status()"]
+        send_request["_send_request()"]
+        notify_fn["notify()"]
+        auto_paste_fn["auto_paste()"]
+        hotkey_loop["hotkey_loop()"]
+    end
+    subgraph config["src/voicecli/config.py"]
+        load_stt["load_stt_config()"]
+    end
+    subgraph daemon["src/voicecli/stt_daemon.py (existing)"]
+        socket["AF_UNIX socket"]
+    end
+
+    dictate_cmd -->|"--listen"| hotkey_loop
+    dictate_cmd --> send_toggle
+    dictate_status --> send_status
+    hotkey_loop -->|"on hotkey"| send_toggle
+    hotkey_loop -->|"reads hotkey"| load_stt
+    send_toggle --> send_request
+    send_status --> send_request
+    send_request -->|"JSON over socket"| socket
+    send_toggle --> notify_fn
+    send_toggle -->|"--paste"| auto_paste_fn
+```
+
+```mermaid
+flowchart LR
+    subgraph stt_client["stt_client.py"]
+        _send_request
+        send_toggle
+        send_status
+        notify
+        auto_paste
+        hotkey_loop
+    end
+    subgraph cli["cli.py"]
+        dictate
+        dictate_status_cmd["dictate_status"]
+    end
+    subgraph config["config.py"]
+        load_stt_config
+    end
+    subgraph tests["tests/test_stt_client.py"]
+        test_toggle
+        test_status
+        test_notify
+        test_hotkey
+    end
+
+    dictate --> send_toggle
+    dictate_status_cmd --> send_status
+    dictate --> hotkey_loop
+    hotkey_loop --> load_stt_config
+    test_toggle --> send_toggle
+    test_status --> send_status
+    test_notify --> notify
+    test_hotkey --> hotkey_loop
+```
+
+## Agents
+
+| Agent | Tasks | Files |
+|-------|-------|-------|
+| backend-dev | T1-T8 | `stt_client.py`, `cli.py`, `config.py`, `pyproject.toml` |
+| tester | T9-T10 | `tests/test_stt_client.py` |
+| doc-writer | T11 | `docs/dictation-setup.md` |
+
+## Ref Patterns
+
+- `daemon.py:daemon_request()` — existing TTS daemon client pattern (connect, send JSON, recv JSON, close). STT client follows same shape.
+- `cli.py:samples_app` — existing sub-typer pattern for command groups. `dictate_app` follows same registration.
+- `stt_daemon.py:_send_json/_recv_json` — wire protocol helpers to replicate in client.
+
+## Consistency Report
+
+13/13 success criteria covered. 0 uncovered. 0 untraced.
+
+| SC | Criteria | Tasks |
+|----|----------|-------|
+| SC-1 | dictate connects + sends toggle | T1, T3 |
+| SC-2 | Toggle response printed to stdout | T3 |
+| SC-3 | Toggling during transcription prints queued | T3 |
+| SC-4 | dictate status prints state | T4 |
+| SC-5 | Exit code 0/1 | T1, T3 |
+| SC-6 | notify-send called on events | T5 |
+| SC-7 | Notifications use replace-id | T5 |
+| SC-8 | Notifications degrade gracefully | T5 |
+| SC-9 | --paste triggers xdotool | T6 |
+| SC-10 | --listen starts pynput listener | T8 |
+| SC-11 | Hotkey configurable via toml | T7 |
+| SC-12 | --listen exits cleanly on Ctrl+C | T8 |
+| SC-13 | docs/dictation-setup.md | T11 |
+
+## Micro-Tasks
+
+### Slice 1: Socket client + toggle
+
+#### T1 — Wire protocol client `[P]`
+- **Agent:** backend-dev
+- **File:** `src/voicecli/stt_client.py` (new)
+- **Spec trace:** SC-1, SC-5, N1→N2
+- **Phase:** RED
+- **Difficulty:** 2
+- **Description:** Create `stt_client.py` with `_send_request(action, **kwargs)` that connects to `~/.local/share/voicecli/stt-daemon.sock`, sends newline-delimited JSON, receives response, returns dict. Follow `daemon.py:daemon_request()` pattern. Handle `ConnectionRefusedError` and `FileNotFoundError` → return `{"status": "error", "message": "STT daemon not running"}`.
+- **Code snippet:**
+```python
+SOCKET_PATH = Path.home() / ".local" / "share" / "voicecli" / "stt-daemon.sock"
+
+def _send_request(action: str, timeout: int = 10) -> dict:
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.settimeout(timeout)
+    try:
+        sock.connect(str(SOCKET_PATH))
+        payload = json.dumps({"action": action}) + "\n"
+        sock.sendall(payload.encode())
+        # recv until newline
+        buf = bytearray()
+        while b"\n" not in buf:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            buf.extend(chunk)
+        return json.loads(buf.split(b"\n")[0])
+    except (ConnectionRefusedError, FileNotFoundError, OSError):
+        return {"status": "error", "message": "STT daemon not running"}
+    finally:
+        sock.close()
+```
+- **Verify:** `python -c "from voicecli.stt_client import _send_request; print('ok')"`
+- **Expected output:** `ok`
+- **Time:** 3 min
+
+#### T2 — Public send_toggle() and send_status() `[P]`
+- **Agent:** backend-dev
+- **File:** `src/voicecli/stt_client.py`
+- **Spec trace:** N1, N2
+- **Phase:** GREEN
+- **Difficulty:** 1
+- **Description:** Add `send_toggle() -> dict` and `send_status() -> dict` thin wrappers around `_send_request`.
+- **Code snippet:**
+```python
+def send_toggle() -> dict:
+    return _send_request("toggle")
+
+def send_status() -> dict:
+    return _send_request("status")
+```
+- **Verify:** `python -c "from voicecli.stt_client import send_toggle, send_status; print('ok')"`
+- **Expected output:** `ok`
+- **Time:** 2 min
+
+#### T3 — CLI dictate command (toggle)
+- **Agent:** backend-dev
+- **File:** `src/voicecli/cli.py`
+- **Spec trace:** SC-1, SC-2, SC-3, SC-5, U1
+- **Phase:** GREEN
+- **Difficulty:** 3
+- **Description:** Create `dictate_app = typer.Typer()` sub-app, register with `app.add_typer(dictate_app, name="dictate")`. Add default callback that calls `send_toggle()`, prints `response["state"]` or `response["text"]` based on state, raises `typer.Exit(code=1)` on error. Handle all 4 daemon states (idle→recording, recording→idle+text, transcribing→queued, queued→no-op).
+- **Code snippet:**
+```python
+dictate_app = typer.Typer(help="Dictation client for STT daemon")
+app.add_typer(dictate_app, name="dictate", invoke_without_command=True)
+
+@dictate_app.callback(invoke_without_command=True)
+def dictate(
+    ctx: typer.Context,
+    listen: bool = typer.Option(False, "--listen", help="..."),
+    paste: bool = typer.Option(False, "--paste", help="..."),
+):
+    if ctx.invoked_subcommand is not None:
+        return
+    from voicecli.stt_client import send_toggle
+    resp = send_toggle()
+    if resp.get("status") == "error":
+        print(resp.get("message", "unknown error"), file=sys.stderr)
+        raise typer.Exit(code=1)
+    state = resp.get("state", "")
+    text = resp.get("text", "")
+    if text:
+        print(text)
+    else:
+        print(state)
+```
+- **Verify:** `uv run voicecli dictate --help`
+- **Expected output:** Shows dictate help with --listen and --paste options
+- **Time:** 5 min
+
+#### T4 — CLI dictate status subcommand
+- **Agent:** backend-dev
+- **File:** `src/voicecli/cli.py`
+- **Spec trace:** SC-4, U2
+- **Phase:** GREEN
+- **Difficulty:** 1
+- **Description:** Add `@dictate_app.command("status")` that calls `send_status()` and prints `response["state"]`.
+- **Code snippet:**
+```python
+@dictate_app.command("status")
+def dictate_status():
+    """Show current STT daemon state."""
+    from voicecli.stt_client import send_status
+    resp = send_status()
+    if resp.get("status") == "error":
+        print(resp.get("message"), file=sys.stderr)
+        raise typer.Exit(code=1)
+    print(resp.get("state", "unknown"))
+```
+- **Verify:** `uv run voicecli dictate status --help`
+- **Expected output:** Shows status help
+- **Time:** 2 min
+
+---
+**RED-GATE: Slice 1** — Verify `voicecli dictate --help` and `voicecli dictate status --help` work. Socket client importable.
+
+---
+
+### Slice 2: Notifications + auto-paste
+
+#### T5 — notify() helper
+- **Agent:** backend-dev
+- **File:** `src/voicecli/stt_client.py`
+- **Spec trace:** SC-6, SC-7, SC-8, N3
+- **Phase:** RED
+- **Difficulty:** 2
+- **Description:** Add `notify(title: str, body: str, timeout: int = 3000)` that calls `notify-send -r voicecli-dictate "{title}" "{body}" -t {timeout}` via `subprocess.run`. Use `shutil.which("notify-send")` to check availability — skip silently if missing. Catch all exceptions silently.
+- **Code snippet:**
+```python
+def notify(body: str, timeout: int = 3000) -> None:
+    import shutil, subprocess
+    if not shutil.which("notify-send"):
+        return
+    try:
+        subprocess.run(
+            ["notify-send", "-r", "voicecli-dictate", "VoiceCLI", body, "-t", str(timeout)],
+            check=False, capture_output=True,
+        )
+    except Exception:
+        pass
+```
+- **Verify:** `python -c "from voicecli.stt_client import notify; notify('test', 3000); print('ok')"`
+- **Expected output:** `ok`
+- **Time:** 3 min
+
+#### T5b — Wire notifications into toggle flow
+- **Agent:** backend-dev
+- **File:** `src/voicecli/cli.py`
+- **Spec trace:** SC-6, SC-7
+- **Phase:** GREEN
+- **Difficulty:** 2
+- **Description:** After `send_toggle()` in the `dictate` callback, call `notify()` based on response state: `recording` → `notify("Recording...", 0)`, `idle` + text → `notify(f"[{lang}]: {text[:50]}...", 3000)`, `queued` → `notify("Queued...", 3000)`, error → `notify("STT daemon not running", 3000)`.
+- **Time:** 3 min
+
+#### T6 — auto_paste() helper
+- **Agent:** backend-dev
+- **File:** `src/voicecli/stt_client.py`
+- **Spec trace:** SC-9, N4
+- **Phase:** RED
+- **Difficulty:** 2
+- **Description:** Add `auto_paste(text: str)` that checks `shutil.which("xdotool")`, sleeps 150ms for focus, then runs `xdotool type --clearmodifiers -- "{text}"`. Skip silently if xdotool missing or any error.
+- **Code snippet:**
+```python
+def auto_paste(text: str) -> None:
+    import shutil, subprocess, time
+    if not shutil.which("xdotool"):
+        return
+    try:
+        time.sleep(0.15)
+        subprocess.run(
+            ["xdotool", "type", "--clearmodifiers", "--", text],
+            check=False, capture_output=True,
+        )
+    except Exception:
+        pass
+```
+- **Verify:** `python -c "from voicecli.stt_client import auto_paste; print('ok')"`
+- **Expected output:** `ok`
+- **Time:** 2 min
+
+#### T6b — Wire --paste into toggle flow
+- **Agent:** backend-dev
+- **File:** `src/voicecli/cli.py`
+- **Spec trace:** SC-9, U4
+- **Phase:** GREEN
+- **Difficulty:** 1
+- **Description:** In `dictate` callback, after printing transcription text, if `paste=True` and text exists, call `auto_paste(text)`.
+- **Time:** 2 min
+
+---
+**RED-GATE: Slice 2** — Verify toggle with daemon produces notification. `--paste` importable.
+
+---
+
+### Slice 3: Hotkey listener
+
+#### T7 — Config: load_stt_config()
+- **Agent:** backend-dev
+- **File:** `src/voicecli/config.py`
+- **Spec trace:** SC-11, S1
+- **Phase:** RED
+- **Difficulty:** 2
+- **Description:** Add `load_stt_config() -> dict` that reads `[stt]` table from `voicecli.toml`. Returns `{"hotkey": "alt+space"}` (default). Known keys: `hotkey` (str).
+- **Code snippet:**
+```python
+_KNOWN_STT: dict[str, object] = {
+    "hotkey": str,
+}
+
+def load_stt_config(config: "Path | None" = None) -> dict:
+    path = config if config is not None else _find_config()
+    if path is None:
+        return {"hotkey": "alt+space"}
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+    raw = data.get("stt", {})
+    result: dict[str, object] = {"hotkey": "alt+space"}
+    for key, expected_type in _KNOWN_STT.items():
+        if key in raw:
+            try:
+                result[key] = expected_type(raw[key])
+            except (ValueError, TypeError):
+                pass
+    return result
+```
+- **Verify:** `python -c "from voicecli.config import load_stt_config; print(load_stt_config())"`
+- **Expected output:** `{'hotkey': 'alt+space'}`
+- **Time:** 3 min
+
+#### T7b — Add pynput optional dependency
+- **Agent:** backend-dev
+- **File:** `pyproject.toml`
+- **Spec trace:** SC-10
+- **Phase:** GREEN
+- **Difficulty:** 1
+- **Description:** Add `pynput` as optional dependency under `[project.optional-dependencies]` group `hotkey` (or inline if no groups exist). Also add to dev deps if needed.
+- **Time:** 2 min
+
+#### T8 — hotkey_loop()
+- **Agent:** backend-dev
+- **File:** `src/voicecli/stt_client.py`
+- **Spec trace:** SC-10, SC-12, N5
+- **Phase:** RED
+- **Difficulty:** 3
+- **Description:** Add `hotkey_loop(hotkey: str, paste: bool)` that uses `pynput.keyboard.GlobalHotKeys` to listen for the configured hotkey. 300ms debounce via `time.monotonic()`. On hotkey: call `send_toggle()` + `notify()` + optional `auto_paste()`. Block until Ctrl+C (KeyboardInterrupt). Print "Listening for {hotkey}... (Ctrl+C to stop)" on start.
+- **Code snippet:**
+```python
+def hotkey_loop(hotkey: str = "alt+space", paste: bool = False) -> None:
+    from pynput import keyboard
+    import time
+
+    last_trigger = 0.0
+    DEBOUNCE = 0.3
+
+    def on_hotkey():
+        nonlocal last_trigger
+        now = time.monotonic()
+        if now - last_trigger < DEBOUNCE:
+            return
+        last_trigger = now
+        resp = send_toggle()
+        # handle response same as single-shot...
+
+    hotkey_str = f"<{hotkey.replace('+', '>+<')}>"  # pynput format
+    with keyboard.GlobalHotKeys({hotkey_str: on_hotkey}) as listener:
+        print(f"Listening for {hotkey}... (Ctrl+C to stop)", flush=True)
+        listener.join()
+```
+- **Verify:** `python -c "from voicecli.stt_client import hotkey_loop; print('ok')"`
+- **Expected output:** `ok`
+- **Time:** 5 min
+
+#### T8b — Wire --listen into CLI
+- **Agent:** backend-dev
+- **File:** `src/voicecli/cli.py`
+- **Spec trace:** SC-10, SC-12, U3
+- **Phase:** GREEN
+- **Difficulty:** 2
+- **Description:** In `dictate` callback, if `listen=True`: load `stt_config = load_stt_config()`, call `hotkey_loop(stt_config["hotkey"], paste)`. This replaces the single-shot toggle flow.
+- **Time:** 2 min
+
+---
+**RED-GATE: Slice 3** — Verify `voicecli dictate --listen --help` shows options. Config loads hotkey default.
+
+---
+
+### Cross-cutting
+
+#### T9 — Unit tests for stt_client `[P]`
+- **Agent:** tester
+- **File:** `tests/test_stt_client.py` (new)
+- **Spec trace:** SC-1 through SC-12
+- **Phase:** GREEN
+- **Difficulty:** 3
+- **Description:** Test `_send_request` with mocked socket (patch `socket.socket`), test `send_toggle`/`send_status` delegation, test `notify` with `shutil.which` returning None (silent skip), test `auto_paste` with xdotool missing, test `hotkey_loop` starts and responds to keyboard interrupt. Mock `subprocess.run` for notify/paste tests.
+- **Verify:** `uv run pytest tests/test_stt_client.py -v`
+- **Expected output:** All tests pass
+- **Time:** 8 min
+
+#### T10 — Unit tests for config load_stt_config
+- **Agent:** tester
+- **File:** `tests/test_stt_client.py`
+- **Spec trace:** SC-11
+- **Phase:** GREEN
+- **Difficulty:** 1
+- **Description:** Test `load_stt_config()` returns default hotkey when no config, and reads `[stt]` table when present (use tmp_path with toml file).
+- **Verify:** `uv run pytest tests/test_stt_client.py -v -k stt_config`
+- **Expected output:** Tests pass
+- **Time:** 3 min
+
+#### T11 — Documentation `[P]`
+- **Agent:** doc-writer
+- **File:** `docs/dictation-setup.md` (new)
+- **Spec trace:** SC-13
+- **Phase:** GREEN
+- **Difficulty:** 2
+- **Description:** Write setup guide covering: (1) Recommended: Windows keyboard shortcut → `wsl voicecli dictate`, (2) Alternative: `voicecli dictate --listen` with pynput, (3) KDE Custom Shortcuts setup, (4) GNOME Keyboard Shortcuts setup, (5) voicecli.toml `[stt]` config, (6) Troubleshooting (daemon not running, no notifications).
+- **Verify:** `test -f docs/dictation-setup.md && echo ok`
+- **Expected output:** `ok`
+- **Time:** 5 min

--- a/docs/dictation-setup.md
+++ b/docs/dictation-setup.md
@@ -1,0 +1,304 @@
+---
+title: Dictation Setup
+description: How to set up voicecli dictate with a keyboard shortcut for hands-free dictation
+---
+
+## Overview
+
+`voicecli dictate` is a thin socket client for the STT daemon (`voicecli stt-serve`). Each
+invocation connects to the daemon's Unix socket, sends a `toggle` action, and returns
+immediately — there is no model loading on the client side. The daemon handles recording,
+transcription, and clipboard write; the client reads the result from the response and shows
+a desktop notification.
+
+Typical flow:
+
+1. First press: daemon starts recording. Notification: "Recording..."
+2. Second press: daemon stops recording, transcribes, writes text to clipboard. Notification shows the transcribed text.
+3. Ctrl+V in any app to paste.
+
+## Prerequisites
+
+The STT daemon must be running before `voicecli dictate` can do anything:
+
+```bash
+voicecli stt-serve
+```
+
+The daemon loads the faster-whisper model eagerly at startup (default: `large-v3-turbo`).
+Keep it running in the background — a supervisord config is shown in `voicecli stt-serve --help`.
+
+To verify the daemon is ready:
+
+```bash
+voicecli dictate status
+```
+
+Expected output: `idle`
+
+## Recommended: Windows Keyboard Shortcut
+
+This is the primary path for WSL2 users. A Windows keyboard shortcut can trigger
+`wsl voicecli dictate` from any focused application — including native Windows apps,
+browsers, and Office tools. No X11 focus is required.
+
+### Windows Settings (built-in)
+
+1. Open **Settings > Bluetooth & devices > Keyboard > Advanced keyboard settings**.
+2. Under **Custom keyboard shortcuts**, add a new shortcut.
+3. Set the command to:
+
+```
+wsl voicecli dictate
+```
+
+4. Assign your preferred key combination (e.g. `Alt+Shift+Space`).
+
+When triggered, the `wsl` launcher starts the WSL2 process, runs `voicecli dictate`,
+and exits. The clipboard is shared between WSL2 and Windows — text written by the
+daemon via `xclip`/`wl-copy` is immediately available for Ctrl+V in any Windows app.
+Notifications appear in the WSLg notification area in the Windows system tray.
+
+### AutoHotkey Alternative
+
+If you prefer AutoHotkey (v2), save this as `dictate.ahk` and run it at login:
+
+```ahk
+; AutoHotkey v2 — trigger voicecli dictate from anywhere
+!+Space:: {  ; Alt+Shift+Space
+    RunWait "wsl voicecli dictate", , "Hide"
+}
+```
+
+For AutoHotkey v1:
+
+```ahk
+; AutoHotkey v1 — trigger voicecli dictate from anywhere
+!+Space::
+    RunWait, wsl voicecli dictate,, Hide
+return
+```
+
+Adjust the hotkey combination (`!` = Alt, `+` = Shift, `^` = Ctrl, `#` = Win) to
+your preference.
+
+## Alternative: Built-in Hotkey Listener
+
+`voicecli dictate --listen` starts a persistent pynput listener that watches for the
+configured hotkey and calls `voicecli dictate` on each press.
+
+**Limitation:** pynput captures keys only when an X11 or WSLg window has focus. If you
+switch to a native Windows app, the listener will not receive key events. Use the Windows
+keyboard shortcut approach above for global coverage.
+
+### Install pynput
+
+pynput is an optional dependency. Install it into the voicecli environment:
+
+```bash
+uv pip install pynput
+```
+
+### Start the listener
+
+```bash
+voicecli dictate --listen
+```
+
+Output:
+
+```
+Listening for alt+space... (Ctrl+C to stop)
+```
+
+Press Ctrl+C to stop the listener.
+
+### Configure the hotkey
+
+In `voicecli.toml`, add an `[stt]` section:
+
+```toml
+[stt]
+hotkey = "alt+space"
+```
+
+The default is `alt+space`. The hotkey string uses pynput's format: modifier names
+(`alt`, `ctrl`, `shift`, `cmd`) joined with `+`, followed by the key name.
+
+Examples:
+
+```toml
+hotkey = "ctrl+shift+space"
+hotkey = "alt+f9"
+hotkey = "cmd+shift+d"
+```
+
+### Combine with auto-paste
+
+```bash
+voicecli dictate --listen --paste
+```
+
+With `--paste`, after each successful transcription the text is typed into the focused
+X11/WSLg window via `xdotool`. See [Auto-paste](#auto-paste) for details.
+
+## Linux Desktop Shortcuts
+
+### KDE Plasma
+
+1. Open **System Settings > Shortcuts > Custom Shortcuts**.
+2. Click **Edit > New > Global Shortcut > Command/URL**.
+3. Name it "Dictate".
+4. Under **Trigger**, assign your key combination.
+5. Under **Action**, set the command to:
+
+```
+voicecli dictate
+```
+
+If `voicecli` is not on the KDE session PATH, use the full path:
+
+```
+/home/<user>/.local/bin/voicecli dictate
+```
+
+Or via `uv run`:
+
+```
+bash -c 'cd /path/to/voiceCLI && uv run voicecli dictate'
+```
+
+### GNOME
+
+1. Open **Settings > Keyboard > Keyboard Shortcuts > Custom Shortcuts**.
+2. Click **+** to add a new shortcut.
+3. Set the name to "Dictate" and the command to `voicecli dictate`.
+4. Click **Set Shortcut** and press your key combination.
+
+## Auto-paste
+
+The `--paste` flag triggers `xdotool type` to type the transcribed text directly into
+the focused window after each successful transcription.
+
+```bash
+voicecli dictate --paste
+```
+
+**Limitation:** `xdotool` only works in X11/XWayland windows. For native Windows apps,
+it has no effect. The text is always written to the clipboard regardless of `--paste`,
+so Ctrl+V always works as a fallback.
+
+If `xdotool` is not installed, `--paste` silently does nothing. Install it with:
+
+```bash
+sudo apt install xdotool
+```
+
+## Status Check
+
+Check the current daemon state without toggling:
+
+```bash
+voicecli dictate status
+```
+
+Possible outputs:
+
+| Output | Meaning |
+|--------|---------|
+| `idle` | Daemon is running, not recording |
+| `recording` | Currently capturing audio |
+| `transcribing` | Audio captured, model running |
+| `queued` | Toggle received during transcription; will record next |
+
+If the daemon is not running, the command exits with code 1 and prints:
+
+```
+STT daemon not running
+```
+
+## Notifications
+
+When `notify-send` is available, `voicecli dictate` sends desktop notifications:
+
+| Event | Notification |
+|-------|-------------|
+| Recording started | "Recording..." (persistent until next event) |
+| Transcription complete | First 50 characters of transcribed text |
+| Queued | "Queued..." |
+| Daemon not running | "STT daemon not running" |
+
+Notifications use a stable replace-ID (`voicecli-dictate`) so each new notification
+replaces the previous one rather than stacking.
+
+On WSL2 with WSLg, notifications appear in the Windows system tray notification area.
+
+Install `notify-send` if not present:
+
+```bash
+sudo apt install libnotify-bin
+```
+
+If `notify-send` is not installed, notifications are silently skipped — the command
+still functions normally.
+
+## Troubleshooting
+
+**"STT daemon not running"**
+
+Start the daemon:
+
+```bash
+voicecli stt-serve
+```
+
+Wait for the "Ready" message before triggering dictate. The model load takes 10–30
+seconds depending on your GPU.
+
+**No notifications appear**
+
+Check that `notify-send` is installed:
+
+```bash
+which notify-send
+```
+
+If missing: `sudo apt install libnotify-bin`. On WSL2, also verify that WSLg is active
+(an X server process should be running — check Task Manager for `wslg.exe`).
+
+**Hotkey not captured with `--listen`**
+
+pynput requires an active X11/WSLg session and focus on an X11 window. If you are
+working in a native Windows app, the hotkey will not fire. Switch to the Windows
+keyboard shortcut approach described in [Recommended: Windows Keyboard Shortcut](#recommended-windows-keyboard-shortcut).
+
+**Transcription is slow after restart**
+
+The daemon loads the model at startup. If `voicecli stt-serve` was just started, wait
+for `[voicecli stt] Ready on ...` before dictating. Subsequent toggles have sub-second
+latency.
+
+**Toggle triggers twice**
+
+The built-in listener applies a 300ms debounce. If you are triggering via an external
+script or hotkey manager that sends multiple key events, add a short delay between
+invocations on the Windows/AHK side.
+
+## Configuration Reference
+
+Add an `[stt]` table to `voicecli.toml` to configure STT behavior:
+
+```toml
+[stt]
+model  = "large-v3-turbo"   # Whisper model (overridden by --model flag)
+hotkey = "alt+space"        # Hotkey for --listen mode
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `model` | `large-v3-turbo` | faster-whisper model loaded by `stt-serve` at startup |
+| `hotkey` | `alt+space` | Hotkey string for `voicecli dictate --listen` |
+
+Priority chain: `CLI flag > voicecli.toml > hardcoded default`
+
+See [Configuration](./configuration) for config file discovery rules.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ override-dependencies = [
 # src layout: expose src/ to pytest without relying on editable install
 pythonpath = ["src"]
 
+[project.optional-dependencies]
+hotkey = ["pynput>=1.7"]
+
 [dependency-groups]
 dev = [
     "ruff",

--- a/src/voicecli/cli.py
+++ b/src/voicecli/cli.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 from typing import Annotated, Optional
 
@@ -147,6 +148,78 @@ def samples_from_url(
     except (RuntimeError, ValueError) as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
+
+
+# ── Dictate sub-app ───────────────────────────────────────────────────────────
+
+dictate_app = typer.Typer(help="Dictation client for STT daemon")
+app.add_typer(dictate_app, name="dictate", invoke_without_command=True)
+
+
+@dictate_app.callback(invoke_without_command=True)
+def dictate(
+    ctx: typer.Context,
+    listen: Annotated[
+        bool,
+        typer.Option("--listen", help="Start global hotkey listener (blocks until Ctrl+C)"),
+    ] = False,
+    paste: Annotated[
+        bool,
+        typer.Option("--paste", help="Auto-type transcribed text into the focused window"),
+    ] = False,
+) -> None:
+    """Toggle dictation recording or start the hotkey listener."""
+    if ctx.invoked_subcommand is not None:
+        return
+
+    if listen:
+        from voicecli.config import load_stt_config
+        from voicecli.stt_client import hotkey_loop
+
+        stt_cfg = load_stt_config()
+        hotkey_loop(stt_cfg["hotkey"], paste=paste)
+        return
+
+    from voicecli.stt_client import auto_paste, notify, send_toggle
+
+    resp = send_toggle()
+
+    if resp.get("status") == "error":
+        print(resp.get("message", "unknown error"), file=sys.stderr)
+        notify(resp.get("message", "STT daemon not running"), timeout=3000)
+        raise typer.Exit(code=1)
+
+    state = resp.get("state", "")
+    text = resp.get("text", "")
+    language = resp.get("language") or ""
+
+    if state == "recording":
+        print(state)
+        notify("Recording...", timeout=0)
+    elif state == "idle" and text:
+        print(text)
+        preview = text[:50] + ("..." if len(text) > 50 else "")
+        lang_tag = f"[{language}] " if language else ""
+        notify(f"{lang_tag}{preview}", timeout=3000)
+        if paste:
+            auto_paste(text)
+    elif state == "queued":
+        print(state)
+        notify("Queued...", timeout=3000)
+    else:
+        print(state)
+
+
+@dictate_app.command("status")
+def dictate_status() -> None:
+    """Show current STT daemon state."""
+    from voicecli.stt_client import send_status
+
+    resp = send_status()
+    if resp.get("status") == "error":
+        print(resp.get("message", "unknown error"), file=sys.stderr)
+        raise typer.Exit(code=1)
+    print(resp.get("state", "unknown"))
 
 
 # ── CUDA error formatting (moved from engine.py cuda_guard) ──────────────────

--- a/src/voicecli/config.py
+++ b/src/voicecli/config.py
@@ -1,5 +1,7 @@
 """Load user defaults from voicecli.toml."""
 
+from __future__ import annotations
+
 import sys
 import tomllib
 from pathlib import Path
@@ -43,7 +45,7 @@ def _find_config() -> Path | None:
         current = current.parent
 
 
-def load_defaults(config: "Path | None" = None) -> dict:
+def load_defaults(config: Path | None = None) -> dict:
     """Load [defaults] from voicecli.toml, walking up from CWD to $HOME. Returns empty dict if not found.
 
     Args:
@@ -61,6 +63,53 @@ def load_defaults(config: "Path | None" = None) -> dict:
     raw = data.get("defaults", {})
     result = {}
     for key, expected_type in _KNOWN_DEFAULTS.items():
+        if key in raw:
+            try:
+                result[key] = expected_type(raw[key])
+            except (ValueError, TypeError):
+                pass
+    return result
+
+
+def load_config(config: Path | None = None) -> dict:
+    """Load the full voicecli.toml as a raw dict (all tables preserved).
+
+    Returns an empty dict if no config file is found (no warning printed).
+    Used by commands that need access to non-[defaults] tables (e.g. [stt]).
+
+    Args:
+        config: Explicit path to a toml file. If provided, skips the walk-up search.
+    """
+    path = config if config is not None else _find_config()
+    if path is None:
+        return {}
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+_KNOWN_STT: dict[str, type] = {
+    "hotkey": str,
+    "model": str,
+}
+
+
+def load_stt_config(config: Path | None = None) -> dict:
+    """Load the ``[stt]`` table from voicecli.toml.
+
+    Returns ``{"hotkey": "alt+space"}`` (and other defaults) when no config is
+    found or the table is absent.
+
+    Args:
+        config: Explicit path to a toml file. If provided, skips the walk-up search.
+    """
+    path = config if config is not None else _find_config()
+    result: dict[str, object] = {"hotkey": "alt+space"}
+    if path is None:
+        return result
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+    raw = data.get("stt", {})
+    for key, expected_type in _KNOWN_STT.items():
         if key in raw:
             try:
                 result[key] = expected_type(raw[key])

--- a/src/voicecli/stt_client.py
+++ b/src/voicecli/stt_client.py
@@ -66,6 +66,7 @@ def notify(body: str, timeout: int = 3000) -> None:
     Silently skips if notify-send is not installed or any error occurs.
     Uses a fixed replace-ID so each call replaces the previous notification.
     """
+    import html
     import shutil
     import subprocess
 
@@ -78,7 +79,7 @@ def notify(body: str, timeout: int = 3000) -> None:
                 "-r",
                 _NOTIFY_REPLACE_ID,
                 "VoiceCLI",
-                body,
+                html.escape(body),
                 "-t",
                 str(timeout),
             ],
@@ -129,6 +130,13 @@ def hotkey_loop(hotkey: str = "alt+space", paste: bool = False) -> None:
                 (e.g. ``"alt+space"``, ``"ctrl+shift+d"``).
         paste:  If True, type transcribed text into the focused window.
     """
+    import re
+    import sys
+
+    if not re.fullmatch(r"[a-z0-9_]+(\+[a-z0-9_]+)*", hotkey.lower()):
+        print(f"Invalid hotkey format: {hotkey!r}", file=sys.stderr)
+        return
+
     from pynput import keyboard
     import time
 

--- a/src/voicecli/stt_client.py
+++ b/src/voicecli/stt_client.py
@@ -30,13 +30,14 @@ def _send_request(action: str, timeout: int = _DEFAULT_TIMEOUT) -> dict:
         payload = json.dumps({"action": action}, ensure_ascii=False) + "\n"
         sock.sendall(payload.encode())
         buf = bytearray()
-        while b"\n" not in buf:
+        max_response = 65536
+        while b"\n" not in buf and len(buf) < max_response:
             chunk = sock.recv(4096)
             if not chunk:
                 break
             buf.extend(chunk)
         return json.loads(buf.split(b"\n")[0])
-    except (ConnectionRefusedError, FileNotFoundError, OSError):
+    except (ConnectionRefusedError, FileNotFoundError, OSError, ValueError):
         return {"status": "error", "message": "STT daemon not running"}
     finally:
         sock.close()
@@ -44,7 +45,7 @@ def _send_request(action: str, timeout: int = _DEFAULT_TIMEOUT) -> dict:
 
 def send_toggle() -> dict:
     """Send a toggle action to the STT daemon and return the response dict."""
-    return _send_request("toggle")
+    return _send_request("toggle", timeout=60)
 
 
 def send_status() -> dict:
@@ -132,14 +133,63 @@ def hotkey_loop(hotkey: str = "alt+space", paste: bool = False) -> None:
     import time
 
     last_trigger = 0.0
-    DEBOUNCE = 0.3
+    debounce_s = 0.3
 
-    # Convert "alt+space" → "<alt>+<space>" (pynput GlobalHotKeys format).
-    # Single-char keys like "space" stay as-is inside angle brackets;
-    # modifier shorthands like "alt" map to "<alt>".
+    # Convert "alt+space" → "<alt>+<space>", "ctrl+shift+d" → "<ctrl>+<shift>+d".
+    # Named keys (modifiers + special) get <...>; single printable chars stay bare.
+    _NAMED_KEYS = frozenset(
+        {
+            "alt",
+            "alt_l",
+            "alt_r",
+            "ctrl",
+            "ctrl_l",
+            "ctrl_r",
+            "shift",
+            "shift_l",
+            "shift_r",
+            "cmd",
+            "cmd_l",
+            "cmd_r",
+            "space",
+            "enter",
+            "return",
+            "tab",
+            "esc",
+            "escape",
+            "backspace",
+            "delete",
+            "insert",
+            "home",
+            "end",
+            "page_up",
+            "page_down",
+            "up",
+            "down",
+            "left",
+            "right",
+            "caps_lock",
+            "num_lock",
+            "scroll_lock",
+            "print_screen",
+            "f1",
+            "f2",
+            "f3",
+            "f4",
+            "f5",
+            "f6",
+            "f7",
+            "f8",
+            "f9",
+            "f10",
+            "f11",
+            "f12",
+        }
+    )
+
     def _to_pynput(combo: str) -> str:
         parts = combo.lower().split("+")
-        wrapped = [f"<{p}>" for p in parts]
+        wrapped = [f"<{p}>" if p in _NAMED_KEYS else p for p in parts]
         return "+".join(wrapped)
 
     hotkey_pynput = _to_pynput(hotkey)
@@ -147,7 +197,7 @@ def hotkey_loop(hotkey: str = "alt+space", paste: bool = False) -> None:
     def on_hotkey() -> None:
         nonlocal last_trigger
         now = time.monotonic()
-        if now - last_trigger < DEBOUNCE:
+        if now - last_trigger < debounce_s:
             return
         last_trigger = now
 
@@ -169,8 +219,12 @@ def hotkey_loop(hotkey: str = "alt+space", paste: bool = False) -> None:
             notify(f"{lang_tag}{preview}", timeout=3000)
             if paste:
                 auto_paste(text)
+        elif state == "idle":
+            notify("No speech detected", timeout=2000)
         elif state == "queued":
             notify("Queued...", timeout=3000)
+        else:
+            notify(state, timeout=2000)
 
     with keyboard.GlobalHotKeys({hotkey_pynput: on_hotkey}) as listener:
         print(f"Listening for {hotkey}... (Ctrl+C to stop)", flush=True)

--- a/src/voicecli/stt_client.py
+++ b/src/voicecli/stt_client.py
@@ -1,0 +1,180 @@
+"""Client for the STT daemon — toggle, status, notifications, auto-paste, hotkey listener.
+
+Protocol: newline-delimited JSON over AF_UNIX SOCK_STREAM.
+Socket path: ~/.local/share/voicecli/stt-daemon.sock
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+from pathlib import Path
+
+SOCKET_PATH = Path.home() / ".local" / "share" / "voicecli" / "stt-daemon.sock"
+_DEFAULT_TIMEOUT = 10  # seconds
+
+
+# ── Wire protocol ─────────────────────────────────────────────────────────────
+
+
+def _send_request(action: str, timeout: int = _DEFAULT_TIMEOUT) -> dict:
+    """Connect to STT daemon, send action, return response dict.
+
+    Returns ``{"status": "error", "message": "STT daemon not running"}`` when the
+    socket is absent or the connection is refused.
+    """
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.settimeout(timeout)
+    try:
+        sock.connect(str(SOCKET_PATH))
+        payload = json.dumps({"action": action}, ensure_ascii=False) + "\n"
+        sock.sendall(payload.encode())
+        buf = bytearray()
+        while b"\n" not in buf:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            buf.extend(chunk)
+        return json.loads(buf.split(b"\n")[0])
+    except (ConnectionRefusedError, FileNotFoundError, OSError):
+        return {"status": "error", "message": "STT daemon not running"}
+    finally:
+        sock.close()
+
+
+def send_toggle() -> dict:
+    """Send a toggle action to the STT daemon and return the response dict."""
+    return _send_request("toggle")
+
+
+def send_status() -> dict:
+    """Send a status action to the STT daemon and return the response dict."""
+    return _send_request("status")
+
+
+# ── Desktop notifications ─────────────────────────────────────────────────────
+
+# Stable replace-ID so each notify-send call replaces the previous bubble.
+# notify-send -r requires an integer; we derive one from the app name.
+_NOTIFY_REPLACE_ID = str(abs(hash("voicecli-dictate")) % 65536)
+
+
+def notify(body: str, timeout: int = 3000) -> None:
+    """Show a desktop notification via notify-send.
+
+    Silently skips if notify-send is not installed or any error occurs.
+    Uses a fixed replace-ID so each call replaces the previous notification.
+    """
+    import shutil
+    import subprocess
+
+    if not shutil.which("notify-send"):
+        return
+    try:
+        subprocess.run(
+            [
+                "notify-send",
+                "-r",
+                _NOTIFY_REPLACE_ID,
+                "VoiceCLI",
+                body,
+                "-t",
+                str(timeout),
+            ],
+            check=False,
+            capture_output=True,
+        )
+    except Exception:
+        pass
+
+
+# ── Auto-paste ────────────────────────────────────────────────────────────────
+
+
+def auto_paste(text: str) -> None:
+    """Type *text* into the focused window via xdotool.
+
+    Waits 150 ms first so the caller's window can regain focus after the hotkey
+    is released.  Silently skips if xdotool is not installed or any error occurs.
+    """
+    import shutil
+    import subprocess
+    import time
+
+    if not shutil.which("xdotool"):
+        return
+    try:
+        time.sleep(0.15)
+        subprocess.run(
+            ["xdotool", "type", "--clearmodifiers", "--", text],
+            check=False,
+            capture_output=True,
+        )
+    except Exception:
+        pass
+
+
+# ── Hotkey listener ───────────────────────────────────────────────────────────
+
+
+def hotkey_loop(hotkey: str = "alt+space", paste: bool = False) -> None:
+    """Block until Ctrl+C, firing send_toggle() on each *hotkey* press.
+
+    Applies a 300 ms debounce to avoid double-triggers.  Calls ``notify()`` and
+    optionally ``auto_paste()`` based on the daemon response.
+
+    Args:
+        hotkey: Key combination in pynput format pieces separated by ``+``
+                (e.g. ``"alt+space"``, ``"ctrl+shift+d"``).
+        paste:  If True, type transcribed text into the focused window.
+    """
+    from pynput import keyboard
+    import time
+
+    last_trigger = 0.0
+    DEBOUNCE = 0.3
+
+    # Convert "alt+space" → "<alt>+<space>" (pynput GlobalHotKeys format).
+    # Single-char keys like "space" stay as-is inside angle brackets;
+    # modifier shorthands like "alt" map to "<alt>".
+    def _to_pynput(combo: str) -> str:
+        parts = combo.lower().split("+")
+        wrapped = [f"<{p}>" for p in parts]
+        return "+".join(wrapped)
+
+    hotkey_pynput = _to_pynput(hotkey)
+
+    def on_hotkey() -> None:
+        nonlocal last_trigger
+        now = time.monotonic()
+        if now - last_trigger < DEBOUNCE:
+            return
+        last_trigger = now
+
+        resp = send_toggle()
+
+        if resp.get("status") == "error":
+            notify(resp.get("message", "STT daemon not running"), timeout=3000)
+            return
+
+        state = resp.get("state", "")
+        text = resp.get("text", "")
+        language = resp.get("language") or ""
+
+        if state == "recording":
+            notify("Recording...", timeout=0)
+        elif state == "idle" and text:
+            preview = text[:50] + ("..." if len(text) > 50 else "")
+            lang_tag = f"[{language}] " if language else ""
+            notify(f"{lang_tag}{preview}", timeout=3000)
+            if paste:
+                auto_paste(text)
+        elif state == "queued":
+            notify("Queued...", timeout=3000)
+
+    with keyboard.GlobalHotKeys({hotkey_pynput: on_hotkey}) as listener:
+        print(f"Listening for {hotkey}... (Ctrl+C to stop)", flush=True)
+        try:
+            listener.join()
+        except KeyboardInterrupt:
+            pass

--- a/tests/test_stt_client.py
+++ b/tests/test_stt_client.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import json
 import socket
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+from typer.testing import CliRunner
 
 
 # ---------------------------------------------------------------------------
@@ -506,3 +508,511 @@ class TestLoadSttConfig:
 
         assert result["hotkey"] == "alt+space"
         assert result["model"] == "large-v3-turbo"
+
+
+# ---------------------------------------------------------------------------
+# T11 — dictate CLI command
+# ---------------------------------------------------------------------------
+
+
+class TestDictateCLI:
+    """Integration tests for the 'dictate' CLI command using CliRunner."""
+
+    @pytest.fixture(autouse=True)
+    def runner(self):
+        self._runner = CliRunner()
+
+    def _invoke(self, args=None):
+        from voicecli.cli import app
+
+        return self._runner.invoke(app, ["dictate"] + (args or []))
+
+    # -- toggle branch tests --------------------------------------------------
+
+    def test_error_response_exits_1_with_stderr_message(self):
+        """Error response from daemon → exit code 1, message printed to stderr."""
+        with (
+            patch(
+                "voicecli.stt_client.send_toggle",
+                return_value={"status": "error", "message": "STT daemon not running"},
+            ),
+            patch("voicecli.stt_client.notify"),
+        ):
+            # Act
+            result = self._invoke()
+
+        # Assert
+        assert result.exit_code == 1
+        assert "STT daemon not running" in result.output
+
+    def test_recording_state_exits_0_prints_recording_notifies(self):
+        """Recording state → exit code 0, 'recording' on stdout, notify called."""
+        with (
+            patch(
+                "voicecli.stt_client.send_toggle",
+                return_value={"status": "ok", "state": "recording"},
+            ),
+            patch("voicecli.stt_client.notify") as mock_notify,
+        ):
+            # Act
+            result = self._invoke()
+
+        # Assert
+        assert result.exit_code == 0
+        assert "recording" in result.output
+        mock_notify.assert_called_once_with("Recording...", timeout=0)
+
+    def test_idle_with_text_exits_0_prints_text_notifies_preview(self):
+        """Idle + text → exit 0, text printed, notify called with preview."""
+        with (
+            patch(
+                "voicecli.stt_client.send_toggle",
+                return_value={"status": "ok", "state": "idle", "text": "Hello world"},
+            ),
+            patch("voicecli.stt_client.notify") as mock_notify,
+            patch("voicecli.stt_client.auto_paste"),
+        ):
+            # Act
+            result = self._invoke()
+
+        # Assert
+        assert result.exit_code == 0
+        assert "Hello world" in result.output
+        mock_notify.assert_called_once_with("Hello world", timeout=3000)
+
+    def test_idle_with_empty_text_exits_0_prints_idle(self):
+        """Idle + empty text → exit 0, 'idle' printed, no notify call."""
+        with (
+            patch(
+                "voicecli.stt_client.send_toggle",
+                return_value={"status": "ok", "state": "idle", "text": ""},
+            ),
+            patch("voicecli.stt_client.notify") as mock_notify,
+        ):
+            # Act
+            result = self._invoke()
+
+        # Assert
+        assert result.exit_code == 0
+        assert "idle" in result.output
+        mock_notify.assert_not_called()
+
+    def test_queued_state_exits_0_prints_queued_notifies(self):
+        """Queued state → exit 0, 'queued' on stdout, notify called with 'Queued...'."""
+        with (
+            patch(
+                "voicecli.stt_client.send_toggle",
+                return_value={"status": "ok", "state": "queued"},
+            ),
+            patch("voicecli.stt_client.notify") as mock_notify,
+        ):
+            # Act
+            result = self._invoke()
+
+        # Assert
+        assert result.exit_code == 0
+        assert "queued" in result.output
+        mock_notify.assert_called_once_with("Queued...", timeout=3000)
+
+    def test_idle_with_text_includes_language_tag_in_notify(self):
+        """Idle + text + language → notify preview includes '[fr] ' language tag."""
+        with (
+            patch(
+                "voicecli.stt_client.send_toggle",
+                return_value={
+                    "status": "ok",
+                    "state": "idle",
+                    "text": "Bonjour",
+                    "language": "fr",
+                },
+            ),
+            patch("voicecli.stt_client.notify") as mock_notify,
+            patch("voicecli.stt_client.auto_paste"),
+        ):
+            # Act
+            result = self._invoke()
+
+        # Assert
+        assert result.exit_code == 0
+        notify_body = mock_notify.call_args[0][0]
+        assert "[fr]" in notify_body
+        assert "Bonjour" in notify_body
+
+    # -- dictate status subcommand ------------------------------------------
+
+    def test_status_success_prints_state_exits_0(self):
+        """dictate status success → state printed, exit 0."""
+        with patch(
+            "voicecli.stt_client.send_status",
+            return_value={"status": "ok", "state": "idle"},
+        ):
+            # Act
+            result = self._invoke(["status"])
+
+        # Assert
+        assert result.exit_code == 0
+        assert "idle" in result.output
+
+    def test_status_error_exits_1(self):
+        """dictate status error → exit 1."""
+        with patch(
+            "voicecli.stt_client.send_status",
+            return_value={"status": "error", "message": "STT daemon not running"},
+        ):
+            # Act
+            result = self._invoke(["status"])
+
+        # Assert
+        assert result.exit_code == 1
+
+    # -- dictate --listen ----------------------------------------------------
+
+    def test_listen_calls_hotkey_loop_with_config_hotkey(self):
+        """dictate --listen → hotkey_loop called with hotkey from config and paste=False."""
+        with (
+            patch(
+                "voicecli.config.load_stt_config",
+                return_value={"hotkey": "alt+space"},
+            ),
+            patch("voicecli.stt_client.hotkey_loop") as mock_loop,
+        ):
+            # Act
+            result = self._invoke(["--listen"])
+
+        # Assert
+        assert result.exit_code == 0
+        mock_loop.assert_called_once_with("alt+space", paste=False)
+
+    def test_listen_paste_forwards_paste_true(self):
+        """dictate --listen --paste → hotkey_loop called with paste=True."""
+        with (
+            patch(
+                "voicecli.config.load_stt_config",
+                return_value={"hotkey": "ctrl+shift+d"},
+            ),
+            patch("voicecli.stt_client.hotkey_loop") as mock_loop,
+        ):
+            # Act
+            result = self._invoke(["--listen", "--paste"])
+
+        # Assert
+        assert result.exit_code == 0
+        mock_loop.assert_called_once_with("ctrl+shift+d", paste=True)
+
+
+# ---------------------------------------------------------------------------
+# T11 — hotkey_loop behavioral tests (added to TestHotkeyLoop)
+# ---------------------------------------------------------------------------
+
+
+def _fire_hotkey_once(mock_global_hotkeys_cls, on_hotkey_fn):
+    """Build a GlobalHotKeys mock that fires the callback once then exits via KeyboardInterrupt."""
+
+    def fake_ctor(hotkeys_dict):
+        cb = list(hotkeys_dict.values())[0]
+
+        def join_side():
+            on_hotkey_fn(cb)
+            raise KeyboardInterrupt
+
+        inst = MagicMock()
+        inst.__enter__ = MagicMock(return_value=inst)
+        inst.__exit__ = MagicMock(return_value=False)
+        inst.join.side_effect = join_side
+        return inst
+
+    return fake_ctor
+
+
+class TestHotkeyLoopBehavioral:
+    """Behavioral tests for hotkey_loop — debounce, notification branches, paste, truncation."""
+
+    def _build_pynput_env(self, fake_ctor):
+        """Return (pynput_mock, keyboard_mock) with GlobalHotKeys wired."""
+        mock_keyboard = MagicMock()
+        mock_keyboard.GlobalHotKeys = fake_ctor
+        pynput_mock = MagicMock()
+        pynput_mock.keyboard = mock_keyboard
+        return pynput_mock, mock_keyboard
+
+    def _evict_pynput(self):
+        for key in list(sys.modules):
+            if key == "pynput" or key.startswith("pynput."):
+                del sys.modules[key]
+
+    # -- debounce -----------------------------------------------------------
+
+    def test_debounce_rapid_fires_calls_send_toggle_once(self):
+        """Two rapid hotkey fires within debounce window → send_toggle called once.
+
+        hotkey_loop uses 'import time' locally and calls time.monotonic().
+        We patch time.monotonic at the stdlib level so the locally-imported
+        time module sees the controlled values.
+
+        Sequence of monotonic() return values:
+          call 1: 0.5 → first press, now=0.5, 0.5-0.0=0.5 >= 0.3 → fires, last_trigger=0.5
+          call 2: 0.6 → second press, now=0.6, 0.6-0.5=0.1 < 0.3 → debounced
+        """
+        from voicecli.stt_client import hotkey_loop
+
+        # Arrange
+        def fake_ctor(hotkeys_dict):
+            cb = list(hotkeys_dict.values())[0]
+
+            def join_side():
+                cb()  # first press: fires
+                cb()  # second press: debounced (0.1s later)
+                raise KeyboardInterrupt
+
+            inst = MagicMock()
+            inst.__enter__ = MagicMock(return_value=inst)
+            inst.__exit__ = MagicMock(return_value=False)
+            inst.join.side_effect = join_side
+            return inst
+
+        pynput_mock, mock_keyboard = self._build_pynput_env(fake_ctor)
+        self._evict_pynput()
+
+        monotonic_values = iter([0.5, 0.6])
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {"pynput": pynput_mock, "pynput.keyboard": mock_keyboard},
+            ),
+            patch(
+                "voicecli.stt_client.send_toggle",
+                return_value={"status": "ok", "state": "recording"},
+            ) as mock_toggle,
+            patch("voicecli.stt_client.notify"),
+            patch("time.monotonic", side_effect=monotonic_values),
+        ):
+            # Act
+            hotkey_loop(hotkey="alt+space")
+
+        # Assert: only one call made it past the debounce
+        assert mock_toggle.call_count == 1
+
+    # -- notification branches ----------------------------------------------
+
+    @pytest.mark.parametrize(
+        "resp, expected_notify_body, expected_timeout",
+        [
+            (
+                {"status": "ok", "state": "recording"},
+                "Recording...",
+                0,
+            ),
+            (
+                {"status": "ok", "state": "idle", "text": "Hello world", "language": ""},
+                "Hello world",
+                3000,
+            ),
+            (
+                {"status": "ok", "state": "idle", "text": "", "language": ""},
+                "No speech detected",
+                2000,
+            ),
+            (
+                {"status": "ok", "state": "queued"},
+                "Queued...",
+                3000,
+            ),
+        ],
+        ids=["recording", "idle-with-text", "idle-no-text", "queued"],
+    )
+    def test_notification_branch(self, resp, expected_notify_body, expected_timeout):
+        """Each daemon state triggers the correct notify() call."""
+        from voicecli.stt_client import hotkey_loop
+
+        def fake_ctor(hotkeys_dict):
+            cb = list(hotkeys_dict.values())[0]
+
+            def join_side():
+                cb()
+                raise KeyboardInterrupt
+
+            inst = MagicMock()
+            inst.__enter__ = MagicMock(return_value=inst)
+            inst.__exit__ = MagicMock(return_value=False)
+            inst.join.side_effect = join_side
+            return inst
+
+        pynput_mock, mock_keyboard = self._build_pynput_env(fake_ctor)
+        self._evict_pynput()
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {"pynput": pynput_mock, "pynput.keyboard": mock_keyboard},
+            ),
+            patch("voicecli.stt_client.send_toggle", return_value=resp),
+            patch("voicecli.stt_client.notify") as mock_notify,
+            patch("voicecli.stt_client.auto_paste"),
+        ):
+            hotkey_loop(hotkey="alt+space", paste=False)
+
+        mock_notify.assert_called_once_with(expected_notify_body, timeout=expected_timeout)
+
+    # -- paste conditional --------------------------------------------------
+
+    def test_paste_true_calls_auto_paste_on_idle_with_text(self):
+        """paste=True + idle + text → auto_paste called with full text."""
+        from voicecli.stt_client import hotkey_loop
+
+        def fake_ctor(hotkeys_dict):
+            cb = list(hotkeys_dict.values())[0]
+
+            def join_side():
+                cb()
+                raise KeyboardInterrupt
+
+            inst = MagicMock()
+            inst.__enter__ = MagicMock(return_value=inst)
+            inst.__exit__ = MagicMock(return_value=False)
+            inst.join.side_effect = join_side
+            return inst
+
+        pynput_mock, mock_keyboard = self._build_pynput_env(fake_ctor)
+        self._evict_pynput()
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {"pynput": pynput_mock, "pynput.keyboard": mock_keyboard},
+            ),
+            patch(
+                "voicecli.stt_client.send_toggle",
+                return_value={"status": "ok", "state": "idle", "text": "typed text"},
+            ),
+            patch("voicecli.stt_client.notify"),
+            patch("voicecli.stt_client.auto_paste") as mock_paste,
+        ):
+            # Act
+            hotkey_loop(hotkey="alt+space", paste=True)
+
+        # Assert
+        mock_paste.assert_called_once_with("typed text")
+
+    def test_paste_false_does_not_call_auto_paste(self):
+        """paste=False + idle + text → auto_paste NOT called."""
+        from voicecli.stt_client import hotkey_loop
+
+        def fake_ctor(hotkeys_dict):
+            cb = list(hotkeys_dict.values())[0]
+
+            def join_side():
+                cb()
+                raise KeyboardInterrupt
+
+            inst = MagicMock()
+            inst.__enter__ = MagicMock(return_value=inst)
+            inst.__exit__ = MagicMock(return_value=False)
+            inst.join.side_effect = join_side
+            return inst
+
+        pynput_mock, mock_keyboard = self._build_pynput_env(fake_ctor)
+        self._evict_pynput()
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {"pynput": pynput_mock, "pynput.keyboard": mock_keyboard},
+            ),
+            patch(
+                "voicecli.stt_client.send_toggle",
+                return_value={"status": "ok", "state": "idle", "text": "typed text"},
+            ),
+            patch("voicecli.stt_client.notify"),
+            patch("voicecli.stt_client.auto_paste") as mock_paste,
+        ):
+            # Act
+            hotkey_loop(hotkey="alt+space", paste=False)
+
+        # Assert
+        mock_paste.assert_not_called()
+
+    # -- text truncation ----------------------------------------------------
+
+    def test_text_truncation_51_chars_ends_with_ellipsis(self):
+        """Text of 51 chars → notify preview is first 50 chars + '...'."""
+        from voicecli.stt_client import hotkey_loop
+
+        long_text = "A" * 51  # 51 characters
+
+        def fake_ctor(hotkeys_dict):
+            cb = list(hotkeys_dict.values())[0]
+
+            def join_side():
+                cb()
+                raise KeyboardInterrupt
+
+            inst = MagicMock()
+            inst.__enter__ = MagicMock(return_value=inst)
+            inst.__exit__ = MagicMock(return_value=False)
+            inst.join.side_effect = join_side
+            return inst
+
+        pynput_mock, mock_keyboard = self._build_pynput_env(fake_ctor)
+        self._evict_pynput()
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {"pynput": pynput_mock, "pynput.keyboard": mock_keyboard},
+            ),
+            patch(
+                "voicecli.stt_client.send_toggle",
+                return_value={"status": "ok", "state": "idle", "text": long_text},
+            ),
+            patch("voicecli.stt_client.notify") as mock_notify,
+            patch("voicecli.stt_client.auto_paste"),
+        ):
+            # Act
+            hotkey_loop(hotkey="alt+space", paste=False)
+
+        # Assert
+        notify_body = mock_notify.call_args[0][0]
+        assert notify_body.endswith("...")
+        assert len(notify_body) == 53  # 50 chars + "..."
+
+    def test_text_exactly_50_chars_no_ellipsis(self):
+        """Text of exactly 50 chars → notify preview has no trailing '...'."""
+        from voicecli.stt_client import hotkey_loop
+
+        text_50 = "B" * 50
+
+        def fake_ctor(hotkeys_dict):
+            cb = list(hotkeys_dict.values())[0]
+
+            def join_side():
+                cb()
+                raise KeyboardInterrupt
+
+            inst = MagicMock()
+            inst.__enter__ = MagicMock(return_value=inst)
+            inst.__exit__ = MagicMock(return_value=False)
+            inst.join.side_effect = join_side
+            return inst
+
+        pynput_mock, mock_keyboard = self._build_pynput_env(fake_ctor)
+        self._evict_pynput()
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {"pynput": pynput_mock, "pynput.keyboard": mock_keyboard},
+            ),
+            patch(
+                "voicecli.stt_client.send_toggle",
+                return_value={"status": "ok", "state": "idle", "text": text_50},
+            ),
+            patch("voicecli.stt_client.notify") as mock_notify,
+            patch("voicecli.stt_client.auto_paste"),
+        ):
+            # Act
+            hotkey_loop(hotkey="alt+space", paste=False)
+
+        # Assert
+        notify_body = mock_notify.call_args[0][0]
+        assert not notify_body.endswith("...")

--- a/tests/test_stt_client.py
+++ b/tests/test_stt_client.py
@@ -1,0 +1,508 @@
+"""Tests for voicecli.stt_client and load_stt_config from voicecli.config."""
+
+from __future__ import annotations
+
+import json
+import socket
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# T9 — _send_request
+# ---------------------------------------------------------------------------
+
+
+class TestSendRequest:
+    """Tests for stt_client._send_request — wire-protocol helper."""
+
+    def test_success_returns_parsed_json(self):
+        """Happy path: daemon responds with valid JSON → dict is returned."""
+        from voicecli.stt_client import _send_request
+
+        response_payload = json.dumps({"status": "ok", "state": "idle"}) + "\n"
+
+        mock_sock = MagicMock()
+        mock_sock.recv.side_effect = [response_payload.encode(), b""]
+
+        with patch("socket.socket", return_value=mock_sock):
+            # Act
+            result = _send_request("status")
+
+        # Assert
+        assert result == {"status": "ok", "state": "idle"}
+        mock_sock.connect.assert_called_once()
+        mock_sock.sendall.assert_called_once()
+        mock_sock.close.assert_called_once()
+
+    def test_send_request_sends_correct_action(self):
+        """_send_request sends a JSON payload with the correct action field."""
+        from voicecli.stt_client import _send_request
+
+        response_payload = json.dumps({"status": "ok"}) + "\n"
+        mock_sock = MagicMock()
+        mock_sock.recv.side_effect = [response_payload.encode(), b""]
+
+        with patch("socket.socket", return_value=mock_sock):
+            _send_request("toggle")
+
+        # Assert the payload sent contains the correct action
+        sent_bytes = mock_sock.sendall.call_args[0][0]
+        sent_obj = json.loads(sent_bytes.decode().strip())
+        assert sent_obj == {"action": "toggle"}
+
+    def test_connection_refused_returns_error_dict(self):
+        """ConnectionRefusedError → error dict with daemon-not-running message."""
+        from voicecli.stt_client import _send_request
+
+        mock_sock = MagicMock()
+        mock_sock.connect.side_effect = ConnectionRefusedError
+
+        with patch("socket.socket", return_value=mock_sock):
+            # Act
+            result = _send_request("toggle")
+
+        # Assert
+        assert result == {"status": "error", "message": "STT daemon not running"}
+        mock_sock.close.assert_called_once()
+
+    def test_file_not_found_returns_error_dict(self):
+        """FileNotFoundError (socket absent) → error dict."""
+        from voicecli.stt_client import _send_request
+
+        mock_sock = MagicMock()
+        mock_sock.connect.side_effect = FileNotFoundError
+
+        with patch("socket.socket", return_value=mock_sock):
+            result = _send_request("status")
+
+        assert result == {"status": "error", "message": "STT daemon not running"}
+        mock_sock.close.assert_called_once()
+
+    def test_os_error_returns_error_dict(self):
+        """Generic OSError → error dict (covers other socket failures)."""
+        from voicecli.stt_client import _send_request
+
+        mock_sock = MagicMock()
+        mock_sock.connect.side_effect = OSError("connection failed")
+
+        with patch("socket.socket", return_value=mock_sock):
+            result = _send_request("ping")
+
+        assert result["status"] == "error"
+        assert result["message"] == "STT daemon not running"
+
+    def test_socket_closed_in_finally(self):
+        """Socket.close() is always called — even on error — via finally block."""
+        from voicecli.stt_client import _send_request
+
+        mock_sock = MagicMock()
+        mock_sock.connect.side_effect = ConnectionRefusedError
+
+        with patch("socket.socket", return_value=mock_sock):
+            _send_request("toggle")
+
+        mock_sock.close.assert_called_once()
+
+    def test_multipart_recv_assembled_correctly(self):
+        """Response arriving in multiple recv() chunks is reassembled before parsing."""
+        from voicecli.stt_client import _send_request
+
+        full_payload = json.dumps({"status": "ok", "text": "hello"}) + "\n"
+        # Split into two chunks
+        chunk1 = full_payload[:10].encode()
+        chunk2 = full_payload[10:].encode()
+
+        mock_sock = MagicMock()
+        mock_sock.recv.side_effect = [chunk1, chunk2, b""]
+
+        with patch("socket.socket", return_value=mock_sock):
+            result = _send_request("toggle")
+
+        assert result == {"status": "ok", "text": "hello"}
+
+
+# ---------------------------------------------------------------------------
+# T9 — send_toggle / send_status wrappers
+# ---------------------------------------------------------------------------
+
+
+class TestSendToggleAndStatus:
+    """send_toggle and send_status are thin wrappers around _send_request."""
+
+    def test_send_toggle_calls_send_request_with_toggle(self):
+        """send_toggle() invokes _send_request('toggle') and returns its result."""
+        from voicecli.stt_client import send_toggle
+
+        expected = {"status": "ok", "state": "recording"}
+
+        with patch("voicecli.stt_client._send_request", return_value=expected) as mock_req:
+            result = send_toggle()
+
+        mock_req.assert_called_once_with("toggle")
+        assert result == expected
+
+    def test_send_status_calls_send_request_with_status(self):
+        """send_status() invokes _send_request('status') and returns its result."""
+        from voicecli.stt_client import send_status
+
+        expected = {"status": "ok", "state": "idle"}
+
+        with patch("voicecli.stt_client._send_request", return_value=expected) as mock_req:
+            result = send_status()
+
+        mock_req.assert_called_once_with("status")
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# T9 — notify
+# ---------------------------------------------------------------------------
+
+
+class TestNotify:
+    """Tests for stt_client.notify — desktop notification via notify-send."""
+
+    def test_notify_skipped_when_notify_send_missing(self):
+        """notify() is a no-op when notify-send is not installed."""
+        from voicecli.stt_client import notify
+
+        with (
+            patch("shutil.which", return_value=None),
+            patch("subprocess.run") as mock_run,
+        ):
+            notify("Recording...")
+
+        mock_run.assert_not_called()
+
+    def test_notify_calls_subprocess_when_notify_send_present(self):
+        """notify() calls subprocess.run with notify-send and correct args."""
+        from voicecli.stt_client import _NOTIFY_REPLACE_ID, notify
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/notify-send"),
+            patch("subprocess.run") as mock_run,
+        ):
+            notify("Recording...", timeout=5000)
+
+        mock_run.assert_called_once_with(
+            [
+                "notify-send",
+                "-r",
+                _NOTIFY_REPLACE_ID,
+                "VoiceCLI",
+                "Recording...",
+                "-t",
+                "5000",
+            ],
+            check=False,
+            capture_output=True,
+        )
+
+    def test_notify_uses_replace_id_to_replace_previous_bubble(self):
+        """notify() includes the stable replace-ID so bubbles replace each other."""
+        from voicecli.stt_client import _NOTIFY_REPLACE_ID, notify
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/notify-send"),
+            patch("subprocess.run") as mock_run,
+        ):
+            notify("msg1")
+            notify("msg2")
+
+        # Both calls use the same replace-ID
+        assert mock_run.call_count == 2
+        for c in mock_run.call_args_list:
+            args_list = c[0][0]
+            assert "-r" in args_list
+            idx = args_list.index("-r")
+            assert args_list[idx + 1] == _NOTIFY_REPLACE_ID
+
+    def test_notify_default_timeout_is_3000(self):
+        """notify() uses 3000 ms as the default timeout."""
+        from voicecli.stt_client import notify
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/notify-send"),
+            patch("subprocess.run") as mock_run,
+        ):
+            notify("hello")
+
+        args_list = mock_run.call_args[0][0]
+        idx = args_list.index("-t")
+        assert args_list[idx + 1] == "3000"
+
+    def test_notify_survives_subprocess_exception(self):
+        """notify() swallows exceptions from subprocess.run silently."""
+        from voicecli.stt_client import notify
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/notify-send"),
+            patch("subprocess.run", side_effect=OSError("display not found")),
+        ):
+            # Should not raise
+            notify("message")
+
+
+# ---------------------------------------------------------------------------
+# T9 — auto_paste
+# ---------------------------------------------------------------------------
+
+
+class TestAutoPaste:
+    """Tests for stt_client.auto_paste — type text via xdotool."""
+
+    def test_auto_paste_skipped_when_xdotool_missing(self):
+        """auto_paste() is a no-op when xdotool is not installed."""
+        from voicecli.stt_client import auto_paste
+
+        with (
+            patch("shutil.which", return_value=None),
+            patch("subprocess.run") as mock_run,
+        ):
+            auto_paste("hello world")
+
+        mock_run.assert_not_called()
+
+    def test_auto_paste_calls_xdotool_with_correct_args(self):
+        """auto_paste() calls xdotool type with the provided text."""
+        from voicecli.stt_client import auto_paste
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/xdotool"),
+            patch("subprocess.run") as mock_run,
+            patch("time.sleep"),  # skip the 150ms wait
+        ):
+            auto_paste("hello world")
+
+        mock_run.assert_called_once_with(
+            ["xdotool", "type", "--clearmodifiers", "--", "hello world"],
+            check=False,
+            capture_output=True,
+        )
+
+    def test_auto_paste_sleeps_before_typing(self):
+        """auto_paste() calls time.sleep(0.15) before invoking xdotool."""
+        from voicecli.stt_client import auto_paste
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/xdotool"),
+            patch("subprocess.run"),
+            patch("time.sleep") as mock_sleep,
+        ):
+            auto_paste("text")
+
+        mock_sleep.assert_called_once_with(0.15)
+
+    def test_auto_paste_survives_subprocess_exception(self):
+        """auto_paste() swallows exceptions from xdotool silently."""
+        from voicecli.stt_client import auto_paste
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/xdotool"),
+            patch("subprocess.run", side_effect=OSError("no display")),
+            patch("time.sleep"),
+        ):
+            # Should not raise
+            auto_paste("text")
+
+
+# ---------------------------------------------------------------------------
+# T9 — hotkey_loop
+# ---------------------------------------------------------------------------
+
+
+def _make_pynput_mock(mock_global_hotkeys_cls):
+    """Build a (pynput_mock, keyboard_mock) pair where pynput.keyboard is wired correctly.
+
+    ``from pynput import keyboard`` resolves the ``keyboard`` attribute from the
+    ``pynput`` module object in sys.modules, *not* ``sys.modules['pynput.keyboard']``.
+    Both must be set consistently.
+    """
+    mock_keyboard = MagicMock()
+    mock_keyboard.GlobalHotKeys = mock_global_hotkeys_cls
+    pynput_mock = MagicMock()
+    pynput_mock.keyboard = mock_keyboard
+    return pynput_mock, mock_keyboard
+
+
+class TestHotkeyLoop:
+    """Tests for stt_client.hotkey_loop — pynput GlobalHotKeys wrapper."""
+
+    def _make_listener(self):
+        """Return a mock listener that exits via KeyboardInterrupt on join()."""
+        inst = MagicMock()
+        inst.__enter__ = MagicMock(return_value=inst)
+        inst.__exit__ = MagicMock(return_value=False)
+        inst.join.side_effect = KeyboardInterrupt
+        return inst
+
+    def test_hotkey_loop_constructs_global_hotkeys_with_correct_format(self):
+        """hotkey_loop converts 'alt+space' to '<alt>+<space>' for GlobalHotKeys."""
+        from voicecli.stt_client import hotkey_loop
+
+        mock_global_hotkeys_cls = MagicMock(return_value=self._make_listener())
+        pynput_mock, mock_keyboard = _make_pynput_mock(mock_global_hotkeys_cls)
+
+        with (
+            patch.dict("sys.modules", {"pynput": pynput_mock, "pynput.keyboard": mock_keyboard}),
+            patch("voicecli.stt_client.send_toggle", return_value={"status": "error"}),
+        ):
+            hotkey_loop(hotkey="alt+space")
+
+        # Assert GlobalHotKeys was constructed with the pynput-formatted hotkey
+        call_args = mock_global_hotkeys_cls.call_args
+        hotkeys_dict = call_args[0][0]
+        assert "<alt>+<space>" in hotkeys_dict
+
+    def test_hotkey_loop_multi_key_combo_formatted_correctly(self):
+        """hotkey_loop converts 'ctrl+shift+d' to '<ctrl>+<shift>+<d>'."""
+        from voicecli.stt_client import hotkey_loop
+
+        mock_global_hotkeys_cls = MagicMock(return_value=self._make_listener())
+        pynput_mock, mock_keyboard = _make_pynput_mock(mock_global_hotkeys_cls)
+
+        with (
+            patch.dict("sys.modules", {"pynput": pynput_mock, "pynput.keyboard": mock_keyboard}),
+            patch("voicecli.stt_client.send_toggle", return_value={"status": "error"}),
+        ):
+            hotkey_loop(hotkey="ctrl+shift+d")
+
+        hotkeys_dict = mock_global_hotkeys_cls.call_args[0][0]
+        assert "<ctrl>+<shift>+<d>" in hotkeys_dict
+
+    def test_hotkey_loop_callback_triggers_send_toggle(self):
+        """The callback registered with GlobalHotKeys calls send_toggle()."""
+        import sys
+
+        toggle_calls = []
+
+        def fake_send_toggle():
+            toggle_calls.append(1)
+            return {"status": "error", "message": "STT daemon not running"}
+
+        def fake_global_hotkeys(hotkeys_dict):
+            # Fire the hotkey callback once during join() to simulate a key press,
+            # then raise KeyboardInterrupt to let the loop exit cleanly.
+            on_hotkey_fn = list(hotkeys_dict.values())[0]
+
+            def join_side_effect():
+                on_hotkey_fn()
+                raise KeyboardInterrupt
+
+            inst = MagicMock()
+            inst.__enter__ = MagicMock(return_value=inst)
+            inst.__exit__ = MagicMock(return_value=False)
+            inst.join.side_effect = join_side_effect
+            return inst
+
+        mock_keyboard = MagicMock()
+        mock_keyboard.GlobalHotKeys = fake_global_hotkeys
+        pynput_mock = MagicMock()
+        pynput_mock.keyboard = mock_keyboard
+
+        # Evict any cached pynput modules so our patch.dict takes effect cleanly.
+        for key in list(sys.modules):
+            if key == "pynput" or key.startswith("pynput."):
+                del sys.modules[key]
+
+        with (
+            patch.dict("sys.modules", {"pynput": pynput_mock, "pynput.keyboard": mock_keyboard}),
+            patch("voicecli.stt_client.send_toggle", side_effect=fake_send_toggle),
+        ):
+            from voicecli.stt_client import hotkey_loop
+
+            hotkey_loop(hotkey="alt+space")
+
+        assert len(toggle_calls) == 1, "send_toggle() should have been called once"
+
+
+# ---------------------------------------------------------------------------
+# T10 — load_stt_config
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSttConfig:
+    """Tests for config.load_stt_config."""
+
+    def test_returns_default_hotkey_when_no_config_file(self):
+        """Returns {'hotkey': 'alt+space'} when no voicecli.toml is found."""
+        from voicecli.config import load_stt_config
+
+        with patch("voicecli.config._find_config", return_value=None):
+            result = load_stt_config()
+
+        assert result == {"hotkey": "alt+space"}
+
+    def test_reads_stt_table_from_toml(self, tmp_path):
+        """Reads [stt] table values from a real toml file via tmp_path."""
+        from voicecli.config import load_stt_config
+
+        toml_file = tmp_path / "voicecli.toml"
+        toml_file.write_text('[stt]\nhotkey = "ctrl+shift+d"\n')
+
+        result = load_stt_config(config=toml_file)
+
+        assert result["hotkey"] == "ctrl+shift+d"
+
+    def test_custom_hotkey_parsed_correctly(self, tmp_path):
+        """A non-default hotkey value from toml is parsed and returned."""
+        from voicecli.config import load_stt_config
+
+        toml_file = tmp_path / "voicecli.toml"
+        toml_file.write_text('[stt]\nhotkey = "alt+h"\n')
+
+        result = load_stt_config(config=toml_file)
+
+        assert result["hotkey"] == "alt+h"
+
+    def test_missing_stt_table_falls_back_to_defaults(self, tmp_path):
+        """When [stt] table is absent, returns default {'hotkey': 'alt+space'}."""
+        from voicecli.config import load_stt_config
+
+        toml_file = tmp_path / "voicecli.toml"
+        toml_file.write_text('[defaults]\nlanguage = "French"\n')
+
+        result = load_stt_config(config=toml_file)
+
+        assert result == {"hotkey": "alt+space"}
+
+    def test_model_key_in_stt_table_is_parsed(self, tmp_path):
+        """The 'model' key from [stt] is also parsed if present."""
+        from voicecli.config import load_stt_config
+
+        toml_file = tmp_path / "voicecli.toml"
+        toml_file.write_text('[stt]\nhotkey = "alt+space"\nmodel = "large-v3"\n')
+
+        result = load_stt_config(config=toml_file)
+
+        assert result["hotkey"] == "alt+space"
+        assert result["model"] == "large-v3"
+
+    def test_explicit_config_path_skips_walk_up(self, tmp_path):
+        """Passing config= explicitly uses that file, bypassing _find_config."""
+        from voicecli.config import load_stt_config
+
+        toml_file = tmp_path / "custom.toml"
+        toml_file.write_text('[stt]\nhotkey = "ctrl+space"\n')
+
+        with patch("voicecli.config._find_config") as mock_find:
+            result = load_stt_config(config=toml_file)
+
+        # _find_config should NOT be called when config= is provided
+        mock_find.assert_not_called()
+        assert result["hotkey"] == "ctrl+space"
+
+    def test_stt_table_with_only_model_preserves_default_hotkey(self, tmp_path):
+        """If [stt] only has model (no hotkey), the default hotkey is preserved."""
+        from voicecli.config import load_stt_config
+
+        toml_file = tmp_path / "voicecli.toml"
+        toml_file.write_text('[stt]\nmodel = "large-v3-turbo"\n')
+
+        result = load_stt_config(config=toml_file)
+
+        assert result["hotkey"] == "alt+space"
+        assert result["model"] == "large-v3-turbo"

--- a/tests/test_stt_client.py
+++ b/tests/test_stt_client.py
@@ -141,7 +141,7 @@ class TestSendToggleAndStatus:
         with patch("voicecli.stt_client._send_request", return_value=expected) as mock_req:
             result = send_toggle()
 
-        mock_req.assert_called_once_with("toggle")
+        mock_req.assert_called_once_with("toggle", timeout=60)
         assert result == expected
 
     def test_send_status_calls_send_request_with_status(self):
@@ -371,7 +371,7 @@ class TestHotkeyLoop:
             hotkey_loop(hotkey="ctrl+shift+d")
 
         hotkeys_dict = mock_global_hotkeys_cls.call_args[0][0]
-        assert "<ctrl>+<shift>+<d>" in hotkeys_dict
+        assert "<ctrl>+<shift>+d" in hotkeys_dict
 
     def test_hotkey_loop_callback_triggers_send_toggle(self):
         """The callback registered with GlobalHotKeys calls send_toggle()."""

--- a/uv.lock
+++ b/uv.lock
@@ -418,6 +418,12 @@ wheels = [
 ]
 
 [[package]]
+name = "evdev"
+version = "1.9.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/f5/397b61091120a9ca5001041dd7bf76c385b3bfd67a0e5bcb74b852bd22a4/evdev-1.9.3.tar.gz", hash = "sha256:2c140e01ac8437758fa23fe5c871397412461f42d421aa20241dc8fe8cfccbc9", size = 32723, upload-time = "2026-02-05T21:54:24.987Z" }
+
+[[package]]
 name = "fastapi"
 version = "0.134.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1577,6 +1583,90 @@ wheels = [
 ]
 
 [[package]]
+name = "pynput"
+version = "1.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "evdev", marker = "'linux' in sys_platform" },
+    { name = "pyobjc-framework-applicationservices", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
+    { name = "python-xlib", marker = "'linux' in sys_platform" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/c3/dccf44c68225046df5324db0cc7d563a560635355b3e5f1d249468268a6f/pynput-1.8.1.tar.gz", hash = "sha256:70d7c8373ee98911004a7c938742242840a5628c004573d84ba849d4601df81e", size = 82289, upload-time = "2025-03-17T17:12:01.481Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/4f/ac3fa906ae8a375a536b12794128c5efacade9eaa917a35dfd27ce0c7400/pynput-1.8.1-py2.py3-none-any.whl", hash = "sha256:42dfcf27404459ca16ca889c8fb8ffe42a9fe54f722fd1a3e130728e59e768d2", size = 91693, upload-time = "2025-03-17T17:12:00.094Z" },
+]
+
+[[package]]
+name = "pyobjc-core"
+version = "12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/b6/d5612eb40be4fd5ef88c259339e6313f46ba67577a95d86c3470b951fce0/pyobjc_core-12.1.tar.gz", hash = "sha256:2bb3903f5387f72422145e1466b3ac3f7f0ef2e9960afa9bcd8961c5cbf8bd21", size = 1000532, upload-time = "2025-11-14T10:08:28.292Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/df/d2b290708e9da86d6e7a9a2a2022b91915cf2e712a5a82e306cb6ee99792/pyobjc_core-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c918ebca280925e7fcb14c5c43ce12dcb9574a33cccb889be7c8c17f3bcce8b6", size = 671263, upload-time = "2025-11-14T09:31:35.231Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5a/6b15e499de73050f4a2c88fff664ae154307d25dc04da8fb38998a428358/pyobjc_core-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:818bcc6723561f207e5b5453efe9703f34bc8781d11ce9b8be286bb415eb4962", size = 678335, upload-time = "2025-11-14T09:32:20.107Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-applicationservices"
+version = "12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-coretext", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/6a/d4e613c8e926a5744fc47a9e9fea08384a510dc4f27d844f7ad7a2d793bd/pyobjc_framework_applicationservices-12.1.tar.gz", hash = "sha256:c06abb74f119bc27aeb41bf1aef8102c0ae1288aec1ac8665ea186a067a8945b", size = 103247, upload-time = "2025-11-14T10:08:52.18Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/86/d07eff705ff909a0ffa96d14fc14026e9fc9dd716233648c53dfd5056b8e/pyobjc_framework_applicationservices-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bdddd492eeac6d14ff2f5bd342aba29e30dffa72a2d358c08444da22129890e2", size = 32784, upload-time = "2025-11-14T09:36:08.755Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a7/55fa88def5c02732c4b747606ff1cbce6e1f890734bbd00f5596b21eaa02/pyobjc_framework_applicationservices-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c8f6e2fb3b3e9214ab4864ef04eee18f592b46a986c86ea0113448b310520532", size = 32835, upload-time = "2025-11-14T09:36:11.855Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-cocoa"
+version = "12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/07/5760735c0fffc65107e648eaf7e0991f46da442ac4493501be5380e6d9d4/pyobjc_framework_cocoa-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:f52228bcf38da64b77328787967d464e28b981492b33a7675585141e1b0a01e6", size = 383812, upload-time = "2025-11-14T09:40:53.169Z" },
+    { url = "https://files.pythonhosted.org/packages/95/bf/ee4f27ec3920d5c6fc63c63e797c5b2cc4e20fe439217085d01ea5b63856/pyobjc_framework_cocoa-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:547c182837214b7ec4796dac5aee3aa25abc665757b75d7f44f83c994bcb0858", size = 384590, upload-time = "2025-11-14T09:41:17.336Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-coretext"
+version = "12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/da/682c9c92a39f713bd3c56e7375fa8f1b10ad558ecb075258ab6f1cdd4a6d/pyobjc_framework_coretext-12.1.tar.gz", hash = "sha256:e0adb717738fae395dc645c9e8a10bb5f6a4277e73cba8fa2a57f3b518e71da5", size = 90124, upload-time = "2025-11-14T10:14:38.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/81/7b8efc41e743adfa2d74b92dec263c91bcebfb188d2a8f5eea1886a195ff/pyobjc_framework_coretext-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4f6742ba5b0bb7629c345e99eff928fbfd9e9d3d667421ac1a2a43bdb7ba9833", size = 29990, upload-time = "2025-11-14T09:47:01.206Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/0f/ddf45bf0e3ba4fbdc7772de4728fd97ffc34a0b5a15e1ab1115b202fe4ae/pyobjc_framework_coretext-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d246fa654bdbf43bae3969887d58f0b336c29b795ad55a54eb76397d0e62b93c", size = 30108, upload-time = "2025-11-14T09:47:04.228Z" },
+]
+
+[[package]]
+name = "pyobjc-framework-quartz"
+version = "12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/18/cc59f3d4355c9456fc945eae7fe8797003c4da99212dd531ad1b0de8a0c6/pyobjc_framework_quartz-12.1.tar.gz", hash = "sha256:27f782f3513ac88ec9b6c82d9767eef95a5cf4175ce88a1e5a65875fee799608", size = 3159099, upload-time = "2025-11-14T10:21:24.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ef/dcd22b743e38b3c430fce4788176c2c5afa8bfb01085b8143b02d1e75201/pyobjc_framework_quartz-12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:19f99ac49a0b15dd892e155644fe80242d741411a9ed9c119b18b7466048625a", size = 217795, upload-time = "2025-11-14T09:59:46.922Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9b/780f057e5962f690f23fdff1083a4cfda5a96d5b4d3bb49505cac4f624f2/pyobjc_framework_quartz-12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7730cdce46c7e985535b5a42c31381af4aa6556e5642dc55b5e6597595e57a16", size = 218798, upload-time = "2025-11-14T10:00:01.236Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1611,6 +1701,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+]
+
+[[package]]
+name = "python-xlib"
+version = "0.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/f5/8c0653e5bb54e0cbdfe27bf32d41f27bc4e12faa8742778c17f2a71be2c0/python-xlib-0.33.tar.gz", hash = "sha256:55af7906a2c75ce6cb280a584776080602444f75815a7aff4d287bb2d7018b32", size = 269068, upload-time = "2022-12-25T18:53:00.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/b8/ff33610932e0ee81ae7f1269c890f697d56ff74b9f5b2ee5d9b7fa2c5355/python_xlib-0.33-py2.py3-none-any.whl", hash = "sha256:c3534038d42e0df2f1392a1b30a15a4ff5fdc2b86cfa94f072bf11b10a164398", size = 182185, upload-time = "2022-12-25T18:52:58.662Z" },
 ]
 
 [[package]]
@@ -2279,6 +2381,11 @@ dependencies = [
     { name = "typer" },
 ]
 
+[package.optional-dependencies]
+hotkey = [
+    { name = "pynput" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "pip-licenses" },
@@ -2293,12 +2400,14 @@ requires-dist = [
     { name = "faster-qwen3-tts" },
     { name = "faster-whisper", specifier = ">=1.2" },
     { name = "lameenc", specifier = ">=1.7" },
+    { name = "pynput", marker = "extra == 'hotkey'", specifier = ">=1.7" },
     { name = "qwen-tts" },
     { name = "soundfile" },
     { name = "torch", specifier = ">=2.7" },
     { name = "torchaudio", specifier = ">=2.7" },
     { name = "typer", extras = ["all"], specifier = ">=0.12" },
 ]
+provides-extras = ["hotkey"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- Add `voicecli dictate` command group — thin socket client that toggles STT recording via the daemon (#6), with desktop notifications (`notify-send`), optional auto-paste (`xdotool`), and a pynput global hotkey listener
- New `stt_client.py` module with wire protocol client, `notify()`, `auto_paste()`, and `hotkey_loop()`
- Extend `config.py` with `load_stt_config()` for `[stt]` table support in `voicecli.toml`
- Add `docs/dictation-setup.md` covering Windows shortcut, KDE/GNOME, and troubleshooting

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #7: feat: dictate toggle command + global hotkey listener | Open |
| Frame | [7-dictate-toggle-hotkey-frame.mdx](artifacts/frames/7-dictate-toggle-hotkey-frame.mdx) | Approved |
| Spec | [7-dictate-toggle-hotkey-spec.mdx](artifacts/specs/7-dictate-toggle-hotkey-spec.mdx) | Approved |
| Plan | [7-dictate-toggle-hotkey-plan.mdx](artifacts/plans/7-dictate-toggle-hotkey-plan.mdx) | Approved |
| Implementation | 1 commit on `feat/7-dictate-toggle-hotkey` | Complete |
| Verification | Lint ✅ Tests ✅ (28 new) | Passed |

## Test Plan
- [ ] Start STT daemon (`voicecli stt-serve`), then `voicecli dictate` toggles recording
- [ ] `voicecli dictate status` prints `idle`/`recording`/`transcribing`/`queued`
- [ ] `voicecli dictate` with daemon stopped prints error and exits 1
- [ ] `notify-send` shows notification on toggle (recording start, transcription done)
- [ ] `voicecli dictate --paste` types text via xdotool after transcription
- [ ] `voicecli dictate --listen` captures global hotkey and toggles (X11/WSLg only)
- [ ] Hotkey configurable via `voicecli.toml` `[stt] hotkey = "ctrl+space"`
- [ ] Graceful degradation when `notify-send` or `xdotool` are not installed

Closes #7

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`