### PR TITLE
feat(api): add input validation for TTS parameters

### DIFF
--- a/src/voicecli/api.py
+++ b/src/voicecli/api.py
@@ -38,6 +38,8 @@ def _check_float(name: str, value, lo: float, hi: float) -> None:
     """Validate a float parameter: type, finite, within range."""
     if value is None:
         return
+    if isinstance(value, bool):
+        raise TypeError(f"{name} must be a number, got bool")
     if not isinstance(value, (int, float)):
         raise TypeError(f"{name} must be a number, got {type(value).__name__}")
     import math
@@ -52,6 +54,8 @@ def _check_int(name: str, value, lo: int, hi: int) -> None:
     """Validate an integer parameter: type, within range."""
     if value is None:
         return
+    if isinstance(value, bool):
+        raise TypeError(f"{name} must be an integer, got bool")
     if not isinstance(value, int):
         raise TypeError(f"{name} must be an integer, got {type(value).__name__}")
     if not (lo <= value <= hi):

--- a/src/voicecli/api.py
+++ b/src/voicecli/api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import logging
+import math
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -42,8 +43,6 @@ def _check_float(name: str, value, lo: float, hi: float) -> None:
         raise TypeError(f"{name} must be a number, got bool")
     if not isinstance(value, (int, float)):
         raise TypeError(f"{name} must be a number, got {type(value).__name__}")
-    import math
-
     if math.isnan(value) or math.isinf(value):
         raise ValueError(f"{name} must be finite, got {value}")
     if not (lo <= value <= hi):
@@ -840,6 +839,7 @@ def clone(
         chunk_size=chunk_size,
         extra_kwargs=kwargs,
     )
+    _check_str("ref_text", ref_text)
 
     from voicecli.engine import QWEN_ENGINES, get_engine
     from voicecli.utils import build_output_prefix, default_output_path

--- a/src/voicecli/api.py
+++ b/src/voicecli/api.py
@@ -141,8 +141,16 @@ def _resolve_config(
     r_chunk_size = chunk_size if chunk_size is not None else cfg.get("chunk_size", 500)
 
     # Numeric defaults from config
-    for field in ("exaggeration", "cfg_weight", "flow_steps", "cfg_alpha",
-                   "temperature", "top_p", "min_p", "repetition_penalty"):
+    for field in (
+        "exaggeration",
+        "cfg_weight",
+        "flow_steps",
+        "cfg_alpha",
+        "temperature",
+        "top_p",
+        "min_p",
+        "repetition_penalty",
+    ):
         if field not in kw and field in cfg:
             kw[field] = cfg[field]
 

--- a/src/voicecli/api.py
+++ b/src/voicecli/api.py
@@ -16,6 +16,81 @@ class DaemonUnavailableError(RuntimeError):
     """Raised when the voicecli daemon is not reachable for a QWEN engine."""
 
 
+# ── Input validation ────────────────────────────────────────────────────────
+
+_MAX_STRING_LEN = 256
+_MAX_TEXT_LEN = 100_000
+
+
+def _check_str(name: str, value, *, max_len: int = _MAX_STRING_LEN) -> None:
+    """Validate a string parameter: type, length, no embedded newlines."""
+    if value is None:
+        return
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a string, got {type(value).__name__}")
+    if len(value) > max_len:
+        raise ValueError(f"{name} exceeds maximum length ({max_len} chars)")
+    if "\n" in value or "\r" in value:
+        raise ValueError(f"{name} must not contain newline characters")
+
+
+def _check_float(name: str, value, lo: float, hi: float) -> None:
+    """Validate a float parameter: type, finite, within range."""
+    if value is None:
+        return
+    if not isinstance(value, (int, float)):
+        raise TypeError(f"{name} must be a number, got {type(value).__name__}")
+    import math
+
+    if math.isnan(value) or math.isinf(value):
+        raise ValueError(f"{name} must be finite, got {value}")
+    if not (lo <= value <= hi):
+        raise ValueError(f"{name} must be between {lo} and {hi}, got {value}")
+
+
+def _check_int(name: str, value, lo: int, hi: int) -> None:
+    """Validate an integer parameter: type, within range."""
+    if value is None:
+        return
+    if not isinstance(value, int):
+        raise TypeError(f"{name} must be an integer, got {type(value).__name__}")
+    if not (lo <= value <= hi):
+        raise ValueError(f"{name} must be between {lo} and {hi}, got {value}")
+
+
+def _validate_tts_params(
+    *,
+    text: str | Path | None = None,
+    engine: str | None = None,
+    voice: str | None = None,
+    language: str | None = None,
+    segment_gap: int | None = None,
+    crossfade: int | None = None,
+    chunk_size: int | None = None,
+    extra_kwargs: dict | None = None,
+) -> None:
+    """Validate TTS parameters at the API boundary.
+
+    Raises TypeError or ValueError for invalid input.
+    """
+    # Text length (only for raw strings, not file paths)
+    if isinstance(text, str) and Path(text).suffix not in (".md", ".txt"):
+        _check_str("text", text, max_len=_MAX_TEXT_LEN)
+
+    _check_str("engine", engine, max_len=64)
+    _check_str("voice", voice)
+    _check_str("language", language)
+    _check_int("segment_gap", segment_gap, 0, 30_000)
+    _check_int("crossfade", crossfade, 0, 10_000)
+    _check_int("chunk_size", chunk_size, 1, 10_000)
+
+    if extra_kwargs:
+        for field in ("instruct", "accent", "personality", "speed", "emotion"):
+            _check_str(field, extra_kwargs.get(field))
+        _check_float("exaggeration", extra_kwargs.get("exaggeration"), 0.0, 2.0)
+        _check_float("cfg_weight", extra_kwargs.get("cfg_weight"), 0.0, 1.0)
+
+
 @dataclass
 class TTSResult:
     """Result of a TTS generation or cloning operation."""
@@ -587,10 +662,22 @@ def generate(
         TTSResult with wav_path and optional mp3_path.
 
     Raises:
-        ValueError: Invalid engine name.
+        TypeError: Wrong parameter type.
+        ValueError: Invalid engine name or parameter out of range.
         FileNotFoundError: Script file not found.
         RuntimeError: CUDA/GPU error.
     """
+    _validate_tts_params(
+        text=text,
+        engine=engine,
+        voice=voice,
+        language=language,
+        segment_gap=segment_gap,
+        crossfade=crossfade,
+        chunk_size=chunk_size,
+        extra_kwargs=kwargs,
+    )
+
     from voicecli.engine import QWEN_ENGINES, get_engine
     from voicecli.utils import build_output_prefix, default_output_path
 
@@ -734,10 +821,22 @@ def clone(
         TTSResult with wav_path and optional mp3_path.
 
     Raises:
-        ValueError: Invalid engine name or no active sample set.
+        TypeError: Wrong parameter type.
+        ValueError: Invalid engine name, no active sample, or parameter out of range.
         FileNotFoundError: Reference audio or script file not found.
         RuntimeError: CUDA/GPU error.
     """
+    _validate_tts_params(
+        text=text,
+        engine=engine,
+        voice=None,
+        language=language,
+        segment_gap=segment_gap,
+        crossfade=crossfade,
+        chunk_size=chunk_size,
+        extra_kwargs=kwargs,
+    )
+
     from voicecli.engine import QWEN_ENGINES, get_engine
     from voicecli.utils import build_output_prefix, default_output_path
 

--- a/src/voicecli/cli.py
+++ b/src/voicecli/cli.py
@@ -552,7 +552,9 @@ def generate(
     ] = None,
     cfg_alpha: Annotated[
         Optional[float],
-        typer.Option("--cfg-alpha", help="Voxtral classifier-free guidance (1.0=faster, 1.2=quality)"),
+        typer.Option(
+            "--cfg-alpha", help="Voxtral classifier-free guidance (1.0=faster, 1.2=quality)"
+        ),
     ] = None,
     temperature: Annotated[
         Optional[float],
@@ -568,7 +570,9 @@ def generate(
     ] = None,
     repetition_penalty: Annotated[
         Optional[float],
-        typer.Option("--repetition-penalty", help="Repetition penalty (Qwen/Chatterbox, default varies)"),
+        typer.Option(
+            "--repetition-penalty", help="Repetition penalty (Qwen/Chatterbox, default varies)"
+        ),
     ] = None,
     plain: Annotated[
         bool,
@@ -672,7 +676,9 @@ def clone(
     ] = None,
     cfg_alpha: Annotated[
         Optional[float],
-        typer.Option("--cfg-alpha", help="Voxtral classifier-free guidance (1.0=faster, 1.2=quality)"),
+        typer.Option(
+            "--cfg-alpha", help="Voxtral classifier-free guidance (1.0=faster, 1.2=quality)"
+        ),
     ] = None,
     temperature: Annotated[
         Optional[float],
@@ -688,7 +694,9 @@ def clone(
     ] = None,
     repetition_penalty: Annotated[
         Optional[float],
-        typer.Option("--repetition-penalty", help="Repetition penalty (Qwen/Chatterbox, default varies)"),
+        typer.Option(
+            "--repetition-penalty", help="Repetition penalty (Qwen/Chatterbox, default varies)"
+        ),
     ] = None,
     plain: Annotated[
         bool,

--- a/src/voicecli/daemon.py
+++ b/src/voicecli/daemon.py
@@ -184,6 +184,69 @@ def _sanitize_request(req: dict) -> str | None:
                 return f"{field} must be between {lo} and {hi}, got {val}"
             req[field] = val
 
+    # Integer range validation
+    for field, lo, hi in [("segment_gap", 0, 30_000), ("crossfade", 0, 10_000)]:
+        val = req.get(field)
+        if val is not None:
+            try:
+                val = int(val)
+            except (TypeError, ValueError):
+                return f"{field} must be an integer"
+            if not (lo <= val <= hi):
+                return f"{field} must be between {lo} and {hi}, got {val}"
+            req[field] = val
+
+    # Sanitize per-segment fields
+    segments = req.get("segments")
+    if isinstance(segments, list):
+        for i, seg in enumerate(segments):
+            if not isinstance(seg, dict):
+                return f"segments[{i}] must be a dict"
+            for sf, max_len in [
+                ("instruct", _STR_MAX),
+                ("language", _STR_MAX),
+                ("voice", _STR_MAX),
+                ("accent", _STR_MAX),
+                ("personality", _STR_MAX),
+                ("speed", _STR_MAX),
+                ("emotion", _STR_MAX),
+            ]:
+                sv = seg.get(sf)
+                if sv is not None and isinstance(sv, str):
+                    if len(sv) > max_len:
+                        return f"segments[{i}].{sf} exceeds maximum length ({max_len} chars)"
+                    seg[sf] = sv.replace("\n", "").replace("\r", "")
+            # Per-segment text
+            st = seg.get("text")
+            if isinstance(st, str):
+                if len(st) > _TEXT_MAX:
+                    return f"segments[{i}].text exceeds maximum length ({_TEXT_MAX} chars)"
+                seg["text"] = st.replace("\n", " ").replace("\r", "")
+            # Per-segment float fields
+            for sf, lo, hi in [("exaggeration", 0.0, 2.0), ("cfg_weight", 0.0, 1.0)]:
+                sv = seg.get(sf)
+                if sv is not None:
+                    try:
+                        sv = float(sv)
+                    except (TypeError, ValueError):
+                        return f"segments[{i}].{sf} must be a number"
+                    if math.isnan(sv) or math.isinf(sv):
+                        return f"segments[{i}].{sf} must be finite"
+                    if not (lo <= sv <= hi):
+                        return f"segments[{i}].{sf} must be between {lo} and {hi}, got {sv}"
+                    seg[sf] = sv
+            # Per-segment int fields
+            for sf, lo, hi in [("segment_gap", 0, 30_000), ("crossfade", 0, 10_000)]:
+                sv = seg.get(sf)
+                if sv is not None:
+                    try:
+                        sv = int(sv)
+                    except (TypeError, ValueError):
+                        return f"segments[{i}].{sf} must be an integer"
+                    if not (lo <= sv <= hi):
+                        return f"segments[{i}].{sf} must be between {lo} and {hi}, got {sv}"
+                    seg[sf] = sv
+
     return None
 
 

--- a/src/voicecli/daemon.py
+++ b/src/voicecli/daemon.py
@@ -156,6 +156,7 @@ def _sanitize_request(req: dict) -> str | None:
         ("voice", _STR_MAX),
         ("language", _STR_MAX),
         ("instruct", _STR_MAX),
+        ("ref_text", _STR_MAX),
     ]:
         val = req.get(field)
         if val is not None and isinstance(val, str):
@@ -332,8 +333,15 @@ def _handle_job(conn: socket.socket, req: dict, engines: dict, fast: bool = Fals
             if not ref_audio:
                 _send_json(conn, {"status": "error", "message": "clone requires ref_audio"})
                 return
+            ref_audio_path = Path(ref_audio).resolve()
+            if not str(ref_audio_path).startswith(str(_OUTPUT_BASE)):
+                _send_json(
+                    conn,
+                    {"status": "error", "message": "ref_audio must be within home directory"},
+                )
+                return
             ref_text = req.get("ref_text")
-            result = eng.clone(text, Path(ref_audio), output_path, ref_text=ref_text, **kwargs)
+            result = eng.clone(text, ref_audio_path, output_path, ref_text=ref_text, **kwargs)
         else:
             _send_json(conn, {"status": "error", "message": f"Unknown action: {action!r}"})
             return

--- a/src/voicecli/daemon.py
+++ b/src/voicecli/daemon.py
@@ -139,9 +139,63 @@ def _has_vram(eng_name: str) -> bool:
         return False
 
 
+def _sanitize_request(req: dict) -> str | None:
+    """Validate and sanitize daemon request fields.
+
+    Returns an error message string if validation fails, None if OK.
+    Mutates req in-place to strip newlines from string fields.
+    """
+    import math
+
+    _STR_MAX = 256
+    _TEXT_MAX = 100_000
+
+    # Sanitize string fields: cap length, strip newlines (protocol safety)
+    for field, max_len in [
+        ("engine", 64),
+        ("voice", _STR_MAX),
+        ("language", _STR_MAX),
+        ("instruct", _STR_MAX),
+    ]:
+        val = req.get(field)
+        if val is not None and isinstance(val, str):
+            if len(val) > max_len:
+                return f"{field} exceeds maximum length ({max_len} chars)"
+            req[field] = val.replace("\n", "").replace("\r", "")
+
+    # Text length
+    text = req.get("text")
+    if isinstance(text, str) and len(text) > _TEXT_MAX:
+        return f"text exceeds maximum length ({_TEXT_MAX} chars)"
+    if isinstance(text, str):
+        req["text"] = text.replace("\n", " ").replace("\r", "")
+
+    # Float range validation
+    for field, lo, hi in [("exaggeration", 0.0, 2.0), ("cfg_weight", 0.0, 1.0)]:
+        val = req.get(field)
+        if val is not None:
+            try:
+                val = float(val)
+            except (TypeError, ValueError):
+                return f"{field} must be a number"
+            if math.isnan(val) or math.isinf(val):
+                return f"{field} must be finite"
+            if not (lo <= val <= hi):
+                return f"{field} must be between {lo} and {hi}, got {val}"
+            req[field] = val
+
+    return None
+
+
 def _handle_job(conn: socket.socket, req: dict, engines: dict, fast: bool = False) -> None:
     """Process one synthesis job. Called exclusively from the worker thread."""
     try:
+        # Validate and sanitize request fields
+        error = _sanitize_request(req)
+        if error:
+            _send_json(conn, {"status": "error", "message": error})
+            return
+
         action = req.get("action")
 
         eng_name = req.get("engine")

--- a/src/voicecli/engines/chatterbox_turbo.py
+++ b/src/voicecli/engines/chatterbox_turbo.py
@@ -95,8 +95,11 @@ class ChatterboxTurboEngine(TTSEngine):
 
         if segments and len(segments) > 1:
             base_kwargs = dict(
-                exaggeration=exaggeration, cfg_weight=cfg_weight,
-                temperature=temperature, top_p=top_p, min_p=min_p,
+                exaggeration=exaggeration,
+                cfg_weight=cfg_weight,
+                temperature=temperature,
+                top_p=top_p,
+                min_p=min_p,
                 repetition_penalty=repetition_penalty,
             )
             audio = self._generate_segmented(
@@ -109,8 +112,11 @@ class ChatterboxTurboEngine(TTSEngine):
             return output_path
 
         gen_kwargs = dict(
-            exaggeration=exaggeration, cfg_weight=cfg_weight,
-            temperature=temperature, top_p=top_p, min_p=min_p,
+            exaggeration=exaggeration,
+            cfg_weight=cfg_weight,
+            temperature=temperature,
+            top_p=top_p,
+            min_p=min_p,
             repetition_penalty=repetition_penalty,
         )
         audio = self._generate_chunked(text, **gen_kwargs)
@@ -135,8 +141,11 @@ class ChatterboxTurboEngine(TTSEngine):
         if segments and len(segments) > 1:
             base_kwargs = dict(
                 audio_prompt_path=str(ref_audio),
-                exaggeration=exaggeration, cfg_weight=cfg_weight,
-                temperature=temperature, top_p=top_p, min_p=min_p,
+                exaggeration=exaggeration,
+                cfg_weight=cfg_weight,
+                temperature=temperature,
+                top_p=top_p,
+                min_p=min_p,
                 repetition_penalty=repetition_penalty,
             )
             audio = self._generate_segmented(
@@ -150,8 +159,11 @@ class ChatterboxTurboEngine(TTSEngine):
 
         gen_kwargs = dict(
             audio_prompt_path=str(ref_audio),
-            exaggeration=exaggeration, cfg_weight=cfg_weight,
-            temperature=temperature, top_p=top_p, min_p=min_p,
+            exaggeration=exaggeration,
+            cfg_weight=cfg_weight,
+            temperature=temperature,
+            top_p=top_p,
+            min_p=min_p,
             repetition_penalty=repetition_penalty,
         )
         audio = self._generate_chunked(text, **gen_kwargs)

--- a/src/voicecli/engines/voxtral.py
+++ b/src/voicecli/engines/voxtral.py
@@ -67,7 +67,6 @@ class VoxtralEngine(TTSEngine):
             return self._model
 
         with cuda_guard("voxtral"):
-            import torch
             from voxtral_tts import load_model_int4, TekkenTokenizer, enable_static_cache
 
             warn_if_first_download(VOXTRAL_MODEL)

--- a/src/voicecli/engines/voxtral.py
+++ b/src/voicecli/engines/voxtral.py
@@ -80,7 +80,12 @@ class VoxtralEngine(TTSEngine):
         return self._model
 
     def _generate_one(
-        self, text: str, voice: str, *, flow_steps: int = 8, cfg_alpha: float = 1.2,
+        self,
+        text: str,
+        voice: str,
+        *,
+        flow_steps: int = 8,
+        cfg_alpha: float = 1.2,
     ) -> np.ndarray:
         """Generate audio for a single text chunk."""
         import torch
@@ -117,7 +122,9 @@ class VoxtralEngine(TTSEngine):
         all_wavs: list[np.ndarray] = []
         for i, seg in enumerate(segments):
             print(f"  [{i + 1}/{len(segments)}] {seg.text[:60]}...")
-            seg_voice = _resolve_voice(seg.voice, seg.language) if seg.voice or seg.language else voice
+            seg_voice = (
+                _resolve_voice(seg.voice, seg.language) if seg.voice or seg.language else voice
+            )
             seg_flow = seg.flow_steps if seg.flow_steps is not None else flow_steps
             seg_cfg = seg.cfg_alpha if seg.cfg_alpha is not None else cfg_alpha
             audio = self._generate_one(seg.text, seg_voice, flow_steps=seg_flow, cfg_alpha=seg_cfg)
@@ -145,14 +152,17 @@ class VoxtralEngine(TTSEngine):
 
         if segments and len(segments) > 1:
             audio = self._generate_segmented(
-                segments, resolved_voice,
+                segments,
+                resolved_voice,
                 default_gap=default_gap,
                 default_crossfade=default_crossfade,
                 flow_steps=flow_steps,
                 cfg_alpha=cfg_alpha,
             )
         else:
-            audio = self._generate_one(text, resolved_voice, flow_steps=flow_steps, cfg_alpha=cfg_alpha)
+            audio = self._generate_one(
+                text, resolved_voice, flow_steps=flow_steps, cfg_alpha=cfg_alpha
+            )
 
         sf.write(str(output_path), audio, _SAMPLE_RATE)
         return output_path

--- a/src/voicecli/markdown.py
+++ b/src/voicecli/markdown.py
@@ -128,7 +128,15 @@ _COMMENT_RE = re.compile(r"<!--(.+?)-->", re.DOTALL)
 
 # Fields that can appear as <!-- key: value --> inline directives
 _STR_DIRECTIVES = {"instruct", "accent", "personality", "speed", "emotion", "language", "voice"}
-_FLOAT_DIRECTIVES = {"exaggeration", "cfg_weight", "cfg_alpha", "temperature", "top_p", "min_p", "repetition_penalty"}
+_FLOAT_DIRECTIVES = {
+    "exaggeration",
+    "cfg_weight",
+    "cfg_alpha",
+    "temperature",
+    "top_p",
+    "min_p",
+    "repetition_penalty",
+}
 _INT_DIRECTIVES = {"segment_gap", "crossfade", "flow_steps"}
 _ALL_DIRECTIVES = _STR_DIRECTIVES | _FLOAT_DIRECTIVES | _INT_DIRECTIVES
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -132,6 +132,14 @@ class TestFloatValidation:
         """Int values should be accepted for float fields."""
         _validate_tts_params(extra_kwargs={"exaggeration": 1, "cfg_weight": 0})
 
+    def test_rejects_bool_exaggeration(self):
+        with pytest.raises(TypeError, match="got bool"):
+            _validate_tts_params(extra_kwargs={"exaggeration": True})
+
+    def test_rejects_bool_cfg_weight(self):
+        with pytest.raises(TypeError, match="got bool"):
+            _validate_tts_params(extra_kwargs={"cfg_weight": False})
+
 
 # ── Integer field validation ─────────────────────────────────────────────────
 
@@ -168,6 +176,14 @@ class TestIntValidation:
     def test_rejects_non_int_segment_gap(self):
         with pytest.raises(TypeError, match="must be an integer"):
             _validate_tts_params(segment_gap=200.5)
+
+    def test_rejects_bool_segment_gap(self):
+        with pytest.raises(TypeError, match="got bool"):
+            _validate_tts_params(segment_gap=True)
+
+    def test_rejects_bool_crossfade(self):
+        with pytest.raises(TypeError, match="got bool"):
+            _validate_tts_params(crossfade=False)
 
 
 # ── Integration: validation in generate/clone ────────────────────────────────
@@ -276,3 +292,75 @@ class TestDaemonSanitizeRequest:
         err = _sanitize_request(req)
         assert err is not None
         assert "must be a number" in err
+
+    def test_rejects_negative_segment_gap(self):
+        from voicecli.daemon import _sanitize_request
+
+        req = {"engine": "qwen", "text": "hello", "segment_gap": -100}
+        err = _sanitize_request(req)
+        assert err is not None
+        assert "between" in err
+
+    def test_rejects_too_large_crossfade(self):
+        from voicecli.daemon import _sanitize_request
+
+        req = {"engine": "qwen", "text": "hello", "crossfade": 99999}
+        err = _sanitize_request(req)
+        assert err is not None
+        assert "between" in err
+
+    def test_accepts_valid_segment_gap_and_crossfade(self):
+        from voicecli.daemon import _sanitize_request
+
+        req = {"engine": "qwen", "text": "hello", "segment_gap": 200, "crossfade": 50}
+        err = _sanitize_request(req)
+        assert err is None
+
+    def test_sanitizes_segment_strings(self):
+        from voicecli.daemon import _sanitize_request
+
+        req = {
+            "engine": "qwen",
+            "text": "hello",
+            "segments": [{"text": "seg1\ntext", "instruct": "loud\nevil", "language": "French"}],
+        }
+        err = _sanitize_request(req)
+        assert err is None
+        assert req["segments"][0]["text"] == "seg1 text"
+        assert req["segments"][0]["instruct"] == "loudevil"
+
+    def test_rejects_overlong_segment_instruct(self):
+        from voicecli.daemon import _sanitize_request
+
+        req = {
+            "engine": "qwen",
+            "text": "hello",
+            "segments": [{"text": "ok", "instruct": "x" * 257}],
+        }
+        err = _sanitize_request(req)
+        assert err is not None
+        assert "segments[0].instruct" in err
+
+    def test_rejects_segment_nan_exaggeration(self):
+        from voicecli.daemon import _sanitize_request
+
+        req = {
+            "engine": "qwen",
+            "text": "hello",
+            "segments": [{"text": "ok", "exaggeration": float("nan")}],
+        }
+        err = _sanitize_request(req)
+        assert err is not None
+        assert "segments[0].exaggeration" in err
+
+    def test_rejects_segment_out_of_range_crossfade(self):
+        from voicecli.daemon import _sanitize_request
+
+        req = {
+            "engine": "qwen",
+            "text": "hello",
+            "segments": [{"text": "ok", "crossfade": -1}],
+        }
+        err = _sanitize_request(req)
+        assert err is not None
+        assert "segments[0].crossfade" in err

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,278 @@
+"""Tests for TTS parameter input validation (#33)."""
+
+import math
+from unittest.mock import patch
+
+import pytest
+
+from voicecli.api import _validate_tts_params
+
+
+# ── String field validation ──────────────────────────────────────────────────
+
+
+class TestStringValidation:
+    def test_accepts_valid_strings(self):
+        _validate_tts_params(engine="qwen", voice="Ryan", language="French")
+
+    def test_accepts_none_strings(self):
+        _validate_tts_params(engine=None, voice=None, language=None)
+
+    def test_rejects_newline_in_engine(self):
+        with pytest.raises(ValueError, match="newline"):
+            _validate_tts_params(engine="qwen\nevil")
+
+    def test_rejects_carriage_return_in_voice(self):
+        with pytest.raises(ValueError, match="newline"):
+            _validate_tts_params(voice="Ryan\revil")
+
+    def test_rejects_overlong_engine(self):
+        with pytest.raises(ValueError, match="maximum length"):
+            _validate_tts_params(engine="x" * 65)
+
+    def test_rejects_overlong_voice(self):
+        with pytest.raises(ValueError, match="maximum length"):
+            _validate_tts_params(voice="x" * 257)
+
+    def test_rejects_overlong_language(self):
+        with pytest.raises(ValueError, match="maximum length"):
+            _validate_tts_params(language="x" * 257)
+
+    def test_rejects_non_string_engine(self):
+        with pytest.raises(TypeError, match="must be a string"):
+            _validate_tts_params(engine=123)
+
+    def test_rejects_overlong_text(self):
+        with pytest.raises(ValueError, match="maximum length"):
+            _validate_tts_params(text="x" * 100_001)
+
+    def test_accepts_long_text_within_limit(self):
+        _validate_tts_params(text="x" * 100_000)
+
+    def test_rejects_newline_in_text(self):
+        """Raw text strings must not contain newlines (protocol safety)."""
+        with pytest.raises(ValueError, match="newline"):
+            _validate_tts_params(text="line1\nline2")
+
+    def test_skips_text_validation_for_md_path(self):
+        """File paths (.md) skip text string validation."""
+        _validate_tts_params(text="script.md")
+
+    def test_skips_text_validation_for_txt_path(self):
+        """File paths (.txt) skip text string validation."""
+        _validate_tts_params(text="article.txt")
+
+
+# ── Extra kwargs string fields ───────────────────────────────────────────────
+
+
+class TestExtraKwargsStrings:
+    @pytest.mark.parametrize("field", ["instruct", "accent", "personality", "speed", "emotion"])
+    def test_rejects_overlong_extra_string(self, field):
+        with pytest.raises(ValueError, match="maximum length"):
+            _validate_tts_params(extra_kwargs={field: "x" * 257})
+
+    @pytest.mark.parametrize("field", ["instruct", "accent", "personality", "speed", "emotion"])
+    def test_rejects_newline_in_extra_string(self, field):
+        with pytest.raises(ValueError, match="newline"):
+            _validate_tts_params(extra_kwargs={field: "valid\ninjection"})
+
+    @pytest.mark.parametrize("field", ["instruct", "accent", "personality", "speed", "emotion"])
+    def test_accepts_valid_extra_string(self, field):
+        _validate_tts_params(extra_kwargs={field: "Léger accent provençal"})
+
+
+# ── Float field validation ───────────────────────────────────────────────────
+
+
+class TestFloatValidation:
+    def test_accepts_valid_exaggeration(self):
+        _validate_tts_params(extra_kwargs={"exaggeration": 0.7})
+
+    def test_accepts_exaggeration_boundaries(self):
+        _validate_tts_params(extra_kwargs={"exaggeration": 0.0})
+        _validate_tts_params(extra_kwargs={"exaggeration": 2.0})
+
+    def test_rejects_negative_exaggeration(self):
+        with pytest.raises(ValueError, match="between 0.0 and 2.0"):
+            _validate_tts_params(extra_kwargs={"exaggeration": -0.1})
+
+    def test_rejects_too_large_exaggeration(self):
+        with pytest.raises(ValueError, match="between 0.0 and 2.0"):
+            _validate_tts_params(extra_kwargs={"exaggeration": 2.1})
+
+    def test_rejects_nan_exaggeration(self):
+        with pytest.raises(ValueError, match="must be finite"):
+            _validate_tts_params(extra_kwargs={"exaggeration": float("nan")})
+
+    def test_rejects_inf_exaggeration(self):
+        with pytest.raises(ValueError, match="must be finite"):
+            _validate_tts_params(extra_kwargs={"exaggeration": float("inf")})
+
+    def test_accepts_valid_cfg_weight(self):
+        _validate_tts_params(extra_kwargs={"cfg_weight": 0.5})
+
+    def test_accepts_cfg_weight_boundaries(self):
+        _validate_tts_params(extra_kwargs={"cfg_weight": 0.0})
+        _validate_tts_params(extra_kwargs={"cfg_weight": 1.0})
+
+    def test_rejects_negative_cfg_weight(self):
+        with pytest.raises(ValueError, match="between 0.0 and 1.0"):
+            _validate_tts_params(extra_kwargs={"cfg_weight": -0.1})
+
+    def test_rejects_too_large_cfg_weight(self):
+        with pytest.raises(ValueError, match="between 0.0 and 1.0"):
+            _validate_tts_params(extra_kwargs={"cfg_weight": 1.1})
+
+    def test_rejects_non_numeric_exaggeration(self):
+        with pytest.raises(TypeError, match="must be a number"):
+            _validate_tts_params(extra_kwargs={"exaggeration": "high"})
+
+    def test_accepts_int_as_float(self):
+        """Int values should be accepted for float fields."""
+        _validate_tts_params(extra_kwargs={"exaggeration": 1, "cfg_weight": 0})
+
+
+# ── Integer field validation ─────────────────────────────────────────────────
+
+
+class TestIntValidation:
+    def test_accepts_valid_segment_gap(self):
+        _validate_tts_params(segment_gap=200)
+
+    def test_accepts_zero_segment_gap(self):
+        _validate_tts_params(segment_gap=0)
+
+    def test_rejects_negative_segment_gap(self):
+        with pytest.raises(ValueError, match="between 0 and 30000"):
+            _validate_tts_params(segment_gap=-1)
+
+    def test_rejects_too_large_segment_gap(self):
+        with pytest.raises(ValueError, match="between 0 and 30000"):
+            _validate_tts_params(segment_gap=30_001)
+
+    def test_accepts_valid_crossfade(self):
+        _validate_tts_params(crossfade=50)
+
+    def test_rejects_negative_crossfade(self):
+        with pytest.raises(ValueError, match="between 0 and 10000"):
+            _validate_tts_params(crossfade=-1)
+
+    def test_accepts_valid_chunk_size(self):
+        _validate_tts_params(chunk_size=500)
+
+    def test_rejects_zero_chunk_size(self):
+        with pytest.raises(ValueError, match="between 1 and 10000"):
+            _validate_tts_params(chunk_size=0)
+
+    def test_rejects_non_int_segment_gap(self):
+        with pytest.raises(TypeError, match="must be an integer"):
+            _validate_tts_params(segment_gap=200.5)
+
+
+# ── Integration: validation in generate/clone ────────────────────────────────
+
+
+class TestGenerateValidation:
+    def test_generate_rejects_nan_exaggeration(self):
+        from voicecli.api import generate
+
+        with (
+            patch("voicecli.config.load_defaults", return_value={}),
+            pytest.raises(ValueError, match="must be finite"),
+        ):
+            generate("Hello", exaggeration=float("nan"))
+
+    def test_generate_rejects_overlong_instruct(self):
+        from voicecli.api import generate
+
+        with (
+            patch("voicecli.config.load_defaults", return_value={}),
+            pytest.raises(ValueError, match="maximum length"),
+        ):
+            generate("Hello", instruct="x" * 257)
+
+
+class TestCloneValidation:
+    def test_clone_rejects_negative_exaggeration(self):
+        from voicecli.api import clone
+
+        with (
+            patch("voicecli.config.load_defaults", return_value={}),
+            pytest.raises(ValueError, match="between 0.0 and 2.0"),
+        ):
+            clone("Hello", ref="/tmp/fake.wav", exaggeration=-1.0)
+
+
+# ── Daemon validation ────────────────────────────────────────────────────────
+
+
+class TestDaemonSanitizeRequest:
+    def test_strips_newlines_from_engine(self):
+        from voicecli.daemon import _sanitize_request
+
+        req = {"engine": "qwen\nevil", "text": "hello"}
+        err = _sanitize_request(req)
+        assert err is None
+        assert req["engine"] == "qwenevil"
+
+    def test_strips_newlines_from_text(self):
+        from voicecli.daemon import _sanitize_request
+
+        req = {"engine": "qwen", "text": "line1\nline2"}
+        err = _sanitize_request(req)
+        assert err is None
+        assert req["text"] == "line1 line2"
+
+    def test_rejects_overlong_engine(self):
+        from voicecli.daemon import _sanitize_request
+
+        req = {"engine": "x" * 65, "text": "hello"}
+        err = _sanitize_request(req)
+        assert err is not None
+        assert "maximum length" in err
+
+    def test_rejects_overlong_text(self):
+        from voicecli.daemon import _sanitize_request
+
+        req = {"engine": "qwen", "text": "x" * 100_001}
+        err = _sanitize_request(req)
+        assert err is not None
+        assert "maximum length" in err
+
+    def test_rejects_nan_exaggeration(self):
+        from voicecli.daemon import _sanitize_request
+
+        req = {"engine": "qwen", "text": "hello", "exaggeration": float("nan")}
+        err = _sanitize_request(req)
+        assert err is not None
+        assert "finite" in err
+
+    def test_rejects_out_of_range_cfg_weight(self):
+        from voicecli.daemon import _sanitize_request
+
+        req = {"engine": "qwen", "text": "hello", "cfg_weight": 5.0}
+        err = _sanitize_request(req)
+        assert err is not None
+        assert "between" in err
+
+    def test_accepts_valid_request(self):
+        from voicecli.daemon import _sanitize_request
+
+        req = {
+            "engine": "qwen",
+            "text": "Hello world",
+            "exaggeration": 0.7,
+            "cfg_weight": 0.3,
+        }
+        err = _sanitize_request(req)
+        assert err is None
+
+    def test_clamps_string_exaggeration(self):
+        """Non-numeric exaggeration from JSON should be rejected."""
+        from voicecli.daemon import _sanitize_request
+
+        req = {"engine": "qwen", "text": "hello", "exaggeration": "high"}
+        err = _sanitize_request(req)
+        assert err is not None
+        assert "must be a number" in err


### PR DESCRIPTION
## Summary

- Add `_validate_tts_params()` in `api.py` — validates string fields (length ≤256, no newlines), float fields (`exaggeration` 0.0–2.0, `cfg_weight` 0.0–1.0, finite), and int fields (`segment_gap`, `crossfade`, `chunk_size`) at the API boundary
- Add `_sanitize_request()` in `daemon.py` — defense-in-depth validation/sanitization for the newline-delimited JSON wire protocol
- Called at the top of `generate()` and `clone()` before any processing

Closes #33

## Test plan

- [x] 60 new tests in `tests/test_validation.py` covering all validation paths
- [x] All existing tests unaffected (8 pre-existing failures from daemon-wait commit, not related)
- [x] Lint + format + typecheck hooks pass
- [ ] Manual: `voicecli generate "Hello"` still works end-to-end
- [ ] Manual: verify Lyra agent with invalid params gets clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)