### PR TITLE
chore(typecheck): add pyright setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,7 @@ jobs:
         run: uv run ruff check .
       - name: Format check
         run: uv run ruff format --check .
+      - name: Typecheck
+        run: uv run pyright
       - name: Test
         run: uv run python -m pytest --ignore=tests/test_overlay.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,4 +70,5 @@ dev = [
     "pytest",
     "pre-commit>=4.5.1",
     "pip-licenses>=5.5.1",
+    "pyright>=1.1.408",
 ]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -8,8 +8,6 @@
     "src/voicecli/overlay.py",
     "src/voicecli/engines"
   ],
-  "venvPath": ".",
-  "venv": ".venv",
   "reportMissingImports": "error",
   "reportMissingModuleSource": "none"
 }

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,15 @@
+{
+  "pythonVersion": "3.12",
+  "pythonPlatform": "Linux",
+  "typeCheckingMode": "basic",
+  "include": ["src/voicecli"],
+  "exclude": [
+    "src/voicecli/__pycache__",
+    "src/voicecli/overlay.py",
+    "src/voicecli/engines"
+  ],
+  "venvPath": ".",
+  "venv": ".venv",
+  "reportMissingImports": "warning",
+  "reportMissingModuleSource": "none"
+}

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -10,6 +10,6 @@
   ],
   "venvPath": ".",
   "venv": ".venv",
-  "reportMissingImports": "warning",
+  "reportMissingImports": "error",
   "reportMissingModuleSource": "none"
 }

--- a/src/voicecli/cli.py
+++ b/src/voicecli/cli.py
@@ -271,10 +271,10 @@ def _run_dictate_setup() -> None:
 
     # Overlay (GTK3 + gtk-layer-shell)
     try:
-        import gi
+        import gi  # type: ignore[import-untyped]
 
         gi.require_version("Gtk", "3.0")
-        from gi.repository import Gtk  # noqa: F401
+        from gi.repository import Gtk  # type: ignore[import-untyped]  # noqa: F401
 
         typer.echo("  overlay OK")
     except (ValueError, ImportError):

--- a/src/voicecli/config.py
+++ b/src/voicecli/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 import tomllib
+from typing import Any, Callable
 from pathlib import Path
 
 VOICECLI_DIR = Path.home() / ".voicecli"
@@ -15,7 +16,7 @@ def _parse_bool(value: object) -> bool:
     return str(value).lower() in ("true", "1", "yes", "on")
 
 
-_KNOWN_DEFAULTS: dict[str, object] = {
+_KNOWN_DEFAULTS: dict[str, Callable[..., Any]] = {
     "engine": str,
     "language": str,
     "voice": str,

--- a/src/voicecli/engine.py
+++ b/src/voicecli/engine.py
@@ -61,6 +61,7 @@ def cuda_guard(engine_name: str) -> Iterator[None]:
 
 class TTSEngine(ABC):
     name: str
+    _small: bool = False
 
     @abstractmethod
     def generate(self, text: str, voice: str | None, output_path: Path, **kwargs) -> Path:

--- a/src/voicecli/engines/__init__.py
+++ b/src/voicecli/engines/__init__.py
@@ -1,0 +1,1 @@
+# pyright: ignore — excluded from pyrightconfig.json (heavy ML deps, no type stubs)

--- a/src/voicecli/engines/chatterbox.py
+++ b/src/voicecli/engines/chatterbox.py
@@ -1,3 +1,4 @@
+# pyright: ignore — excluded from pyrightconfig.json (heavy ML deps, no type stubs)
 from __future__ import annotations
 
 import numpy as np

--- a/src/voicecli/engines/chatterbox_turbo.py
+++ b/src/voicecli/engines/chatterbox_turbo.py
@@ -1,3 +1,4 @@
+# pyright: ignore — excluded from pyrightconfig.json (heavy ML deps, no type stubs)
 from __future__ import annotations
 
 import numpy as np

--- a/src/voicecli/engines/qwen.py
+++ b/src/voicecli/engines/qwen.py
@@ -1,3 +1,4 @@
+# pyright: ignore — excluded from pyrightconfig.json (heavy ML deps, no type stubs)
 from __future__ import annotations
 
 import numpy as np

--- a/src/voicecli/engines/qwen_fast.py
+++ b/src/voicecli/engines/qwen_fast.py
@@ -1,3 +1,4 @@
+# pyright: ignore — excluded from pyrightconfig.json (heavy ML deps, no type stubs)
 """Qwen3-TTS engine with CUDA graph acceleration via faster-qwen3-tts."""
 
 from __future__ import annotations

--- a/src/voicecli/engines/voxtral.py
+++ b/src/voicecli/engines/voxtral.py
@@ -1,3 +1,4 @@
+# pyright: ignore — excluded from pyrightconfig.json (heavy ML deps, no type stubs)
 from __future__ import annotations
 
 import numpy as np

--- a/src/voicecli/listen.py
+++ b/src/voicecli/listen.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from typing import Any
 
 MODELS = {
     "1b": "kyutai/stt-1b-en_fr-trfs",  # EN + FR, 0.5s latency
@@ -11,7 +12,7 @@ MODELS = {
 }
 DEFAULT_MODEL = "1b"
 
-_pipeline_cache: dict[str, object] = {}
+_pipeline_cache: dict[str, Any] = {}
 
 
 def _load_pipeline(model: str):

--- a/src/voicecli/stt_daemon.py
+++ b/src/voicecli/stt_daemon.py
@@ -640,7 +640,7 @@ class SttDaemon:
             elif action == "transcribe_file":
                 self._handle_transcribe_file(conn, req)
             else:
-                self._handle_unknown(conn, str(action) if action is not None else "unknown")
+                self._handle_unknown(conn, action)
         except Exception as exc:
             try:
                 _send_json(conn, {"status": "error", "message": str(exc)})
@@ -658,7 +658,7 @@ class SttDaemon:
             mode = self._current_mode or self.default_mode
         _send_json(conn, {"status": "ok", "state": state, "mode": mode})
 
-    def _handle_unknown(self, conn: socket.socket, action: str) -> None:
+    def _handle_unknown(self, conn: socket.socket, action: str | None) -> None:
         _send_json(conn, {"status": "error", "message": f"unknown action: {action}"})
 
     def _handle_transcribe_file(self, conn: socket.socket, req: dict) -> None:

--- a/src/voicecli/stt_daemon.py
+++ b/src/voicecli/stt_daemon.py
@@ -640,7 +640,7 @@ class SttDaemon:
             elif action == "transcribe_file":
                 self._handle_transcribe_file(conn, req)
             else:
-                self._handle_unknown(conn, action)
+                self._handle_unknown(conn, str(action) if action is not None else "unknown")
         except Exception as exc:
             try:
                 _send_json(conn, {"status": "error", "message": str(exc)})

--- a/src/voicecli/transcribe.py
+++ b/src/voicecli/transcribe.py
@@ -8,6 +8,10 @@ if the daemon is unavailable.
 import threading
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from faster_whisper import WhisperModel
 
 MODELS = ["tiny", "base", "small", "medium", "large-v3", "large-v3-turbo"]
 DEFAULT_MODEL = "large-v3-turbo"
@@ -33,7 +37,7 @@ VALID_MODELS = frozenset(
     }
 )
 
-_model_cache: dict[str, object] = {}
+_model_cache: "dict[str, WhisperModel]" = {}
 _model_lock = threading.Lock()
 
 
@@ -209,7 +213,7 @@ def unload_model() -> None:
     print("[stt] Models unloaded.")
 
 
-def _load_model(model: str):
+def _load_model(model: str) -> "WhisperModel":
     if model not in VALID_MODELS:
         raise ValueError(
             f"Unknown model '{model}'. Valid models: {', '.join(sorted(VALID_MODELS))}"

--- a/src/voicecli/transcribe.py
+++ b/src/voicecli/transcribe.py
@@ -5,6 +5,8 @@ over Unix socket to reuse the warm model. Falls back to local model loading
 if the daemon is unavailable.
 """
 
+from __future__ import annotations
+
 import threading
 from dataclasses import dataclass
 from pathlib import Path
@@ -37,7 +39,7 @@ VALID_MODELS = frozenset(
     }
 )
 
-_model_cache: "dict[str, WhisperModel]" = {}
+_model_cache: dict[str, WhisperModel] = {}
 _model_lock = threading.Lock()
 
 
@@ -213,7 +215,7 @@ def unload_model() -> None:
     print("[stt] Models unloaded.")
 
 
-def _load_model(model: str) -> "WhisperModel":
+def _load_model(model: str) -> WhisperModel:
     if model not in VALID_MODELS:
         raise ValueError(
             f"Unknown model '{model}'. Valid models: {', '.join(sorted(VALID_MODELS))}"

--- a/uv.lock
+++ b/uv.lock
@@ -1717,6 +1717,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.408"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2372,10 +2385,10 @@ name = "triton"
 version = "3.6.0"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/triton-3.6.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:290687f4f310ce794a07d6a43fa94dea9bda86615bf04578533378503bed715a" },
-    { url = "https://download.pytorch.org/whl/triton-3.6.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e021e87e8f266c6f87bf379b669c43c2800aac6247bdf5d518cb553e3c403c00" },
-    { url = "https://download.pytorch.org/whl/triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e42d084864d12b8784736fe51a0cd05f6cc56775b25c8102c9d80c421f4e298" },
-    { url = "https://download.pytorch.org/whl/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f5928e6d44c34a97bbe164cceddc0ef2007121c89ebcfba5415cf452de7ee9f" },
+    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:290687f4f310ce794a07d6a43fa94dea9bda86615bf04578533378503bed715a" },
+    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e021e87e8f266c6f87bf379b669c43c2800aac6247bdf5d518cb553e3c403c00" },
+    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e42d084864d12b8784736fe51a0cd05f6cc56775b25c8102c9d80c421f4e298" },
+    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f5928e6d44c34a97bbe164cceddc0ef2007121c89ebcfba5415cf452de7ee9f" },
 ]
 
 [[package]]
@@ -2492,6 +2505,7 @@ voxtral = [
 dev = [
     { name = "pip-licenses" },
     { name = "pre-commit" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -2520,6 +2534,7 @@ provides-extras = ["voxtral", "hotkey", "overlay"]
 dev = [
     { name = "pip-licenses", specifier = ">=5.5.1" },
     { name = "pre-commit", specifier = ">=4.5.1" },
+    { name = "pyright", specifier = ">=1.1.408" },
     { name = "pytest" },
     { name = "ruff" },
 ]


### PR DESCRIPTION
## Summary
- Add `pyrightconfig.json` (basic mode, Python 3.12, excludes `overlay.py` and `engines/` — optional/internal deps with missing stubs)
- Add `pyright>=1.1.408` as dev dependency
- Add `typecheck` step to CI (`uv run pyright`)
- Fix type annotations in 5 modules to clear pyright errors: `config._KNOWN_DEFAULTS`, `engine.TTSEngine._small`, `transcribe._model_cache` + `WhisperModel` TYPE_CHECKING import, `listen._pipeline_cache`, `stt_daemon` action None guard
- `py.typed` PEP 561 marker was already present

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #38: chore(typecheck): add pyright setup | Open |
| Implementation | 1 commit on `feat/38-chore-typecheck-add-pyright-setup` | Complete |
| Verification | Lint ✅ Typecheck ✅ (0 errors, 2 warnings for optional gi dep) Format ✅ | Passed |

## Test Plan
- [ ] `uv run pyright` reports 0 errors locally
- [ ] CI typecheck step passes on this PR
- [ ] Downstream lyra pyright run no longer reports `reportMissingImports` on `voicecli.*` imports

Closes #38

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`