### PR TITLE
feat(nats): add voicecli nats-serve tts entry point

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y portaudio19-dev libcairo2-dev libgirepository-2.0-dev gir1.2-gtk-3.0
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --dev --extra nats
       - name: Lint
         run: uv run ruff check .
       - name: Format check

--- a/docs/NATS-SERVE.md
+++ b/docs/NATS-SERVE.md
@@ -1,0 +1,201 @@
+---
+title: NATS Serve — Operator Guide
+description: Running voicecli as a NATS queue-group satellite for distributed TTS/STT.
+---
+
+## Overview
+
+`voicecli nats-serve {tts,stt}` runs voicecli as a long-lived NATS queue-group subscriber
+instead of a local Unix-socket daemon. Requests arrive over NATS subject/reply patterns;
+the satellite processes them and publishes the reply back to the hub. Multiple satellite
+instances can subscribe to the same queue group — NATS load-balances across them automatically.
+
+**When to choose this over `tts-serve` / `stt-serve`:**
+
+| Scenario | Use |
+|---|---|
+| Hub and voicecli on the same host, no network boundary | `tts-serve` / `stt-serve` (Unix socket, lower latency) |
+| Hub and voicecli on different hosts | `nats-serve` |
+| You want to add satellite capacity without changing hub config | `nats-serve` (add more queue-group members) |
+| Production deployment where hub is managed separately from GPU worker | `nats-serve` |
+
+ADR-044 in the lyra repo formalised this decoupling to remove lyra's direct Unix-socket
+dependency on voicecli, enabling each service to be deployed and restarted independently.
+
+**Startup sequence:**
+1. Validate env vars and file permissions (seed file `0600`).
+2. Run the VRAM-sequencing guard (probe local socket daemon).
+3. Connect to NATS and join the queue group (`tts-workers` / `stt-workers`).
+4. Load the TTS/STT engine model into VRAM.
+5. Begin accepting requests and publishing heartbeats.
+
+**Current status:** Slice 1 ships the **TTS path** (`nats-serve tts`) only.
+`nats-serve stt` is planned in a follow-up slice — do not rely on it yet.
+
+---
+
+## Environment variables
+
+Precedence: `CLI flag > env var > voicecli.toml > hardcoded default`
+
+All variables below are read at startup. Changes take effect only after a process restart.
+Set them in the supervisord `environment=` line (comma-separated `KEY="value"` pairs) or
+export them in the shell environment before running `voicecli nats-serve`.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `NATS_URL` | — (required) | NATS server URL, e.g. `nats://nats.internal:4222` |
+| `NATS_NKEY_SEED_PATH` | — (required for nkey auth) | Path to the NKey seed file. **File permissions must be `0600`** — the satellite refuses to start if the file is world- or group-readable. |
+| `NATS_CA_CERT` | — (optional) | Path to a PEM CA certificate for TLS verification |
+| `VOICECLI_ENGINE` | from `voicecli.toml` | TTS engine override (`qwen`, `qwen-fast`, `chatterbox`, etc.) |
+| `LYRA_TTS_ENGINE` | — | Alias for `VOICECLI_ENGINE`. Provided for the lyra#658 S3 cutover so existing supervisord `environment=` lines keep working without renaming. Takes the same values; `VOICECLI_ENGINE` wins if both are set. |
+| `VOICECLI_MAX_CONCURRENT` | TTS: `1` / STT: `2` | Maximum requests processed in parallel. Keep at `1` for single-GPU hosts unless VRAM allows more. |
+| `VOICECLI_HEARTBEAT_INTERVAL` | `5.0` | Seconds between heartbeat publishes. Must stay ≤ 5 per ADR-044 — the hub declares a satellite dead after two missed beats. |
+| `VOICECLI_DRAIN_TIMEOUT` | `30` | Seconds to wait for in-flight requests to finish during graceful shutdown before exiting with code 3. |
+| `VOICECLI_REJECT_WHEN_FULL` | unset | Set to `1` to return an error reply immediately when all slots are busy, rather than queuing the request. |
+| `VOICECLI_ALLOW_COEXIST` | unset | Set to `1` to bypass the VRAM-sequencing guard on startup. See [VRAM sequencing](#vram-sequencing). |
+
+---
+
+## VRAM sequencing
+
+Running a NATS satellite alongside a socket daemon (`tts-serve` / `stt-serve`) on the same
+GPU risks CUDA OOM — both processes compete for the same VRAM budget. See the
+[VRAM contention note in CLAUDE.md](../CLAUDE.md#vram-contention-on-rtx-3080-10-gb) for
+measured numbers (TTS daemon: ~7.4 GB, STT daemon: ~2.2 GB on RTX 3080).
+
+The intended deployment model is **either** the socket daemon **or** the NATS satellite on
+a given host — not both. The guard enforces this automatically.
+
+**On startup the satellite probes the socket:**
+
+- TTS: `~/.local/share/voicecli/daemon.sock`
+- STT: `~/.local/share/voicecli/stt-daemon.sock`
+
+| Socket state | Behaviour |
+|---|---|
+| File absent | Proceed normally |
+| File exists, `connect()` returns `ECONNREFUSED` (stale) | Log at INFO, ignore, proceed |
+| File exists, daemon answers the probe (live) | **Refuse to start — exit 78** |
+
+**To resolve exit 78:** stop the socket daemon before starting the NATS satellite.
+
+```bash
+# From ~/projects/lyra (or wherever your supervisord Makefile lives)
+make tts stop                            # stop voicecli_tts (socket daemon)
+supervisorctl start voicecli_nats_tts   # start NATS satellite
+```
+
+On local-dev machines or large-VRAM boxes (e.g. RTX 5070 Ti with 16 GB) where coexistence
+is safe, bypass the guard with the flag or env var:
+
+```bash
+voicecli nats-serve tts --allow-coexist
+# or via env var (suitable for supervisord environment= lines)
+VOICECLI_ALLOW_COEXIST=1 voicecli nats-serve tts
+```
+
+Do not set `VOICECLI_ALLOW_COEXIST=1` on the RTX 3080 (10 GB) production host —
+it will allow OOM conditions during concurrent synthesis. See the
+[VRAM contention gotcha](../CLAUDE.md#vram-contention-on-rtx-3080-10-gb) for details.
+
+---
+
+## Exit codes
+
+Shutdown is triggered by `SIGTERM` or `SIGINT`. On receiving a signal the satellite stops
+accepting new requests, waits up to `VOICECLI_DRAIN_TIMEOUT` seconds for in-flight work to
+complete, then exits.
+
+| Code | Meaning | Operator action |
+|---|---|---|
+| `0` | Clean shutdown; all in-flight requests drained within `--drain-timeout` | None — safe to restart |
+| `3` | Drain timeout exceeded; at least one in-flight request did not finish within the window | Restart is safe; investigate slow synthesis if this recurs frequently — consider raising `VOICECLI_DRAIN_TIMEOUT` |
+| `78` | VRAM-sequencing guard tripped — a live socket daemon was detected on startup | Stop the socket daemon (`voicecli tts-serve` / `voicecli stt-serve`) before restarting, OR pass `--allow-coexist` |
+
+Any other non-zero exit code is an unhandled error — check `stderr_logfile` for the Python
+traceback.
+
+supervisord's default `exitcodes` is `0`, which means it treats exit 3 and exit 78 as
+unexpected and will attempt a restart. Always override with `exitcodes=0,78` as shown in
+[Required supervisord stanza](#required-supervisord-stanza).
+
+---
+
+## Required supervisord stanza
+
+`autorestart=unexpected` combined with `exitcodes=0,78` is **critical**. Without it,
+supervisord treats exit 78 as unexpected and loop-restarts the process — causing a tight
+restart loop on misconfigured hosts. Always include both exit codes together.
+
+Copy this block into your supervisord `conf.d/` directory and fill in host-specific values:
+
+```ini
+[program:voicecli_nats_tts]
+command=voicecli nats-serve tts
+environment=NATS_URL="nats://nats.internal:4222",NATS_NKEY_SEED_PATH="/home/lyra/.lyra/nkeys/voicecli-tts.seed",LYRA_TTS_ENGINE="qwen-fast"
+autorestart=unexpected
+exitcodes=0,78
+startsecs=15
+user=lyra
+stdout_logfile=/home/lyra/.local/state/lyra/logs/voicecli_nats_tts.log
+stderr_logfile=/home/lyra/.local/state/lyra/logs/voicecli_nats_tts.err
+```
+
+Key fields:
+
+| Field | Guidance |
+|---|---|
+| `autorestart=unexpected` | Restart on non-zero exits not listed in `exitcodes`; do NOT use `autorestart=true` |
+| `exitcodes=0,78` | Both must be listed — exit 0 (clean) and exit 78 (guard tripped) are both intentional |
+| `startsecs=15` | GPU model load time; lower on fast NVMe + large VRAM, raise if startup OOM observed |
+| `user=lyra` | Match the user that owns the NKey seed file and log directory |
+
+**For the STT satellite** (once Slice 2 ships): mirror the block substituting `nats-serve stt`,
+queue group `stt-workers`, and the STT-specific seed path. Log file naming convention:
+`voicecli_nats_stt.{log,err}`.
+
+---
+
+## Troubleshooting
+
+### Quick reference
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Process exits 78 immediately on startup | Live socket daemon (`tts-serve` / `stt-serve`) detected | Stop the socket daemon via supervisorctl, then restart; or pass `--allow-coexist` if coexistence is intentional |
+| `PermissionError` referencing the seed file path | NKey seed file is not `0600` | `chmod 600 /path/to/voicecli-tts.seed` |
+| Replies never arrive at the hub / requests time out | Wrong `NATS_URL`, network partition, or mismatched queue group name | Verify `NATS_URL` is reachable from the satellite host; queue group names are `tts-workers` (TTS) and `stt-workers` (STT) |
+| Heartbeats stop arriving during a synthesis | Concurrency contract violated (bug) | Report it — the spec guarantees heartbeats continue independently of in-flight synthesis |
+| Hub logs `payload_too_large` | Reply WAV exceeds NATS server `max_payload` | Increase `max_payload` in the NATS server config, or shorten the synthesis text |
+| Satellite starts but produces no output; logs show CUDA OOM | VRAM exhausted by coexisting processes | Stop other GPU-heavy daemons, reduce `VOICECLI_MAX_CONCURRENT`, or move to a host with more VRAM |
+| supervisord keeps restarting the process in a tight loop | `autorestart=true` or `exitcodes` missing 78 | Set `autorestart=unexpected` and add `78` to `exitcodes` — see [Required supervisord stanza](#required-supervisord-stanza) |
+| TLS handshake errors connecting to NATS | Missing or wrong CA certificate | Set `NATS_CA_CERT` to the PEM file for your internal CA |
+
+### Checking liveness
+
+The satellite logs its startup sequence to stdout. A healthy start looks like:
+
+```
+INFO  vram-guard: no live socket daemon detected — proceeding
+INFO  nats: connected to nats://nats.internal:4222
+INFO  engine: model loaded in 12.3s (qwen-fast)
+INFO  nats-serve: joined queue group tts-workers — ready
+```
+
+If the process exits before the "ready" line, check `stderr_logfile` for the Python
+traceback. The most common causes are: missing env vars, seed file permission error, NATS
+unreachable, and the VRAM guard (exit 78).
+
+### Confirming requests reach the satellite
+
+Use the NATS CLI to publish a test request directly to the TTS subject and observe whether
+the satellite picks it up:
+
+```bash
+nats req tts.synthesize '{"text": "hello"}' --server nats://nats.internal:4222
+```
+
+If no reply arrives within the timeout, the satellite is either not running, not connected
+to the correct server, or stuck processing another request and `VOICECLI_REJECT_WHEN_FULL`
+is not set.

--- a/docs/NATS-SERVE.md
+++ b/docs/NATS-SERVE.md
@@ -117,16 +117,16 @@ Any other non-zero exit code is an unhandled error — check `stderr_logfile` fo
 traceback.
 
 supervisord's default `exitcodes` is `0`, which means it treats exit 3 and exit 78 as
-unexpected and will attempt a restart. Always override with `exitcodes=0,78` as shown in
+unexpected and will attempt a restart. Always override with `exitcodes=0,3,78` as shown in
 [Required supervisord stanza](#required-supervisord-stanza).
 
 ---
 
 ## Required supervisord stanza
 
-`autorestart=unexpected` combined with `exitcodes=0,78` is **critical**. Without it,
+`autorestart=unexpected` combined with `exitcodes=0,3,78` is **critical**. Without it,
 supervisord treats exit 78 as unexpected and loop-restarts the process — causing a tight
-restart loop on misconfigured hosts. Always include both exit codes together.
+restart loop on misconfigured hosts. Always include all three exit codes together.
 
 Copy this block into your supervisord `conf.d/` directory and fill in host-specific values:
 
@@ -135,7 +135,9 @@ Copy this block into your supervisord `conf.d/` directory and fill in host-speci
 command=voicecli nats-serve tts
 environment=NATS_URL="nats://nats.internal:4222",NATS_NKEY_SEED_PATH="/home/lyra/.lyra/nkeys/voicecli-tts.seed",LYRA_TTS_ENGINE="qwen-fast"
 autorestart=unexpected
-exitcodes=0,78
+exitcodes=0,3,78
+stopsignal=TERM
+stopwaitsecs=35
 startsecs=15
 user=lyra
 stdout_logfile=/home/lyra/.local/state/lyra/logs/voicecli_nats_tts.log
@@ -147,7 +149,9 @@ Key fields:
 | Field | Guidance |
 |---|---|
 | `autorestart=unexpected` | Restart on non-zero exits not listed in `exitcodes`; do NOT use `autorestart=true` |
-| `exitcodes=0,78` | Both must be listed — exit 0 (clean) and exit 78 (guard tripped) are both intentional |
+| `exitcodes=0,3,78` | All three intentional exits: 0 (clean), 3 (drain timeout exceeded), 78 (VRAM guard tripped) — without 3, supervisord loop-restarts the process whenever the drain window is exceeded during shutdown |
+| `stopsignal=TERM` | Sends SIGTERM on `supervisorctl stop`, triggering graceful drain before exit |
+| `stopwaitsecs=35` | Must exceed `VOICECLI_DRAIN_TIMEOUT` (default 30 s) by a margin; 35 s gives the satellite time to drain before supervisord sends SIGKILL |
 | `startsecs=15` | GPU model load time; lower on fast NVMe + large VRAM, raise if startup OOM observed |
 | `user=lyra` | Match the user that owns the NKey seed file and log directory |
 
@@ -169,7 +173,7 @@ queue group `stt-workers`, and the STT-specific seed path. Log file naming conve
 | Heartbeats stop arriving during a synthesis | Concurrency contract violated (bug) | Report it — the spec guarantees heartbeats continue independently of in-flight synthesis |
 | Hub logs `payload_too_large` | Reply WAV exceeds NATS server `max_payload` | Increase `max_payload` in the NATS server config, or shorten the synthesis text |
 | Satellite starts but produces no output; logs show CUDA OOM | VRAM exhausted by coexisting processes | Stop other GPU-heavy daemons, reduce `VOICECLI_MAX_CONCURRENT`, or move to a host with more VRAM |
-| supervisord keeps restarting the process in a tight loop | `autorestart=true` or `exitcodes` missing 78 | Set `autorestart=unexpected` and add `78` to `exitcodes` — see [Required supervisord stanza](#required-supervisord-stanza) |
+| supervisord keeps restarting the process in a tight loop | `autorestart=true` or `exitcodes` missing 78 or 3 | Set `autorestart=unexpected` and use `exitcodes=0,3,78` — see [Required supervisord stanza](#required-supervisord-stanza) |
 | TLS handshake errors connecting to NATS | Missing or wrong CA certificate | Set `NATS_CA_CERT` to the PEM file for your internal CA |
 
 ### Checking liveness
@@ -193,7 +197,7 @@ Use the NATS CLI to publish a test request directly to the TTS subject and obser
 the satellite picks it up:
 
 ```bash
-nats req tts.synthesize '{"text": "hello"}' --server nats://nats.internal:4222
+nats req lyra.voice.tts.request '{"request_id":"test-1","text":"hello","engine":"qwen-fast"}' --server nats://nats.internal:4222
 ```
 
 If no reply arrives within the timeout, the satellite is either not running, not connected

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,11 @@ pythonpath = ["src"]
 voxtral = ["voxtral-tts[int4]", "scipy"]
 hotkey = ["pynput>=1.7"]
 overlay = ["PyGObject>=3.42", "pycairo>=1.25"]
+nats = [
+    "nats-py>=2.6,<3",
+    "nkeys>=0.1",
+    "pynvml>=11.5",
+]
 
 [dependency-groups]
 dev = [

--- a/src/voicecli/cli.py
+++ b/src/voicecli/cli.py
@@ -1335,11 +1335,21 @@ app.add_typer(nats_app, name="nats-serve")
 @nats_app.command("tts")
 def nats_serve_tts(
     engine: Annotated[Optional[str], typer.Option("--engine", "-e")] = None,
-    max_concurrent: Annotated[int, typer.Option("--max-concurrent")] = 1,
-    reject_when_full: Annotated[bool, typer.Option("--reject-when-full")] = False,
-    heartbeat_interval: Annotated[float, typer.Option("--heartbeat-interval")] = 5.0,
-    drain_timeout: Annotated[float, typer.Option("--drain-timeout")] = 30.0,
-    allow_coexist: Annotated[bool, typer.Option("--allow-coexist")] = False,
+    max_concurrent: Annotated[
+        int, typer.Option("--max-concurrent", envvar="VOICECLI_MAX_CONCURRENT")
+    ] = 1,
+    reject_when_full: Annotated[
+        bool, typer.Option("--reject-when-full", envvar="VOICECLI_REJECT_WHEN_FULL")
+    ] = False,
+    heartbeat_interval: Annotated[
+        float, typer.Option("--heartbeat-interval", envvar="VOICECLI_HEARTBEAT_INTERVAL")
+    ] = 5.0,
+    drain_timeout: Annotated[
+        float, typer.Option("--drain-timeout", envvar="VOICECLI_DRAIN_TIMEOUT")
+    ] = 30.0,
+    allow_coexist: Annotated[
+        bool, typer.Option("--allow-coexist", envvar="VOICECLI_ALLOW_COEXIST")
+    ] = False,
 ) -> None:
     """Subscribe to lyra.voice.tts.request and reply with synthesized audio."""
     import asyncio
@@ -1351,17 +1361,6 @@ def nats_serve_tts(
 
     logging.basicConfig(level=logging.INFO)
     log = logging.getLogger("voicecli.nats-serve.tts")
-
-    if not reject_when_full and os.environ.get("VOICECLI_REJECT_WHEN_FULL") == "1":
-        reject_when_full = True
-    if not allow_coexist and os.environ.get("VOICECLI_ALLOW_COEXIST") == "1":
-        allow_coexist = True
-    if max_concurrent == 1 and "VOICECLI_MAX_CONCURRENT" in os.environ:
-        max_concurrent = int(os.environ["VOICECLI_MAX_CONCURRENT"])
-    if heartbeat_interval == 5.0 and "VOICECLI_HEARTBEAT_INTERVAL" in os.environ:
-        heartbeat_interval = float(os.environ["VOICECLI_HEARTBEAT_INTERVAL"])
-    if drain_timeout == 30.0 and "VOICECLI_DRAIN_TIMEOUT" in os.environ:
-        drain_timeout = float(os.environ["VOICECLI_DRAIN_TIMEOUT"])
 
     resolved_engine = _resolve_engine(engine)
 
@@ -1384,6 +1383,11 @@ def nats_serve_tts(
         log.error("NATS_URL env var is required")
         raise typer.Exit(2)
 
+    nkey_seed_path: Path | None = None
+    nkey_seed_env = os.environ.get("NATS_NKEY_SEED_PATH")
+    if nkey_seed_env:
+        nkey_seed_path = Path(nkey_seed_env).expanduser()
+
     adapter = TtsNatsAdapter(
         default_engine=resolved_engine,
         max_concurrent=max_concurrent,
@@ -1393,7 +1397,7 @@ def nats_serve_tts(
     )
 
     try:
-        asyncio.run(adapter.run(nats_url=nats_url))
+        asyncio.run(adapter.run(nats_url=nats_url, nkey_seed_path=nkey_seed_path))
     except DrainTimeoutError:
         log.error("drain timeout exceeded; some requests may have been dropped")
         raise typer.Exit(3)

--- a/src/voicecli/cli.py
+++ b/src/voicecli/cli.py
@@ -1,6 +1,6 @@
 import sys
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated, Literal, Optional
 
 import typer
 
@@ -1306,6 +1306,97 @@ def stt_serve(
         default_mode=resolved_default_mode,
         auto_paste=bool(stt_cfg.get("auto_paste", False)),
     ).serve()
+
+
+def _probe_socket_daemon(path: Path) -> Literal["live", "stale", "absent"]:
+    """Probe a Unix-socket daemon. Returns 'live' if a listener accepts,
+    'stale' if the file exists but connect() refuses, 'absent' if no file."""
+    import socket as _socket
+
+    if not path.exists():
+        return "absent"
+    sock = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+    sock.settimeout(0.5)
+    try:
+        sock.connect(str(path))
+        return "live"
+    except (ConnectionRefusedError, OSError):
+        return "stale"
+    finally:
+        sock.close()
+
+
+# ── NATS serve sub-app ────────────────────────────────────────────────────────
+
+nats_app = typer.Typer(help="NATS subscriber satellites for hub-driven voice.")
+app.add_typer(nats_app, name="nats-serve")
+
+
+@nats_app.command("tts")
+def nats_serve_tts(
+    engine: Annotated[Optional[str], typer.Option("--engine", "-e")] = None,
+    max_concurrent: Annotated[int, typer.Option("--max-concurrent")] = 1,
+    reject_when_full: Annotated[bool, typer.Option("--reject-when-full")] = False,
+    heartbeat_interval: Annotated[float, typer.Option("--heartbeat-interval")] = 5.0,
+    drain_timeout: Annotated[float, typer.Option("--drain-timeout")] = 30.0,
+    allow_coexist: Annotated[bool, typer.Option("--allow-coexist")] = False,
+) -> None:
+    """Subscribe to lyra.voice.tts.request and reply with synthesized audio."""
+    import asyncio
+    import logging
+    import os
+
+    from voicecli.nats.base import DrainTimeoutError
+    from voicecli.nats.tts_adapter import TtsNatsAdapter, _resolve_engine
+
+    logging.basicConfig(level=logging.INFO)
+    log = logging.getLogger("voicecli.nats-serve.tts")
+
+    if not reject_when_full and os.environ.get("VOICECLI_REJECT_WHEN_FULL") == "1":
+        reject_when_full = True
+    if not allow_coexist and os.environ.get("VOICECLI_ALLOW_COEXIST") == "1":
+        allow_coexist = True
+    if max_concurrent == 1 and "VOICECLI_MAX_CONCURRENT" in os.environ:
+        max_concurrent = int(os.environ["VOICECLI_MAX_CONCURRENT"])
+    if heartbeat_interval == 5.0 and "VOICECLI_HEARTBEAT_INTERVAL" in os.environ:
+        heartbeat_interval = float(os.environ["VOICECLI_HEARTBEAT_INTERVAL"])
+    if drain_timeout == 30.0 and "VOICECLI_DRAIN_TIMEOUT" in os.environ:
+        drain_timeout = float(os.environ["VOICECLI_DRAIN_TIMEOUT"])
+
+    resolved_engine = _resolve_engine(engine)
+
+    sock_path = Path("~/.local/share/voicecli/daemon.sock").expanduser()
+    state = _probe_socket_daemon(sock_path)
+    if state == "live":
+        if allow_coexist:
+            log.warning("coexisting with live socket daemon at %s", sock_path)
+        else:
+            log.error(
+                "live socket daemon at %s — refusing to start (use --allow-coexist or stop the daemon)",
+                sock_path,
+            )
+            raise typer.Exit(78)
+    elif state == "stale":
+        log.info("stale socket file at %s ignored", sock_path)
+
+    nats_url = os.environ.get("NATS_URL")
+    if not nats_url:
+        log.error("NATS_URL env var is required")
+        raise typer.Exit(2)
+
+    adapter = TtsNatsAdapter(
+        default_engine=resolved_engine,
+        max_concurrent=max_concurrent,
+        reject_when_full=reject_when_full,
+        heartbeat_interval=heartbeat_interval,
+        drain_timeout=drain_timeout,
+    )
+
+    try:
+        asyncio.run(adapter.run(nats_url=nats_url))
+    except DrainTimeoutError:
+        log.error("drain timeout exceeded; some requests may have been dropped")
+        raise typer.Exit(3)
 
 
 @app.command()

--- a/src/voicecli/nats/__init__.py
+++ b/src/voicecli/nats/__init__.py
@@ -1,0 +1,1 @@
+"""voicecli NATS subscriber framework — ports of lyra/src/lyra/nats."""

--- a/src/voicecli/nats/_validate.py
+++ b/src/voicecli/nats/_validate.py
@@ -1,0 +1,38 @@
+"""Envelope validation for NATS payloads.
+
+NOTE: ADR-044's `contract_version` field is read defensively per the spec
+(no validation, log WARN once on mismatch) and MUST NOT be routed through
+this module. This module validates only the structural envelope —
+field presence, types, length caps — not protocol versions.
+"""
+
+from __future__ import annotations
+
+import re
+
+_NATS_IDENT = re.compile(r"[A-Za-z0-9_.\-]+")
+
+
+def validate_nats_token(value: str, *, kind: str, allow_empty: bool = False) -> None:
+    """Raise ``ValueError`` if *value* is not a valid NATS identifier token.
+
+    A valid token matches ``[A-Za-z0-9_.\\-]+`` — no wildcards, spaces, or
+    empty strings. Used for subject prefixes, queue group names, and similar
+    identifiers that are interpolated into NATS protocol lines.
+
+    Args:
+        value: The token to validate.
+        kind: Human-readable name used in the error message (e.g. ``"queue_group"``).
+        allow_empty: When ``True``, an empty string is accepted (used for
+            optional tokens like ``queue_group`` where empty means "no group").
+
+    Raises:
+        ValueError: If *value* does not match the NATS identifier pattern.
+    """
+    if allow_empty and not value:
+        return
+    if not _NATS_IDENT.fullmatch(value):
+        raise ValueError(
+            f"Invalid {kind} for NATS: {value!r} — "
+            "must match [A-Za-z0-9_.\\-]+ (no wildcards or spaces)"
+        )

--- a/src/voicecli/nats/_version_check.py
+++ b/src/voicecli/nats/_version_check.py
@@ -1,0 +1,134 @@
+"""Schema-version envelope check (for the optional `schema_version` field).
+
+WARNING: This module exists for the optional `schema_version` envelope
+field used by some lyra subjects. ADR-044's `contract_version` field on
+voice request/reply payloads is a SEPARATE concept and is read
+defensively (no validation, log WARN on mismatch). Do NOT route
+`contract_version` through this function.
+
+A receiver accepts any payload whose ``schema_version`` is less than or equal
+to the receiver's own compiled-in ``SCHEMA_VERSION_*`` constant (forward-compat
+rule).  Strictly-greater versions are dropped with an ERROR log line and an
+optional in-process counter increment — instead of silently misinterpreting
+unknown or removed fields.
+
+Missing field: treated as version 1 (legacy backwards-compat).
+Non-int / null / negative / zero: treated as malformed → drop.
+
+Log rate limiting
+-----------------
+To avoid a log-flood DoS when a botched deploy produces thousands of mismatches
+per second, drop logs are rate-limited per envelope name to one ERROR line every
+``_LOG_INTERVAL_S`` seconds (default 60).  The counter still increments on every
+drop — rate limiting only affects log volume, not telemetry.  The limiter is
+module-level state intentionally (log volume is a process-wide concern, unlike
+the counter which needs per-instance isolation for correctness).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+log = logging.getLogger(__name__)
+
+# Module-level rate-limit state: envelope_name → monotonic timestamp of last log.
+# Shared across all subscriber instances in the process; that is desirable for
+# log volume (you want the WHOLE process rate-limited, not per-instance).
+# Tests should call ``_reset_log_state()`` between cases.
+_last_log_ts: dict[str, float] = {}
+
+# Minimum seconds between ERROR logs for the same envelope name.
+_LOG_INTERVAL_S: float = 60.0
+
+
+def check_schema_version(
+    payload: dict,
+    *,
+    envelope_name: str,
+    expected: int,
+    subject: str | None = None,
+    counter: dict[str, int] | None = None,
+) -> bool:
+    """Return True if payload is acceptable for this receiver; else drop + log + count.
+
+    Rules
+    -----
+    - Missing field → treated as version 1 (legacy backwards compat).
+    - Non-int value (string, null, float) → dropped.
+    - Integer <= 0 → dropped (invalid range).
+    - Integer > expected → dropped (forward-compat violation).
+    - Integer in [1, expected] → accepted.
+
+    Parameters
+    ----------
+    payload:
+        The decoded JSON dict received from NATS.
+    envelope_name:
+        Human-readable name of the envelope type (e.g. ``"InboundMessage"``).
+        Used as the counter key, rate-limit key, and in the log line.
+    expected:
+        The ``SCHEMA_VERSION_*`` constant this receiver was compiled against.
+    subject:
+        The NATS subject the message arrived on — included in the log line for
+        easier triage.  ``None`` renders as ``"<unknown>"``.
+    counter:
+        Caller-owned mutable dict; incremented at ``counter[envelope_name]`` on
+        every drop.  Pass ``None`` to skip counting.
+    """
+    raw = payload.get("schema_version", 1)
+
+    # Non-int (including None, str, float) → drop.  ``bool`` is a subclass of
+    # ``int`` in Python but we treat it as malformed since JSON ``true``/``false``
+    # is never a valid version value.
+    if not isinstance(raw, int) or isinstance(raw, bool):
+        _drop(envelope_name, raw, expected, subject, counter)
+        return False
+
+    # Out-of-range integer → drop.
+    if raw <= 0:
+        _drop(envelope_name, raw, expected, subject, counter)
+        return False
+
+    # Forward-compat violation → drop.
+    if raw > expected:
+        _drop(envelope_name, raw, expected, subject, counter)
+        return False
+
+    # 1 <= raw <= expected → accept.
+    return True
+
+
+def _drop(
+    envelope_name: str,
+    raw_version: object,
+    expected: int,
+    subject: str | None,
+    counter: dict[str, int] | None,
+) -> None:
+    """Record a dropped message: increment counter, emit rate-limited ERROR log."""
+    # Counter increments unconditionally — rate limiting is log-only.
+    if counter is not None:
+        counter[envelope_name] = counter.get(envelope_name, 0) + 1
+
+    # Rate-limited ERROR log: first drop per envelope fires immediately; repeats
+    # within _LOG_INTERVAL_S are silent (but still counted).  After the interval
+    # elapses, the next drop fires a fresh ERROR log.
+    now = time.monotonic()
+    last = _last_log_ts.get(envelope_name, 0.0)
+    if now - last < _LOG_INTERVAL_S:
+        return
+    _last_log_ts[envelope_name] = now
+    log.error(
+        "NATS schema version mismatch — dropping message: envelope=%s "
+        "payload_version=%r expected=%d subject=%s",
+        envelope_name,
+        raw_version,
+        expected,
+        subject or "<unknown>",
+    )
+
+
+def _reset_log_state() -> None:
+    """Clear the module-level rate-limit state (test helper)."""
+    _last_log_ts.clear()

--- a/src/voicecli/nats/base.py
+++ b/src/voicecli/nats/base.py
@@ -1,0 +1,192 @@
+"""NatsAdapterBase — lifecycle host for voiceCLI NATS request-reply adapters."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import signal
+import socket
+import time
+
+from nats.aio.client import Client as NATS  # type: ignore[import-untyped]
+from nats.aio.msg import Msg  # type: ignore[import-untyped]
+
+from voicecli.nats.connect import nats_connect
+from voicecli.nats.nvml import read_vram
+from voicecli.nats.reply import CONTRACT_VERSION, build_reply, encode_reply
+
+log = logging.getLogger(__name__)
+
+
+class DrainTimeoutError(RuntimeError):
+    """Raised when active requests do not drain within drain_timeout seconds."""
+
+
+class NatsAdapterBase:
+    def __init__(
+        self,
+        *,
+        subject: str,
+        queue_group: str,
+        heartbeat_subject: str,
+        service: str,
+        worker_id: str,
+        heartbeat_interval: float = 5.0,
+        drain_timeout: float = 30.0,
+    ) -> None:
+        self.subject = subject
+        self.queue_group = queue_group
+        self.heartbeat_subject = heartbeat_subject
+        self.service = service
+        self.worker_id = worker_id
+        self.heartbeat_interval = heartbeat_interval
+        self.drain_timeout = drain_timeout
+        self._nc: NATS | None = None
+        self._active_requests: int = 0
+        self.model_loaded: str | None = None
+        self._contract_version_warned: bool = False
+
+    async def run(self, nats_url: str, stop: asyncio.Event | None = None) -> None:
+        nc = await nats_connect(nats_url)
+        self._nc = nc
+
+        # voicecli satellites do NOT probe lyra hub readiness — the satellite
+        # owns its own lifecycle and trusts NATS reconnect to handle hub flakes.
+
+        sub = await nc.subscribe(self.subject, queue=self.queue_group, cb=self._dispatch)
+        hb_sub = await nc.subscribe(self.heartbeat_subject, cb=self._noop_cb)
+
+        if stop is None:
+            stop = asyncio.Event()
+            loop = asyncio.get_running_loop()
+            try:
+                for sig in (signal.SIGTERM, signal.SIGINT):
+                    loop.add_signal_handler(sig, stop.set)
+            except NotImplementedError:
+                # Windows fallback
+                def _make_handler(ev: asyncio.Event):
+                    def _handler(signum, frame):  # noqa: ARG001
+                        ev.set()
+
+                    return _handler
+
+                for sig in (signal.SIGTERM, signal.SIGINT):
+                    signal.signal(sig, _make_handler(stop))
+
+        hb_task = asyncio.create_task(self._heartbeat_loop(stop))
+
+        await stop.wait()
+
+        # Unsubscribe both subjects
+        with contextlib.suppress(Exception):
+            await sub.unsubscribe()
+        with contextlib.suppress(Exception):
+            await hb_sub.unsubscribe()
+
+        # Wait for active requests to drain
+        deadline = time.monotonic() + self.drain_timeout
+        timed_out = False
+        while self._active_requests > 0:
+            if time.monotonic() >= deadline:
+                timed_out = True
+                break
+            await asyncio.sleep(0.05)
+
+        # Final heartbeat
+        try:
+            final = self.heartbeat_payload()
+            final["model_loaded"] = None
+            final["active_requests"] = 0
+            if nc.is_connected:
+                await self._nats_publish(self.heartbeat_subject, json.dumps(final).encode())
+        except Exception:
+            log.warning("base: final heartbeat publish failed", exc_info=True)
+
+        hb_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await hb_task
+
+        with contextlib.suppress(Exception):
+            await nc.drain()
+        with contextlib.suppress(Exception):
+            await nc.close()
+
+        if timed_out:
+            raise DrainTimeoutError(f"Active requests did not drain within {self.drain_timeout}s")
+
+    async def _noop_cb(self, msg: Msg) -> None:
+        pass
+
+    async def _nats_publish(self, subject: str, data: bytes) -> None:
+        """Indirection for tests to intercept all outgoing publishes."""
+        if self._nc is not None:
+            await self._nc.publish(subject, data)
+
+    async def handle(self, msg: Msg, payload: dict) -> dict:
+        raise NotImplementedError
+
+    async def reply(self, msg: Msg, payload: dict) -> None:
+        """Encode payload and respond to msg."""
+        data = encode_reply(payload)
+        await msg.respond(data)
+
+    def heartbeat_payload(self) -> dict:
+        vram_used, vram_total = read_vram()
+        return {
+            "contract_version": CONTRACT_VERSION,
+            "worker_id": self.worker_id,
+            "service": self.service,
+            "host": socket.gethostname(),
+            "subject": self.subject,
+            "queue_group": self.queue_group,
+            "ts": time.time(),
+            "model_loaded": self.model_loaded,
+            "vram_used_mb": vram_used,
+            "vram_total_mb": vram_total,
+            "active_requests": self._active_requests,
+        }
+
+    async def _heartbeat_loop(self, stop: asyncio.Event) -> None:
+        while not stop.is_set():
+            try:
+                payload = self.heartbeat_payload()
+                await self._nats_publish(
+                    self.heartbeat_subject,
+                    json.dumps(payload).encode(),
+                )
+            except Exception:
+                log.warning("base: heartbeat publish failed", exc_info=True)
+            try:
+                await asyncio.wait_for(asyncio.shield(stop.wait()), timeout=self.heartbeat_interval)
+            except asyncio.TimeoutError:
+                pass
+
+    async def _dispatch(self, msg: Msg) -> None:
+        try:
+            payload = json.loads(msg.data.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            log.error("base: malformed JSON on %s", self.subject)
+            error_reply = build_reply(ok=False, request_id="", error="malformed_request")
+            with contextlib.suppress(Exception):
+                await msg.respond(encode_reply(error_reply))
+            return
+
+        if payload.get("contract_version") != CONTRACT_VERSION:
+            if not self._contract_version_warned:
+                self._contract_version_warned = True
+                log.warning(
+                    "base: unexpected contract_version %r on %s (expected %r) — continuing",
+                    payload.get("contract_version"),
+                    self.subject,
+                    CONTRACT_VERSION,
+                )
+
+        self._active_requests += 1
+        try:
+            result = await self.handle(msg, payload)
+            if result is not None:
+                await self.reply(msg, result)
+        finally:
+            self._active_requests -= 1

--- a/src/voicecli/nats/base.py
+++ b/src/voicecli/nats/base.py
@@ -9,9 +9,12 @@ import logging
 import signal
 import socket
 import time
+from pathlib import Path
+from typing import TYPE_CHECKING
 
-from nats.aio.client import Client as NATS  # type: ignore[import-untyped]
-from nats.aio.msg import Msg  # type: ignore[import-untyped]
+if TYPE_CHECKING:
+    from nats.aio.client import Client as NATS  # type: ignore[import-untyped]
+    from nats.aio.msg import Msg  # type: ignore[import-untyped]
 
 from voicecli.nats.connect import nats_connect
 from voicecli.nats.nvml import read_vram
@@ -48,8 +51,17 @@ class NatsAdapterBase:
         self.model_loaded: str | None = None
         self._contract_version_warned: bool = False
 
-    async def run(self, nats_url: str, stop: asyncio.Event | None = None) -> None:
-        nc = await nats_connect(nats_url)
+    async def run(
+        self,
+        nats_url: str,
+        stop: asyncio.Event | None = None,
+        nkey_seed_path: Path | None = None,
+    ) -> None:
+        if nkey_seed_path is not None:
+            log.info("authenticated to NATS with nkey seed at %s", nkey_seed_path)
+        else:
+            log.info("anonymous NATS connection; set NATS_NKEY_SEED_PATH to enable nkey auth")
+        nc = await nats_connect(nats_url, nkey_seed_path=nkey_seed_path)
         self._nc = nc
 
         # voicecli satellites do NOT probe lyra hub readiness — the satellite

--- a/src/voicecli/nats/connect.py
+++ b/src/voicecli/nats/connect.py
@@ -1,0 +1,149 @@
+"""NATS connection helper with optional nkey authentication and TLS."""
+
+from __future__ import annotations
+
+import logging
+import os
+import ssl
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse, urlunparse
+
+if TYPE_CHECKING:
+    from nats.aio.client import Client as NATS
+
+log = logging.getLogger(__name__)
+
+
+def _read_nkey_seed(path: Path) -> str | None:
+    """Read nkey seed from *path*.
+
+    Returns the seed string, or ``None`` if *path* is ``None``.
+    Raises ``PermissionError`` if the file has group/world access bits set —
+    the message mentions "0600" to guide the user toward the correct permission.
+    Raises ``FileNotFoundError`` if the path does not exist or is a symlink.
+
+    Security (TOCTOU): the path is opened once with ``O_NOFOLLOW`` (symlinks
+    rejected) and ``os.fstat`` inspects the live file descriptor so the
+    permission check and the read operate on the same inode. A parent-
+    directory writer cannot swap the path between stat and read.
+    """
+    import errno
+    import stat as _stat
+
+    path_str = str(path)
+    fd = -1
+    try:
+        fd = os.open(path_str, os.O_RDONLY | os.O_NOFOLLOW)
+        st = os.fstat(fd)
+        if not _stat.S_ISREG(st.st_mode):
+            raise FileNotFoundError(f"NATS nkey seed path {path_str!r} is not a file")
+        mode = st.st_mode & 0o777
+        # Reject any group/world access (0o077) — owner-only reads are safe
+        # whether they're 0o600 (rw) or 0o400 (r-only).
+        if mode & 0o077:
+            raise PermissionError(
+                f"NATS nkey seed {path_str!r} has unsafe permissions"
+                f" {oct(mode)} — use 0600 or 0400 (group/world access forbidden)"
+            )
+        with os.fdopen(fd, "r") as fh:
+            fd = -1  # fdopen takes ownership; prevent double-close below
+            seed = fh.read().strip()
+    except OSError as exc:
+        if fd != -1:
+            os.close(fd)
+        if exc.errno in (errno.ENOENT, errno.ELOOP):
+            raise FileNotFoundError(f"NATS nkey seed path {path_str!r} is not a file") from exc
+        raise
+    if not seed:
+        raise ValueError(f"NATS nkey seed {path_str!r} is empty")
+    return seed
+
+
+_RESERVED_KEYS = frozenset({"nkeys_seed_str", "token", "user", "password", "tls"})
+
+
+def _build_tls_context(ca_cert_path: str | None = None) -> ssl.SSLContext | None:
+    """Build a TLS context from *ca_cert_path* or the ``NATS_CA_CERT`` env var.
+
+    Returns ``None`` if no CA cert is configured (plain TCP / dev mode).
+    """
+    ca_path_str = ca_cert_path or os.environ.get("NATS_CA_CERT")
+    if not ca_path_str:
+        return None
+    ca_path = Path(ca_path_str)
+    if not ca_path.is_file():
+        sys.exit(f"NATS_CA_CERT={ca_path_str!r} is not a file")
+    ctx = ssl.create_default_context(cafile=str(ca_path))
+    return ctx
+
+
+def scrub_nats_url(url: str) -> str:
+    """Return *url* with any embedded credentials removed.
+
+    ``nats://user:pass@host:4222`` → ``nats://host:4222``
+    """
+    parsed = urlparse(url)
+    if not parsed.hostname:
+        return url
+    clean_netloc = parsed.hostname
+    if parsed.port:
+        clean_netloc += f":{parsed.port}"
+    return urlunparse(parsed._replace(netloc=clean_netloc))
+
+
+async def _default_error_cb(exc: Exception) -> None:
+    log.error("NATS error: %s", exc)
+
+
+async def _default_disconnected_cb() -> None:
+    log.warning("NATS disconnected")
+
+
+async def _default_reconnected_cb() -> None:
+    log.info("NATS reconnected")
+
+
+async def nats_connect(
+    url: str,
+    *,
+    nkey_seed_path: Path | None = None,
+    ca_cert_path: str | None = None,
+    **extra: Any,
+) -> "NATS":
+    """Connect to NATS, optionally authenticating with an nkey seed.
+
+    If *nkey_seed_path* is provided, reads the seed file and passes it via
+    ``nkeys_seed_str``. If omitted, connects without authentication (dev mode).
+
+    Extra keyword arguments (e.g. ``error_cb``, ``disconnected_cb``,
+    ``reconnected_cb``) are forwarded to ``nats.connect()``.
+    Auth-related keys (``nkeys_seed_str``, ``token``, ``user``, ``password``,
+    ``tls``) are rejected — authentication is owned exclusively by this helper.
+    """
+    import nats as _nats  # deferred: nats-py is an optional extra
+
+    bad = _RESERVED_KEYS & extra.keys()
+    if bad:
+        raise ValueError(f"nats_connect: reserved keys must not be passed via **extra: {bad}")
+    kwargs: dict[str, Any] = {
+        "error_cb": _default_error_cb,
+        "disconnected_cb": _default_disconnected_cb,
+        "reconnected_cb": _default_reconnected_cb,
+        **extra,
+    }
+    seed: str | None = None
+    if nkey_seed_path is not None:
+        seed = _read_nkey_seed(nkey_seed_path)
+    if seed:
+        kwargs["nkeys_seed_str"] = seed
+    tls_ctx = _build_tls_context(ca_cert_path)
+    if tls_ctx:
+        kwargs["tls"] = tls_ctx
+    nc = await _nats.connect(url, **kwargs)
+    if seed:
+        log.info("NATS nkey auth enabled")
+    if tls_ctx:
+        log.info("NATS TLS enabled")
+    return nc

--- a/src/voicecli/nats/nvml.py
+++ b/src/voicecli/nats/nvml.py
@@ -1,0 +1,34 @@
+"""Lazy pynvml probe for VRAM usage."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _import_pynvml() -> Any:
+    try:
+        import pynvml  # type: ignore[import-not-found]
+
+        return pynvml
+    except ImportError:
+        return None
+
+
+def read_vram() -> tuple[int | None, int | None]:
+    """Return (used_mb, total_mb) from device 0, or (None, None) on any failure."""
+    pynvml = _import_pynvml()
+    if pynvml is None:
+        return (None, None)
+    try:
+        pynvml.nvmlInit()
+        try:
+            handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+            info = pynvml.nvmlDeviceGetMemoryInfo(handle)
+            return (info.used // (1024**2), info.total // (1024**2))
+        finally:
+            try:
+                pynvml.nvmlShutdown()
+            except Exception:
+                pass
+    except Exception:
+        return (None, None)

--- a/src/voicecli/nats/queue_groups.py
+++ b/src/voicecli/nats/queue_groups.py
@@ -1,0 +1,14 @@
+"""Canonical NATS queue group names for voicecli's worker roles.
+
+Queue groups enforce load balancing within a role during rolling restarts so
+that no message is delivered twice to the same logical consumer. Each constant
+defines exactly one role → name mapping.
+"""
+
+from __future__ import annotations
+
+#: Queue group for TTS worker processes consuming synthesis requests.
+TTS_WORKERS = "tts-workers"
+
+#: Queue group for STT worker processes consuming transcription requests.
+STT_WORKERS = "stt-workers"

--- a/src/voicecli/nats/reply.py
+++ b/src/voicecli/nats/reply.py
@@ -1,0 +1,16 @@
+"""ADR-044 reply envelope helpers."""
+
+from __future__ import annotations
+
+import json
+
+CONTRACT_VERSION = "1"
+
+
+def build_reply(*, ok: bool, request_id: str, **fields) -> dict:
+    """ADR-044 reply envelope. Stamps contract_version + request_id; merges caller fields last."""
+    return {"contract_version": CONTRACT_VERSION, "request_id": request_id, "ok": ok, **fields}
+
+
+def encode_reply(reply: dict) -> bytes:
+    return json.dumps(reply, separators=(",", ":")).encode("utf-8")

--- a/src/voicecli/nats/tempdir.py
+++ b/src/voicecli/nats/tempdir.py
@@ -9,9 +9,17 @@ TEMP_ROOT = Path("/tmp/voicecli-nats")
 
 
 def scoped_path(request_id: str, ext: str) -> Path:
-    """Per-request unique temp path under TEMP_ROOT. Creates the parent if missing."""
+    """Per-request unique temp path under TEMP_ROOT. Creates the parent if missing.
+
+    Raises ValueError if *request_id* escapes TEMP_ROOT after path resolution
+    (defense-in-depth against path traversal).
+    """
     TEMP_ROOT.mkdir(parents=True, exist_ok=True)
-    return TEMP_ROOT / f"{request_id}.{ext.lstrip('.')}"
+    p = TEMP_ROOT.joinpath(f"{request_id}.{ext.lstrip('.')}").resolve()
+    root_resolved = TEMP_ROOT.resolve()
+    if not p.is_relative_to(root_resolved):
+        raise ValueError(f"request_id escapes temp root: {request_id!r}")
+    return p
 
 
 def cleanup(p: Path) -> None:

--- a/src/voicecli/nats/tempdir.py
+++ b/src/voicecli/nats/tempdir.py
@@ -1,0 +1,20 @@
+"""Per-request temp file management under /tmp/voicecli-nats/."""
+
+from __future__ import annotations
+
+import contextlib
+from pathlib import Path
+
+TEMP_ROOT = Path("/tmp/voicecli-nats")
+
+
+def scoped_path(request_id: str, ext: str) -> Path:
+    """Per-request unique temp path under TEMP_ROOT. Creates the parent if missing."""
+    TEMP_ROOT.mkdir(parents=True, exist_ok=True)
+    return TEMP_ROOT / f"{request_id}.{ext.lstrip('.')}"
+
+
+def cleanup(p: Path) -> None:
+    """Remove p if it exists. Idempotent — silently ignores FileNotFoundError."""
+    with contextlib.suppress(FileNotFoundError):
+        p.unlink()

--- a/src/voicecli/nats/tts_adapter.py
+++ b/src/voicecli/nats/tts_adapter.py
@@ -1,0 +1,160 @@
+"""TtsNatsAdapter — voicecli NATS satellite for TTS synthesis requests."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import functools
+import logging
+import os
+import socket
+import time
+import wave
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+from voicecli.nats.base import NatsAdapterBase
+from voicecli.nats.queue_groups import TTS_WORKERS
+from voicecli.nats.reply import build_reply
+from voicecli.nats.tempdir import cleanup, scoped_path
+
+# voicecli.api is NOT imported at module level — deferred to keep startup fast
+# and avoid pulling torch when only inspecting the adapter (e.g. for --help).
+
+log = logging.getLogger(__name__)
+
+DEFAULT_ENGINE = "qwen-fast"
+SUBJECT = "lyra.voice.tts.request"
+HEARTBEAT_SUBJECT = "lyra.voice.tts.heartbeat"
+
+
+def _resolve_engine(cli_value: str | None = None) -> str:
+    """Resolve TTS engine: CLI arg > VOICECLI_ENGINE > LYRA_TTS_ENGINE > voicecli.toml > DEFAULT_ENGINE."""
+    if cli_value:
+        return cli_value
+    for env_var in ("VOICECLI_ENGINE", "LYRA_TTS_ENGINE"):
+        v = os.environ.get(env_var)
+        if v:
+            return v
+    try:
+        from voicecli.config import load_config
+
+        cfg = load_config()
+        toml_engine = cfg.get("defaults", {}).get("engine")
+        if toml_engine:
+            return toml_engine
+    except Exception:
+        pass
+    return DEFAULT_ENGINE
+
+
+def _engine_available(engine: str) -> bool:
+    from voicecli.engine import _get_registry
+
+    return engine in _get_registry()
+
+
+def _wav_duration_ms(path: Path) -> int:
+    """Read WAV header to compute duration in milliseconds. Returns 0 on failure."""
+    try:
+        with wave.open(str(path), "rb") as wf:
+            frames = wf.getnframes()
+            rate = wf.getframerate()
+            if rate > 0:
+                return int(frames / rate * 1000)
+    except Exception:
+        pass
+    return 0
+
+
+class TtsNatsAdapter(NatsAdapterBase):
+    def __init__(
+        self,
+        *,
+        default_engine: str,
+        max_concurrent: int = 1,
+        reject_when_full: bool = False,
+        heartbeat_interval: float = 5.0,
+        drain_timeout: float = 30.0,
+    ) -> None:
+        worker_id = f"tts-{socket.gethostname()}-{os.getpid()}-{int(time.time())}"
+        super().__init__(
+            subject=SUBJECT,
+            queue_group=TTS_WORKERS,
+            heartbeat_subject=HEARTBEAT_SUBJECT,
+            service="tts_workers",
+            worker_id=worker_id,
+            heartbeat_interval=heartbeat_interval,
+            drain_timeout=drain_timeout,
+        )
+        self.default_engine = default_engine
+        self.max_concurrent = max_concurrent
+        self.reject_when_full = reject_when_full
+        self._sem = asyncio.Semaphore(max_concurrent)
+        self._executor = ThreadPoolExecutor(max_workers=max_concurrent)
+
+    async def handle(self, msg: Any, payload: dict) -> None:  # type: ignore[override]
+        request_id = payload.get("request_id", "")
+        if not request_id:
+            await self.reply(msg, build_reply(ok=False, request_id="", error="malformed_request"))
+            return
+
+        engine = payload.get("engine") or self.default_engine
+        if not _engine_available(engine):
+            await self.reply(
+                msg, build_reply(ok=False, request_id=request_id, error="engine_unavailable")
+            )
+            return
+
+        if self.reject_when_full and self._sem.locked():
+            await self.reply(
+                msg, build_reply(ok=False, request_id=request_id, error="capacity_exceeded")
+            )
+            return
+
+        async with self._sem:
+            out_path = scoped_path(request_id, "wav")
+            try:
+                self.model_loaded = engine
+                from voicecli import api
+
+                optional_kwargs = {
+                    k: v
+                    for k, v in {
+                        "language": payload.get("language"),
+                        "voice": payload.get("voice"),
+                        "speed": payload.get("speed"),
+                        "exaggeration": payload.get("exaggeration"),
+                        "cfg_weight": payload.get("cfg_weight"),
+                    }.items()
+                    if v is not None
+                }
+                fn = functools.partial(
+                    api.generate,
+                    payload["text"],
+                    engine=engine,
+                    output=out_path,
+                    **optional_kwargs,
+                )
+                loop = asyncio.get_running_loop()
+                await loop.run_in_executor(self._executor, fn)
+                audio_b64 = base64.b64encode(out_path.read_bytes()).decode("ascii")
+                duration_ms = _wav_duration_ms(out_path)
+                await self.reply(
+                    msg,
+                    build_reply(
+                        ok=True,
+                        request_id=request_id,
+                        audio_b64=audio_b64,
+                        mime_type="audio/wav",
+                        duration_ms=duration_ms,
+                    ),
+                )
+            except Exception:
+                log.exception("synthesis_failed", extra={"request_id": request_id})
+                await self.reply(
+                    msg, build_reply(ok=False, request_id=request_id, error="synthesis_failed")
+                )
+            finally:
+                cleanup(out_path)

--- a/src/voicecli/nats/tts_adapter.py
+++ b/src/voicecli/nats/tts_adapter.py
@@ -7,6 +7,7 @@ import base64
 import functools
 import logging
 import os
+import re
 import socket
 import time
 import wave
@@ -100,6 +101,26 @@ class TtsNatsAdapter(NatsAdapterBase):
             await self.reply(msg, build_reply(ok=False, request_id="", error="malformed_request"))
             return
 
+        # Reject path-traversal or oversized request IDs at ingestion (Fix 2)
+        if not re.match(r"^[A-Za-z0-9_-]{1,128}$", request_id):
+            await self.reply(
+                msg,
+                build_reply(
+                    ok=False,
+                    request_id=request_id[:64] if request_id else "",
+                    error="malformed_request",
+                ),
+            )
+            return
+
+        # Validate text field early to avoid KeyError being masked as synthesis_failed (Fix 8)
+        text = payload.get("text")
+        if not text or not isinstance(text, str):
+            await self.reply(
+                msg, build_reply(ok=False, request_id=request_id, error="malformed_request")
+            )
+            return
+
         engine = payload.get("engine") or self.default_engine
         if not _engine_available(engine):
             await self.reply(
@@ -107,54 +128,67 @@ class TtsNatsAdapter(NatsAdapterBase):
             )
             return
 
-        if self.reject_when_full and self._sem.locked():
-            await self.reply(
-                msg, build_reply(ok=False, request_id=request_id, error="capacity_exceeded")
-            )
-            return
-
-        async with self._sem:
-            out_path = scoped_path(request_id, "wav")
+        if self.reject_when_full:
+            # Non-blocking acquire: avoid the race in _sem.locked() (Fix 7)
             try:
-                self.model_loaded = engine
-                from voicecli import api
-
-                optional_kwargs = {
-                    k: v
-                    for k, v in {
-                        "language": payload.get("language"),
-                        "voice": payload.get("voice"),
-                        "speed": payload.get("speed"),
-                        "exaggeration": payload.get("exaggeration"),
-                        "cfg_weight": payload.get("cfg_weight"),
-                    }.items()
-                    if v is not None
-                }
-                fn = functools.partial(
-                    api.generate,
-                    payload["text"],
-                    engine=engine,
-                    output=out_path,
-                    **optional_kwargs,
-                )
-                loop = asyncio.get_running_loop()
-                await loop.run_in_executor(self._executor, fn)
-                audio_b64 = base64.b64encode(out_path.read_bytes()).decode("ascii")
-                duration_ms = _wav_duration_ms(out_path)
+                await asyncio.wait_for(self._sem.acquire(), timeout=0)
+            except asyncio.TimeoutError:
                 await self.reply(
-                    msg,
-                    build_reply(
-                        ok=True,
-                        request_id=request_id,
-                        audio_b64=audio_b64,
-                        mime_type="audio/wav",
-                        duration_ms=duration_ms,
-                    ),
+                    msg, build_reply(ok=False, request_id=request_id, error="capacity_exceeded")
                 )
-            except Exception:
-                log.exception("synthesis_failed", extra={"request_id": request_id})
-                await self.reply(
-                    msg, build_reply(ok=False, request_id=request_id, error="synthesis_failed")
-                )
+                return
+            try:
+                await self._run_synthesis(msg, payload, request_id, text, engine)
             finally:
-                cleanup(out_path)
+                self._sem.release()
+        else:
+            async with self._sem:
+                await self._run_synthesis(msg, payload, request_id, text, engine)
+
+    async def _run_synthesis(
+        self, msg: Any, payload: dict, request_id: str, text: str, engine: str
+    ) -> None:
+        out_path = scoped_path(request_id, "wav")
+        try:
+            self.model_loaded = engine
+            from voicecli import api
+
+            optional_kwargs = {
+                k: v
+                for k, v in {
+                    "language": payload.get("language"),
+                    "voice": payload.get("voice"),
+                    "speed": payload.get("speed"),
+                    "exaggeration": payload.get("exaggeration"),
+                    "cfg_weight": payload.get("cfg_weight"),
+                }.items()
+                if v is not None
+            }
+            fn = functools.partial(
+                api.generate,
+                text,
+                engine=engine,
+                output=out_path,
+                **optional_kwargs,
+            )
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(self._executor, fn)
+            audio_b64 = base64.b64encode(out_path.read_bytes()).decode("ascii")
+            duration_ms = _wav_duration_ms(out_path)
+            await self.reply(
+                msg,
+                build_reply(
+                    ok=True,
+                    request_id=request_id,
+                    audio_b64=audio_b64,
+                    mime_type="audio/wav",
+                    duration_ms=duration_ms,
+                ),
+            )
+        except Exception:
+            log.exception("synthesis_failed", extra={"request_id": request_id})
+            await self.reply(
+                msg, build_reply(ok=False, request_id=request_id, error="synthesis_failed")
+            )
+        finally:
+            cleanup(out_path)

--- a/tests/nats/test_connect.py
+++ b/tests/nats/test_connect.py
@@ -1,0 +1,51 @@
+"""RED-phase tests for voicecli.nats.connect._read_nkey_seed (issue #42).
+
+These tests FAIL until the voicecli.nats package is implemented.
+They define the contract for _read_nkey_seed(path: Path) -> KeyPair-like object.
+
+Note: unlike the lyra port which reads from an env var, voicecli's version
+accepts an explicit Path so it integrates cleanly with the CLI option pattern.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from voicecli.nats.connect import _read_nkey_seed
+
+
+class TestReadNkeySeed:
+    def test_nkey_seed_permission_check(self, tmp_path: Path) -> None:
+        """_read_nkey_seed raises PermissionError for group/world-readable files.
+
+        A seed file at mode 0644 (group+world read) must be rejected with a
+        PermissionError whose message mentions "0600" to guide the user toward
+        the correct permission.
+        """
+        # Arrange
+        seed_file = tmp_path / "nkey.seed"
+        seed_file.write_text("SUAXXX123")
+        seed_file.chmod(0o644)
+
+        # Act + Assert
+        with pytest.raises(PermissionError, match="0600"):
+            _read_nkey_seed(seed_file)
+
+    def test_nkey_seed_loads_with_correct_perms(self, tmp_path: Path) -> None:
+        """_read_nkey_seed returns a non-None KeyPair-like object for a 0600 seed file.
+
+        A seed file starting with 'SUA' at mode 0600 is a valid nkey user seed.
+        The returned object must be non-None (KeyPair or equivalent).
+        """
+        # Arrange
+        seed_file = tmp_path / "nkey.seed"
+        seed_file.write_text("SUAXXX123FAKESEEDFORTEST")
+        seed_file.chmod(0o600)
+
+        # Act
+        result = _read_nkey_seed(seed_file)
+
+        # Assert
+        assert result is not None

--- a/tests/nats/test_connect.py
+++ b/tests/nats/test_connect.py
@@ -17,27 +17,94 @@ from voicecli.nats.connect import _read_nkey_seed
 
 
 class TestNkeyEnvVarResolution:
-    def test_nats_nkey_seed_path_env_var_resolved_to_path(
+    """Exercise the real CLI seam end-to-end via typer.testing.CliRunner.
+
+    These tests drive `voicecli nats-serve tts` and patch `TtsNatsAdapter.run`
+    to capture the kwargs the CLI passes in. A regression where the CLI stops
+    reading NATS_NKEY_SEED_PATH, or forgets to forward it to adapter.run(),
+    will fail these tests.
+    """
+
+    def test_cli_forwards_nkey_seed_path_from_env_var(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """NATS_NKEY_SEED_PATH env var is converted to a Path and expanduser'd.
+        from unittest.mock import AsyncMock, patch
 
-        This tests the CLI-level resolver logic in isolation: given the env var,
-        the path object must point at the expected location.
-        """
-        import os
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
 
         seed_file = tmp_path / "test.seed"
         seed_file.write_text("SUAXXX123FAKESEEDFORTEST")
         seed_file.chmod(0o600)
+        monkeypatch.setenv("NATS_URL", "nats://localhost:4222")
         monkeypatch.setenv("NATS_NKEY_SEED_PATH", str(seed_file))
 
-        # Replicate the resolution logic from cli.py nats_serve_tts
-        nkey_seed_env = os.environ.get("NATS_NKEY_SEED_PATH")
-        assert nkey_seed_env is not None
-        resolved = Path(nkey_seed_env).expanduser()
-        assert resolved == seed_file
-        assert resolved.exists()
+        with (
+            patch("voicecli.cli._probe_socket_daemon", return_value="absent"),
+            patch(
+                "voicecli.nats.tts_adapter.TtsNatsAdapter.run",
+                new_callable=AsyncMock,
+            ) as mock_run,
+            patch("voicecli.nats.tts_adapter._engine_available", return_value=True),
+        ):
+            result = CliRunner().invoke(app, ["nats-serve", "tts", "--engine", "qwen-fast"])
+
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_count == 1
+        assert mock_run.call_args.kwargs["nkey_seed_path"] == seed_file
+
+    def test_cli_passes_none_when_env_var_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        monkeypatch.setenv("NATS_URL", "nats://localhost:4222")
+        monkeypatch.delenv("NATS_NKEY_SEED_PATH", raising=False)
+
+        with (
+            patch("voicecli.cli._probe_socket_daemon", return_value="absent"),
+            patch(
+                "voicecli.nats.tts_adapter.TtsNatsAdapter.run",
+                new_callable=AsyncMock,
+            ) as mock_run,
+            patch("voicecli.nats.tts_adapter._engine_available", return_value=True),
+        ):
+            result = CliRunner().invoke(app, ["nats-serve", "tts", "--engine", "qwen-fast"])
+
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_args.kwargs["nkey_seed_path"] is None
+
+    def test_cli_expands_tilde_in_seed_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        seed_file = tmp_path / "tilde.seed"
+        seed_file.write_text("SUAXXX123FAKESEEDFORTEST")
+        seed_file.chmod(0o600)
+        monkeypatch.setenv("NATS_URL", "nats://localhost:4222")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("NATS_NKEY_SEED_PATH", "~/tilde.seed")
+
+        with (
+            patch("voicecli.cli._probe_socket_daemon", return_value="absent"),
+            patch(
+                "voicecli.nats.tts_adapter.TtsNatsAdapter.run",
+                new_callable=AsyncMock,
+            ) as mock_run,
+            patch("voicecli.nats.tts_adapter._engine_available", return_value=True),
+        ):
+            result = CliRunner().invoke(app, ["nats-serve", "tts", "--engine", "qwen-fast"])
+
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_args.kwargs["nkey_seed_path"] == seed_file
 
 
 class TestReadNkeySeed:

--- a/tests/nats/test_connect.py
+++ b/tests/nats/test_connect.py
@@ -16,6 +16,30 @@ import pytest
 from voicecli.nats.connect import _read_nkey_seed
 
 
+class TestNkeyEnvVarResolution:
+    def test_nats_nkey_seed_path_env_var_resolved_to_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """NATS_NKEY_SEED_PATH env var is converted to a Path and expanduser'd.
+
+        This tests the CLI-level resolver logic in isolation: given the env var,
+        the path object must point at the expected location.
+        """
+        import os
+
+        seed_file = tmp_path / "test.seed"
+        seed_file.write_text("SUAXXX123FAKESEEDFORTEST")
+        seed_file.chmod(0o600)
+        monkeypatch.setenv("NATS_NKEY_SEED_PATH", str(seed_file))
+
+        # Replicate the resolution logic from cli.py nats_serve_tts
+        nkey_seed_env = os.environ.get("NATS_NKEY_SEED_PATH")
+        assert nkey_seed_env is not None
+        resolved = Path(nkey_seed_env).expanduser()
+        assert resolved == seed_file
+        assert resolved.exists()
+
+
 class TestReadNkeySeed:
     def test_nkey_seed_permission_check(self, tmp_path: Path) -> None:
         """_read_nkey_seed raises PermissionError for group/world-readable files.

--- a/tests/nats/test_nvml.py
+++ b/tests/nats/test_nvml.py
@@ -1,0 +1,51 @@
+"""RED-phase tests for voicecli.nats.nvml.read_vram (issue #42).
+
+These tests FAIL until voicecli.nats.nvml is implemented.
+They define the contract: read_vram() must degrade gracefully when pynvml
+is absent or fails to initialise, returning (None, None) in both cases.
+"""
+
+from __future__ import annotations
+
+from types import ModuleType
+from typing import Any
+
+from voicecli.nats.nvml import read_vram
+
+
+class TestReadVram:
+    def test_read_vram_returns_nulls_when_pynvml_missing(
+        self, monkeypatch: Any
+    ) -> None:
+        """read_vram returns (None, None) when _import_pynvml returns None.
+
+        Simulates the pynvml package being absent from the environment.
+        """
+        # Arrange
+        monkeypatch.setattr("voicecli.nats.nvml._import_pynvml", lambda: None)
+
+        # Act
+        result = read_vram()
+
+        # Assert
+        assert result == (None, None)
+
+    def test_read_vram_returns_nulls_on_init_error(self, monkeypatch: Any) -> None:
+        """read_vram returns (None, None) when nvmlInit raises any exception.
+
+        Simulates a driver not found or incompatible NVML scenario.
+        """
+        # Arrange
+        def _raise_on_init() -> None:
+            raise RuntimeError("NVML driver not loaded")
+
+        fake_nvml = ModuleType("pynvml")
+        fake_nvml.nvmlInit = _raise_on_init  # type: ignore[attr-defined]
+
+        monkeypatch.setattr("voicecli.nats.nvml._import_pynvml", lambda: fake_nvml)
+
+        # Act
+        result = read_vram()
+
+        # Assert
+        assert result == (None, None)

--- a/tests/nats/test_nvml.py
+++ b/tests/nats/test_nvml.py
@@ -14,9 +14,7 @@ from voicecli.nats.nvml import read_vram
 
 
 class TestReadVram:
-    def test_read_vram_returns_nulls_when_pynvml_missing(
-        self, monkeypatch: Any
-    ) -> None:
+    def test_read_vram_returns_nulls_when_pynvml_missing(self, monkeypatch: Any) -> None:
         """read_vram returns (None, None) when _import_pynvml returns None.
 
         Simulates the pynvml package being absent from the environment.
@@ -35,6 +33,7 @@ class TestReadVram:
 
         Simulates a driver not found or incompatible NVML scenario.
         """
+
         # Arrange
         def _raise_on_init() -> None:
             raise RuntimeError("NVML driver not loaded")

--- a/tests/nats/test_reply_builder.py
+++ b/tests/nats/test_reply_builder.py
@@ -1,0 +1,46 @@
+"""RED-phase tests for voicecli.nats.reply.build_reply (issue #42).
+
+These tests FAIL until voicecli.nats.reply is implemented.
+They define the contract: every reply dict carries contract_version == "1"
+and the appropriate fields for success vs error responses.
+"""
+
+from __future__ import annotations
+
+from voicecli.nats.reply import build_reply
+
+
+class TestBuildReply:
+    def test_build_reply_stamps_contract_version_on_success(self) -> None:
+        """Success reply includes contract_version == "1" and round-trips request_id."""
+        # Arrange / Act
+        result = build_reply(
+            ok=True,
+            request_id="r-1",
+            text="hi",
+            language="en",
+            duration_seconds=0.5,
+        )
+
+        # Assert
+        assert result["contract_version"] == "1"
+        assert result["request_id"] == "r-1"
+        assert result["ok"] is True
+
+    def test_build_reply_stamps_contract_version_on_error(self) -> None:
+        """Error reply includes contract_version == "1" and the error string; no audio_b64."""
+        # Arrange / Act
+        result = build_reply(ok=False, request_id="r-1", error="model_load_failed")
+
+        # Assert
+        assert result["contract_version"] == "1"
+        assert result["error"] == "model_load_failed"
+        assert "audio_b64" not in result
+
+    def test_build_reply_handles_empty_request_id(self) -> None:
+        """build_reply preserves an empty request_id without coercing it."""
+        # Arrange / Act
+        result = build_reply(ok=False, request_id="", error="malformed_request")
+
+        # Assert
+        assert result["request_id"] == ""

--- a/tests/nats/test_tempdir.py
+++ b/tests/nats/test_tempdir.py
@@ -1,0 +1,55 @@
+"""RED-phase tests for voicecli.nats.tempdir (issue #42).
+
+These tests FAIL until voicecli.nats.tempdir is implemented.
+They define the contract for scoped_path() and cleanup():
+- scoped_path produces unique, deterministic paths under /tmp/voicecli-nats/
+- cleanup removes files silently, including missing paths
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from voicecli.nats.tempdir import cleanup, scoped_path
+
+
+class TestScopedPath:
+    def test_scoped_path_unique_per_request_id(self) -> None:
+        """Different request IDs produce different paths; filename encodes the ID."""
+        # Arrange / Act
+        path_1 = scoped_path("req-1", "wav")
+        path_2 = scoped_path("req-2", "wav")
+
+        # Assert
+        assert path_1 != path_2
+        assert path_1.name == "req-1.wav"
+
+    def test_scoped_path_under_voicecli_nats(self) -> None:
+        """scoped_path returns a path inside a voicecli-nats temp directory."""
+        # Arrange / Act
+        path = scoped_path("req-1", "wav")
+
+        # Assert
+        assert "/voicecli-nats/" in str(path)
+
+
+class TestCleanup:
+    def test_cleanup_removes_file(self, tmp_path: Path) -> None:
+        """cleanup deletes an existing file without raising."""
+        # Arrange
+        target = tmp_path / "output.wav"
+        target.write_bytes(b"RIFF")
+
+        # Act
+        cleanup(target)
+
+        # Assert
+        assert not target.exists()
+
+    def test_cleanup_does_not_raise_on_missing_file(self, tmp_path: Path) -> None:
+        """cleanup is a no-op (no exception) when the path does not exist."""
+        # Arrange
+        missing = tmp_path / "does_not_exist.wav"
+
+        # Act + Assert — must not raise
+        cleanup(missing)

--- a/tests/nats/test_tempdir.py
+++ b/tests/nats/test_tempdir.py
@@ -33,6 +33,22 @@ class TestScopedPath:
         assert "/voicecli-nats/" in str(path)
 
 
+class TestScopedPathSecurity:
+    def test_path_traversal_raises_value_error(self) -> None:
+        """scoped_path raises ValueError when request_id escapes TEMP_ROOT."""
+        import pytest
+
+        with pytest.raises(ValueError, match="escapes temp root"):
+            scoped_path("../../etc/passwd", "wav")
+
+    def test_dotdot_request_id_raises_value_error(self) -> None:
+        """request_id with .. components must be rejected."""
+        import pytest
+
+        with pytest.raises(ValueError, match="escapes temp root"):
+            scoped_path("../foo", "wav")
+
+
 class TestCleanup:
     def test_cleanup_removes_file(self, tmp_path: Path) -> None:
         """cleanup deletes an existing file without raising."""

--- a/tests/nats/test_tts_adapter.py
+++ b/tests/nats/test_tts_adapter.py
@@ -24,6 +24,7 @@ try:
     from voicecli.nats.reply import build_reply  # noqa: F401
     from voicecli.nats.tempdir import scoped_path  # noqa: F401
     from voicecli.nats.tts_adapter import TtsNatsAdapter, _resolve_engine
+
     _IMPORT_ERROR: ImportError | None = None
 except ImportError as _e:
     _IMPORT_ERROR = _e
@@ -122,7 +123,9 @@ class TestTtsNatsAdapter:
         def _patched_scoped_path(request_id: str, ext: str) -> Path:
             return tmp_path / f"{request_id}.{ext}"
 
-        with patch("voicecli.engine._get_registry", return_value={"mock": _stub_engine_factory(tmp_path)}):
+        with patch(
+            "voicecli.engine._get_registry", return_value={"mock": _stub_engine_factory(tmp_path)}
+        ):
             with patch("voicecli.nats.tts_adapter.scoped_path", side_effect=_patched_scoped_path):
                 asyncio.run(adapter.handle(msg, payload))
 
@@ -143,7 +146,9 @@ class TestTtsNatsAdapter:
         msg = MockMsg()
         payload = _valid_payload(engine="ghost-engine")
 
-        with patch("voicecli.engine._get_registry", return_value={"mock": _stub_engine_factory(tmp_path)}):
+        with patch(
+            "voicecli.engine._get_registry", return_value={"mock": _stub_engine_factory(tmp_path)}
+        ):
             asyncio.run(adapter.handle(msg, payload))
 
         # Assert
@@ -183,7 +188,9 @@ class TestTtsNatsAdapter:
         def _patched_scoped_path(rid: str, ext: str) -> Path:
             return tmp_path / f"{rid}.{ext}"
 
-        with patch("voicecli.engine._get_registry", return_value={"mock": _stub_engine_factory(tmp_path)}):
+        with patch(
+            "voicecli.engine._get_registry", return_value={"mock": _stub_engine_factory(tmp_path)}
+        ):
             with patch("voicecli.nats.tts_adapter.scoped_path", side_effect=_patched_scoped_path):
                 asyncio.run(adapter.handle(msg, payload))
 
@@ -199,7 +206,9 @@ class TestTtsNatsAdapter:
         msg = MockMsg()
         payload = {"text": "Hello", "engine": "mock"}
 
-        with patch("voicecli.engine._get_registry", return_value={"mock": _stub_engine_factory(tmp_path)}):
+        with patch(
+            "voicecli.engine._get_registry", return_value={"mock": _stub_engine_factory(tmp_path)}
+        ):
             asyncio.run(adapter.handle(msg, payload))
 
         # Assert
@@ -238,7 +247,9 @@ class TestTtsNatsAdapter:
             finally:
                 adapter._sem.release()  # type: ignore[attr-defined]
 
-        with patch("voicecli.engine._get_registry", return_value={"mock": _stub_engine_factory(tmp_path)}):
+        with patch(
+            "voicecli.engine._get_registry", return_value={"mock": _stub_engine_factory(tmp_path)}
+        ):
             asyncio.run(_run())
 
         # Assert
@@ -258,7 +269,9 @@ class TestTtsNatsAdapter:
         def _patched_scoped_path(rid: str, ext: str) -> Path:
             return tmp_path / f"{rid}.{ext}"
 
-        with patch("voicecli.engine._get_registry", return_value={"mock": _stub_engine_factory(tmp_path)}):
+        with patch(
+            "voicecli.engine._get_registry", return_value={"mock": _stub_engine_factory(tmp_path)}
+        ):
             with patch("voicecli.nats.tts_adapter.scoped_path", side_effect=_patched_scoped_path):
                 asyncio.run(adapter.handle(msg, payload))
 
@@ -318,7 +331,9 @@ class TestTtsNatsAdapter:
                 "voicecli.engine._get_registry",
                 return_value={"mock": _stub_engine_factory(tmp_path, sleep_s=1.5)},
             ):
-                with patch("voicecli.nats.tts_adapter.scoped_path", side_effect=_patched_scoped_path):
+                with patch(
+                    "voicecli.nats.tts_adapter.scoped_path", side_effect=_patched_scoped_path
+                ):
                     handle_task = asyncio.create_task(adapter.handle(msg, payload))
                     hb_task = asyncio.create_task(adapter._heartbeat_loop(stop))  # type: ignore[attr-defined]
 
@@ -343,7 +358,9 @@ class TestTtsNatsAdapter:
         # Assert
         assert resolved == "qwen-fast"
 
-    def test_lyra_tts_engine_alias_works(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_lyra_tts_engine_alias_works(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         _require_imports()
         # Arrange — LYRA_TTS_ENGINE set, VOICECLI_ENGINE absent
         monkeypatch.setenv("LYRA_TTS_ENGINE", "qwen")

--- a/tests/nats/test_tts_adapter.py
+++ b/tests/nats/test_tts_adapter.py
@@ -346,6 +346,62 @@ class TestTtsNatsAdapter:
         # Assert — heartbeat fired at least once during the inference window
         assert len(heartbeat_calls) >= 1
 
+    def test_path_traversal_request_id_returns_malformed_request(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange — request_id contains path traversal
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload(request_id="../escape")
+
+        with patch(
+            "voicecli.engine._get_registry", return_value={"mock": _stub_engine_factory(tmp_path)}
+        ):
+            asyncio.run(adapter.handle(msg, payload))
+
+        # Assert
+        reply = msg.last_reply()
+        assert reply["ok"] is False
+        assert reply["error"] == "malformed_request"
+
+    def test_missing_text_returns_malformed_request(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange — no text in payload
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        payload = {"contract_version": "1", "request_id": "req-notext", "engine": "mock"}
+
+        with patch(
+            "voicecli.engine._get_registry", return_value={"mock": _stub_engine_factory(tmp_path)}
+        ):
+            asyncio.run(adapter.handle(msg, payload))
+
+        # Assert
+        reply = msg.last_reply()
+        assert reply["ok"] is False
+        assert reply["error"] == "malformed_request"
+
+    def test_non_string_text_returns_malformed_request(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange — text is not a string
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        payload = {
+            "contract_version": "1",
+            "request_id": "req-badtext",
+            "text": 42,
+            "engine": "mock",
+        }
+
+        with patch(
+            "voicecli.engine._get_registry", return_value={"mock": _stub_engine_factory(tmp_path)}
+        ):
+            asyncio.run(adapter.handle(msg, payload))
+
+        # Assert
+        reply = msg.last_reply()
+        assert reply["ok"] is False
+        assert reply["error"] == "malformed_request"
+
     def test_engine_env_var_fallback(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         _require_imports()
         # Arrange

--- a/tests/nats/test_tts_adapter.py
+++ b/tests/nats/test_tts_adapter.py
@@ -1,0 +1,356 @@
+"""RED-phase tests for TtsNatsAdapter (issue #42 T6).
+
+All 12 cases FAIL until voicecli.nats.tts_adapter is implemented.
+The top-level imports are wrapped so pytest --collect-only works even before
+the voicecli.nats package exists; individual tests will fail on ImportError.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Lazy import shim — lets --collect-only succeed in RED phase
+# ---------------------------------------------------------------------------
+
+try:
+    from voicecli.nats.reply import build_reply  # noqa: F401
+    from voicecli.nats.tempdir import scoped_path  # noqa: F401
+    from voicecli.nats.tts_adapter import TtsNatsAdapter, _resolve_engine
+    _IMPORT_ERROR: ImportError | None = None
+except ImportError as _e:
+    _IMPORT_ERROR = _e
+    TtsNatsAdapter = None  # type: ignore[assignment,misc]
+    _resolve_engine = None  # type: ignore[assignment]
+    build_reply = None  # type: ignore[assignment]
+    scoped_path = None  # type: ignore[assignment]
+
+
+def _require_imports() -> None:
+    """Call at the top of every test; raises if the module is not yet implemented."""
+    if _IMPORT_ERROR is not None:
+        pytest.fail(f"voicecli.nats not yet implemented (RED): {_IMPORT_ERROR}")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class MockMsg:
+    """Minimal NATS message stand-in: carries .reply, records respond() calls."""
+
+    def __init__(self, reply_subject: str = "_INBOX.test") -> None:
+        self.reply = reply_subject
+        self._published: list[bytes] = []
+
+    async def respond(self, data: bytes) -> None:
+        self._published.append(data)
+
+    def last_reply(self) -> dict:
+        assert self._published, "No reply published"
+        return json.loads(self._published[-1])
+
+
+def _valid_payload(
+    *,
+    request_id: str = "req-001",
+    text: str = "Hello world",
+    engine: str = "mock",
+    contract_version: str = "1",
+) -> dict:
+    return {
+        "contract_version": contract_version,
+        "request_id": request_id,
+        "text": text,
+        "engine": engine,
+    }
+
+
+def _stub_engine_factory(
+    tmp_path: Path,
+    *,
+    raises: Exception | None = None,
+    sleep_s: float = 0.0,
+):
+    """Return a class (not instance) for injection into the engine registry.
+
+    generate() writes a 1-byte WAV stub, or raises/sleeps per kwargs.
+    """
+
+    class _FakeEngine:
+        name = "mock"
+
+        def generate(self, text: str, voice, output_path: Path, **kwargs) -> Path:
+            if sleep_s:
+                time.sleep(sleep_s)
+            if raises:
+                raise raises
+            output_path.write_bytes(b"\x00")
+            return output_path
+
+        def clone(self, text, ref_audio, output_path, ref_text=None, **kwargs) -> Path:
+            output_path.write_bytes(b"\x00")
+            return output_path
+
+        def list_voices(self) -> list[str]:
+            return []
+
+    return _FakeEngine
+
+
+# ---------------------------------------------------------------------------
+# Test class
+# ---------------------------------------------------------------------------
+
+
+class TestTtsNatsAdapter:
+    def test_handle_success_publishes_adr044_reply(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload(request_id="req-001")
+
+        def _patched_scoped_path(request_id: str, ext: str) -> Path:
+            return tmp_path / f"{request_id}.{ext}"
+
+        with patch("voicecli.engine._get_registry", return_value={"mock": _stub_engine_factory(tmp_path)}):
+            with patch("voicecli.nats.tts_adapter.scoped_path", side_effect=_patched_scoped_path):
+                asyncio.run(adapter.handle(msg, payload))
+
+        # Assert
+        reply = msg.last_reply()
+        assert reply["ok"] is True
+        assert reply["contract_version"] == "1"
+        assert reply["request_id"] == "req-001"
+        assert reply["mime_type"] == "audio/wav"
+        assert "audio_b64" in reply
+        base64.b64decode(reply["audio_b64"])  # must not raise
+        assert isinstance(reply.get("duration_ms"), (int, float))
+
+    def test_handle_unknown_engine_returns_engine_unavailable(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload(engine="ghost-engine")
+
+        with patch("voicecli.engine._get_registry", return_value={"mock": _stub_engine_factory(tmp_path)}):
+            asyncio.run(adapter.handle(msg, payload))
+
+        # Assert
+        reply = msg.last_reply()
+        assert reply["ok"] is False
+        assert reply["error"] == "engine_unavailable"
+
+    def test_handle_engine_raises_returns_synthesis_failed(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload(request_id="req-boom")
+
+        def _patched_scoped_path(rid: str, ext: str) -> Path:
+            return tmp_path / f"{rid}.{ext}"
+
+        with patch(
+            "voicecli.engine._get_registry",
+            return_value={"mock": _stub_engine_factory(tmp_path, raises=RuntimeError("model OOM"))},
+        ):
+            with patch("voicecli.nats.tts_adapter.scoped_path", side_effect=_patched_scoped_path):
+                asyncio.run(adapter.handle(msg, payload))
+
+        # Assert
+        reply = msg.last_reply()
+        assert reply["ok"] is False
+        assert reply["error"] == "synthesis_failed"
+
+    def test_defensive_contract_version_999_is_handled(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange — contract_version "999" must NOT short-circuit (ADR-044 defensive read).
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload(request_id="req-999", contract_version="999")
+
+        def _patched_scoped_path(rid: str, ext: str) -> Path:
+            return tmp_path / f"{rid}.{ext}"
+
+        with patch("voicecli.engine._get_registry", return_value={"mock": _stub_engine_factory(tmp_path)}):
+            with patch("voicecli.nats.tts_adapter.scoped_path", side_effect=_patched_scoped_path):
+                asyncio.run(adapter.handle(msg, payload))
+
+        # Assert — succeeds normally, reply stamps contract_version "1"
+        reply = msg.last_reply()
+        assert reply["ok"] is True
+        assert reply["contract_version"] == "1"
+
+    def test_missing_request_id_returns_malformed_request(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange — no request_id in payload
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        payload = {"text": "Hello", "engine": "mock"}
+
+        with patch("voicecli.engine._get_registry", return_value={"mock": _stub_engine_factory(tmp_path)}):
+            asyncio.run(adapter.handle(msg, payload))
+
+        # Assert
+        reply = msg.last_reply()
+        assert reply["ok"] is False
+        assert reply["error"] == "malformed_request"
+        assert reply["request_id"] == ""
+
+    def test_max_concurrent_default_is_1_for_tts(self) -> None:
+        _require_imports()
+        # Arrange + Act
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+
+        # Assert — semaphore initialized with value 1
+        sem = adapter._sem  # type: ignore[attr-defined]
+        assert isinstance(sem, asyncio.Semaphore)
+
+        async def _check() -> int:
+            return sem._value  # noqa: SLF001
+
+        value = asyncio.run(_check())
+        assert value == 1
+
+    def test_reject_when_full_returns_capacity_exceeded(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1, reject_when_full=True)
+        msg = MockMsg()
+        payload = _valid_payload(request_id="req-cap")
+
+        async def _run() -> None:
+            # Hold the semaphore to simulate an in-flight request
+            await adapter._sem.acquire()  # type: ignore[attr-defined]
+            try:
+                await adapter.handle(msg, payload)
+            finally:
+                adapter._sem.release()  # type: ignore[attr-defined]
+
+        with patch("voicecli.engine._get_registry", return_value={"mock": _stub_engine_factory(tmp_path)}):
+            asyncio.run(_run())
+
+        # Assert
+        reply = msg.last_reply()
+        assert reply["ok"] is False
+        assert reply["error"] == "capacity_exceeded"
+
+    def test_temp_file_cleaned_up_on_success(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange
+        request_id = "req-clean-ok"
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload(request_id=request_id)
+        temp_file = tmp_path / f"{request_id}.wav"
+
+        def _patched_scoped_path(rid: str, ext: str) -> Path:
+            return tmp_path / f"{rid}.{ext}"
+
+        with patch("voicecli.engine._get_registry", return_value={"mock": _stub_engine_factory(tmp_path)}):
+            with patch("voicecli.nats.tts_adapter.scoped_path", side_effect=_patched_scoped_path):
+                asyncio.run(adapter.handle(msg, payload))
+
+        # Assert — temp file removed after successful reply
+        assert not temp_file.exists()
+
+    def test_temp_file_cleaned_up_on_failure(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange
+        request_id = "req-clean-fail"
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload(request_id=request_id)
+        temp_file = tmp_path / f"{request_id}.wav"
+
+        def _patched_scoped_path(rid: str, ext: str) -> Path:
+            p = tmp_path / f"{rid}.{ext}"
+            p.write_bytes(b"\x00")  # pre-create so cleanup has something to remove
+            return p
+
+        with patch(
+            "voicecli.engine._get_registry",
+            return_value={"mock": _stub_engine_factory(tmp_path, raises=RuntimeError("kaboom"))},
+        ):
+            with patch("voicecli.nats.tts_adapter.scoped_path", side_effect=_patched_scoped_path):
+                asyncio.run(adapter.handle(msg, payload))
+
+        # Assert — temp file removed even when engine raises
+        assert not temp_file.exists()
+
+    def test_heartbeat_continues_during_inference(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange — slow engine (1.5 s); heartbeat every 0.3 s → expect ≥ 1 heartbeat
+        heartbeat_calls: list[float] = []
+
+        async def _run() -> None:
+            adapter = TtsNatsAdapter(
+                default_engine="mock",
+                max_concurrent=1,
+                heartbeat_interval=0.3,
+            )
+            msg = MockMsg()
+            payload = _valid_payload(request_id="req-hb")
+
+            async def _fake_publish(subject: str, data: bytes) -> None:
+                if "heartbeat" in subject:
+                    heartbeat_calls.append(time.monotonic())
+
+            def _patched_scoped_path(rid: str, ext: str) -> Path:
+                return tmp_path / f"{rid}.{ext}"
+
+            adapter._nats_publish = _fake_publish  # type: ignore[attr-defined]
+
+            stop = asyncio.Event()
+
+            with patch(
+                "voicecli.engine._get_registry",
+                return_value={"mock": _stub_engine_factory(tmp_path, sleep_s=1.5)},
+            ):
+                with patch("voicecli.nats.tts_adapter.scoped_path", side_effect=_patched_scoped_path):
+                    handle_task = asyncio.create_task(adapter.handle(msg, payload))
+                    hb_task = asyncio.create_task(adapter._heartbeat_loop(stop))  # type: ignore[attr-defined]
+
+                    await asyncio.wait_for(handle_task, timeout=5.0)
+                    stop.set()
+                    await asyncio.wait_for(hb_task, timeout=1.0)
+
+        asyncio.run(_run())
+
+        # Assert — heartbeat fired at least once during the inference window
+        assert len(heartbeat_calls) >= 1
+
+    def test_engine_env_var_fallback(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _require_imports()
+        # Arrange
+        monkeypatch.setenv("VOICECLI_ENGINE", "qwen-fast")
+        monkeypatch.delenv("LYRA_TTS_ENGINE", raising=False)
+
+        # Act
+        resolved = _resolve_engine()
+
+        # Assert
+        assert resolved == "qwen-fast"
+
+    def test_lyra_tts_engine_alias_works(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _require_imports()
+        # Arrange — LYRA_TTS_ENGINE set, VOICECLI_ENGINE absent
+        monkeypatch.setenv("LYRA_TTS_ENGINE", "qwen")
+        monkeypatch.delenv("VOICECLI_ENGINE", raising=False)
+
+        # Act
+        resolved = _resolve_engine()
+
+        # Assert
+        assert resolved == "qwen"

--- a/tests/nats/test_vram_guard.py
+++ b/tests/nats/test_vram_guard.py
@@ -1,0 +1,104 @@
+"""RED-phase tests for _probe_socket_daemon in voicecli.cli (issue #42).
+
+These tests FAIL until _probe_socket_daemon is implemented.
+They define the contract for the three return values:
+  "absent"  — socket path does not exist
+  "stale"   — path exists but no listener is accepting connections
+  "live"    — path exists and a listener accepts the connection
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Generator
+
+import pytest
+
+from voicecli.cli import _probe_socket_daemon
+
+
+# ---------------------------------------------------------------------------
+# Helper — minimal Unix domain socket listener
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _spawn_unix_listener(path: Path) -> Generator[None, None, None]:
+    """Bind a real AF_UNIX listener at *path*, accept one connection, then close.
+
+    The listener runs in a daemon thread so it does not block the test.  The
+    context manager yields once the socket is bound and listening so the caller
+    can probe immediately.
+    """
+    srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    srv.bind(str(path))
+    srv.listen(1)
+    srv.settimeout(2.0)
+
+    def _accept_one() -> None:
+        try:
+            conn, _ = srv.accept()
+            conn.close()
+        except OSError:
+            pass
+        finally:
+            srv.close()
+
+    t = threading.Thread(target=_accept_one, daemon=True)
+    t.start()
+    try:
+        yield
+    finally:
+        srv.close()
+        t.join(timeout=2.0)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestProbeSocketDaemon:
+    def test_probe_returns_absent_when_no_socket(self, tmp_path: Path) -> None:
+        """Returns "absent" when the socket path does not exist at all."""
+        # Arrange
+        missing = tmp_path / "missing.sock"
+
+        # Act
+        result = _probe_socket_daemon(missing)
+
+        # Assert
+        assert result == "absent"
+
+    def test_probe_returns_stale_when_econnrefused(self, tmp_path: Path) -> None:
+        """Returns "stale" when the path exists but no listener is accepting.
+
+        We use a plain regular file (not a real socket) — connecting to it
+        yields ENOTSOCK rather than ECONNREFUSED, but both represent the same
+        semantic state: a path is present yet no live daemon is behind it.
+        The implementation should treat any connection failure as "stale".
+        """
+        # Arrange
+        stale = tmp_path / "stale.sock"
+        stale.touch()  # regular file, not a socket — connect() gives ENOTSOCK
+
+        # Act
+        result = _probe_socket_daemon(stale)
+
+        # Assert
+        assert result == "stale"
+
+    def test_probe_returns_live_when_listener_accepts(self, tmp_path: Path) -> None:
+        """Returns "live" when a real AF_UNIX listener is bound and accepting."""
+        # Arrange
+        sock_path = tmp_path / "live.sock"
+
+        with _spawn_unix_listener(sock_path):
+            # Act
+            result = _probe_socket_daemon(sock_path)
+
+        # Assert
+        assert result == "live"

--- a/uv.lock
+++ b/uv.lock
@@ -970,6 +970,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nats-py"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/f8/b956c4621ba88748ed707c52e69f95b7a50c8914e750edca59a5bef84a76/nats_py-2.14.0.tar.gz", hash = "sha256:4ed02cb8e3b55c68074a063aa2687087115d805d1513297da90cb2068fb07bed", size = 120751, upload-time = "2026-02-23T22:44:58.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/39/0e87753df1072254bac190b33ed34b264f28f6aa9bea0f01b7e818071756/nats_py-2.14.0-py3-none-any.whl", hash = "sha256:4116f5d2233ce16e63c3d5538fa40a5e207f75fcf42a741773929ddf1e29d19d", size = 82259, upload-time = "2026-02-23T22:45:00.152Z" },
+]
+
+[[package]]
 name = "networkx"
 version = "3.6.1"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
@@ -977,6 +986,15 @@ sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762" },
 ]
+
+[[package]]
+name = "nkeys"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pynacl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/8d/d17254baea57fe4a7dd1ba89827d3cf0a21106988ec8971a46bfc5239b15/nkeys-0.2.1.tar.gz", hash = "sha256:3a201dcd203d8bb05ba2884d441b2c92918b2a537a10d324e73738887dde9da3", size = 10667, upload-time = "2024-09-11T06:32:09.03Z" }
 
 [[package]]
 name = "nodeenv"
@@ -1155,6 +1173,15 @@ source = { registry = "https://download.pytorch.org/whl/cu128" }
 wheels = [
     { url = "https://pypi.nvidia.com/nvidia-cusparselt-cu12/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8878dce784d0fac90131b6817b607e803c36e629ba34dc5b433471382196b6a5" },
     { url = "https://pypi.nvidia.com/nvidia-cusparselt-cu12/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623" },
+]
+
+[[package]]
+name = "nvidia-ml-py"
+version = "13.595.45"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/49/c29f6e30d8662d2e94fef17739ea7309cc76aba269922ae999e4cc07f268/nvidia_ml_py-13.595.45.tar.gz", hash = "sha256:c9f34897fe0441ff35bc8f35baf80f830a20b0f4e6ce71e0a325bc0e66acf079", size = 50780, upload-time = "2026-03-19T16:59:44.956Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/24/fc256107d23597fa33d319505ce77160fa1a2349c096d01901ffc7cb7fc4/nvidia_ml_py-13.595.45-py3-none-any.whl", hash = "sha256:b65a7977f503d56154b14d683710125ef93594adb63fbf7e559336e3318f1376", size = 51776, upload-time = "2026-03-19T16:59:43.603Z" },
 ]
 
 [[package]]
@@ -1633,6 +1660,29 @@ wheels = [
 ]
 
 [[package]]
+name = "pynacl"
+version = "1.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/7b/4845bbf88e94586ec47a432da4e9107e3fc3ce37eb412b1398630a37f7dd/pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465", size = 388458, upload-time = "2026-01-01T17:32:16.829Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/b4/e927e0653ba63b02a4ca5b4d852a8d1d678afbf69b3dbf9c4d0785ac905c/pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0", size = 800020, upload-time = "2026-01-01T17:32:18.34Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/81/d60984052df5c97b1d24365bc1e30024379b42c4edcd79d2436b1b9806f2/pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4", size = 1399174, upload-time = "2026-01-01T17:32:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f7/322f2f9915c4ef27d140101dd0ed26b479f7e6f5f183590fd32dfc48c4d3/pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87", size = 835085, upload-time = "2026-01-01T17:32:22.24Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c", size = 1437614, upload-time = "2026-01-01T17:32:23.766Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/58/fc6e649762b029315325ace1a8c6be66125e42f67416d3dbd47b69563d61/pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130", size = 818251, upload-time = "2026-01-01T17:32:25.69Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a8/b917096b1accc9acd878819a49d3d84875731a41eb665f6ebc826b1af99e/pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6", size = 1402859, upload-time = "2026-01-01T17:32:27.215Z" },
+    { url = "https://files.pythonhosted.org/packages/85/42/fe60b5f4473e12c72f977548e4028156f4d340b884c635ec6b063fe7e9a5/pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e", size = 791926, upload-time = "2026-01-01T17:32:29.314Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f9/e40e318c604259301cc091a2a63f237d9e7b424c4851cafaea4ea7c4834e/pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577", size = 1363101, upload-time = "2026-01-01T17:32:31.263Z" },
+    { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
+]
+
+[[package]]
 name = "pynput"
 version = "1.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1646,6 +1696,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f0/c3/dccf44c68225046df5324db0cc7d563a560635355b3e5f1d249468268a6f/pynput-1.8.1.tar.gz", hash = "sha256:70d7c8373ee98911004a7c938742242840a5628c004573d84ba849d4601df81e", size = 82289, upload-time = "2025-03-17T17:12:01.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/59/4f/ac3fa906ae8a375a536b12794128c5efacade9eaa917a35dfd27ce0c7400/pynput-1.8.1-py2.py3-none-any.whl", hash = "sha256:42dfcf27404459ca16ca889c8fb8ffe42a9fe54f722fd1a3e130728e59e768d2", size = 91693, upload-time = "2025-03-17T17:12:00.094Z" },
+]
+
+[[package]]
+name = "pynvml"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-ml-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/57/da7dc63a79f59e082e26a66ac02d87d69ea316b35b35b7a00d82f3ce3d2f/pynvml-13.0.1.tar.gz", hash = "sha256:1245991d9db786b4d2f277ce66869bd58f38ac654e38c9397d18f243c8f6e48f", size = 35226, upload-time = "2025-09-05T20:33:25.377Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/4a/cac76c174bb439a0c46c9a4413fcbea5c6cabfb01879f7bbdb9fdfaed76c/pynvml-13.0.1-py3-none-any.whl", hash = "sha256:e2b20e0a501eeec951e2455b7ab444759cf048e0e13a57b08049fa2775266aa8", size = 28810, upload-time = "2025-09-05T20:33:24.13Z" },
 ]
 
 [[package]]
@@ -2316,12 +2378,12 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:85ed7944655ea6fd69377692e9cbfd7bba28d99696ceae79985e7caa99cf0a95" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:1d01ffaebf64715c0f507a39463149cb19e596ff702bd4bcf862601f2881dabc" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp311-cp311-win_amd64.whl", hash = "sha256:3523fda6e2cfab2b04ae09b1424681358e508bb3faa11ceb67004113d5e7acad" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6f09cdf2415516be028ae82e6b985bcfc3eac37bc52ab401142689f6224516ca" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:628e89bd5110ced7debee2a57c69959725b7fbc64eab81a39dd70e46c7e28ba5" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:fbde8f6a9ec8c76979a0d14df21c10b9e5cab6f0d106a73ca73e2179bc597cae" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:85ed7944655ea6fd69377692e9cbfd7bba28d99696ceae79985e7caa99cf0a95" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:1d01ffaebf64715c0f507a39463149cb19e596ff702bd4bcf862601f2881dabc" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp311-cp311-win_amd64.whl", hash = "sha256:3523fda6e2cfab2b04ae09b1424681358e508bb3faa11ceb67004113d5e7acad" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6f09cdf2415516be028ae82e6b985bcfc3eac37bc52ab401142689f6224516ca" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:628e89bd5110ced7debee2a57c69959725b7fbc64eab81a39dd70e46c7e28ba5" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:fbde8f6a9ec8c76979a0d14df21c10b9e5cab6f0d106a73ca73e2179bc597cae" },
 ]
 
 [[package]]
@@ -2492,6 +2554,11 @@ dependencies = [
 hotkey = [
     { name = "pynput" },
 ]
+nats = [
+    { name = "nats-py" },
+    { name = "nkeys" },
+    { name = "pynvml" },
+]
 overlay = [
     { name = "pycairo" },
     { name = "pygobject" },
@@ -2516,10 +2583,13 @@ requires-dist = [
     { name = "faster-qwen3-tts" },
     { name = "faster-whisper", specifier = ">=1.2" },
     { name = "lameenc", specifier = ">=1.7" },
+    { name = "nats-py", marker = "extra == 'nats'", specifier = ">=2.6,<3" },
+    { name = "nkeys", marker = "extra == 'nats'", specifier = ">=0.1" },
     { name = "pyaudio", specifier = ">=0.2.14" },
     { name = "pycairo", marker = "extra == 'overlay'", specifier = ">=1.25" },
     { name = "pygobject", marker = "extra == 'overlay'", specifier = ">=3.42" },
     { name = "pynput", marker = "extra == 'hotkey'", specifier = ">=1.7" },
+    { name = "pynvml", marker = "extra == 'nats'", specifier = ">=11.5" },
     { name = "qwen-tts" },
     { name = "scipy", marker = "extra == 'voxtral'" },
     { name = "soundfile" },
@@ -2528,7 +2598,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.12" },
     { name = "voxtral-tts", extras = ["int4"], marker = "extra == 'voxtral'", git = "https://github.com/Roxabi/voxtral-tts.git?branch=main" },
 ]
-provides-extras = ["voxtral", "hotkey", "overlay"]
+provides-extras = ["voxtral", "hotkey", "overlay", "nats"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- Adds `voicecli nats-serve tts` — a NATS subscriber satellite that binds to `lyra.voice.tts.request`, replies per ADR-044, and emits ≤5s heartbeats. Implements the voicecli side of the lyra-voicecli decoupling (sibling: lyra#658 / lyra#688).
- Slice 1 of 4: TTS path only. STT, mock-engine + stub-hub E2E, and SKILL/CLAUDE.md updates land in slices 2-4.
- New optional `nats` extra (`nats-py>=2.6,<3`, `nkeys>=0.1`, `pynvml>=11.5`) — default install unchanged.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #42: feat(nats): add `voicecli nats-serve {stt,tts}` entry point | OPEN |
| Frame | [42-nats-serve-frame.mdx](artifacts/frames/42-nats-serve-frame.mdx) | Approved |
| Analysis | [42-nats-serve-analysis.mdx](artifacts/analyses/42-nats-serve-analysis.mdx) | Approved (4-reviewer pass) |
| Spec | [42-nats-serve-spec.mdx](artifacts/specs/42-nats-serve-spec.mdx) | Approved (4-reviewer pass) |
| Plan | [42-nats-serve-plan.mdx](artifacts/plans/42-nats-serve-plan.mdx) | Slice V1 — 21 micro-tasks |
| Implementation | 1 commit on `feat/42-nats-serve` | Complete |
| Verification | Lint ✅ Pyright ✅ Tests ✅ (26 new nats tests, 262/262 project) | Passed |

## Design notes

- **Concurrency:** engine call runs in `loop.run_in_executor` so the asyncio event loop keeps draining heartbeats during synthesis (5–30 s inferences). Per-mode `asyncio.Semaphore` caps in-flight requests (default 1 for TTS); `--reject-when-full` returns `capacity_exceeded` instead of queueing.
- **Defensive contract_version (ADR-044):** incoming `contract_version` is NOT validated — mismatch logs WARN once per worker and processing continues. Mirrors lyra hub's behavior tested in lyra#688 T7.
- **VRAM-sequencing guard:** startup probes `~/.local/share/voicecli/daemon.sock` via non-blocking connect. Live → exit 78. Stale (file exists, no listener) → log INFO + proceed. Bypass with `--allow-coexist` for local dev.
- **Exit codes:** 0 (clean drain) / 3 (drain timeout) / 78 (`EX_CONFIG`, live socket detected). Operator docs spell out the required supervisord stanza (`autorestart=unexpected`, `exitcodes=0,78`).
- **Env-var precedence:** CLI > `VOICECLI_*` env > `voicecli.toml` > hardcoded default. `LYRA_TTS_ENGINE` accepted as alias for `VOICECLI_ENGINE` to keep the lyra#658 S3 cutover runbook unchanged.
- **Port choice:** lyra's `NatsAdapterBase` + `connect.py` + `_validate.py` + `_version_check.py` are ported (not imported) to avoid a runtime lyra↔voicecli cycle. `wait_for_hub` is dropped — voicecli satellites own their own readiness.

## Test Plan
- [ ] `uv pip install --all-extras` succeeds; default `uv pip install .` does NOT pull `nats-py`/`nkeys`/`pynvml`
- [ ] `uv run voicecli nats-serve tts --help` renders all flags (`--engine`, `--max-concurrent`, `--reject-when-full`, `--heartbeat-interval`, `--drain-timeout`, `--allow-coexist`)
- [ ] Local: start a NATS server (`nats-server -DV`), provision an nkey seed at `0600`, run `voicecli nats-serve tts` — heartbeat visible on `lyra.voice.tts.heartbeat`
- [ ] Publish a TTS request via `nats-cli`; reply contains `ok=true`, base64-decodable `audio_b64`, `mime_type=audio/wav`, `duration_ms`, echoed `request_id`
- [ ] Start `voicecli tts-serve` first, then `voicecli nats-serve tts` — second exits 78. Add `--allow-coexist` and confirm the warning + successful start.
- [ ] Send request with `contract_version: "999"` — handled normally (defensive read)
- [ ] Send request without `request_id` — reply has `ok=false, error="malformed_request", request_id=""`
- [ ] SIGTERM during inference → in-flight request completes within 30 s → exit 0; final heartbeat carries `model_loaded=null, active_requests=0`
- [ ] Operator doc `docs/NATS-SERVE.md` reads end-to-end without referencing missing context

## Follow-ups (out of scope for this PR)

- Slice V2: `nats-serve stt` adapter
- Slice V3: `MockEngine` + docker-compose stub-hub E2E (CI gate)
- Slice V4: optional real-hub compose, SKILL.md / CLAUDE.md updates
- `pynvml` is deprecated (FutureWarning); swap to `nvidia-ml-py` in a follow-up

Closes #42

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)