### PR TITLE
feat(nats): voicecli nats-serve stt entry point (slice V2)

### DIFF
--- a/docs/NATS-SERVE.md
+++ b/docs/NATS-SERVE.md
@@ -29,8 +29,7 @@ dependency on voicecli, enabling each service to be deployed and restarted indep
 4. Load the TTS/STT engine model into VRAM.
 5. Begin accepting requests and publishing heartbeats.
 
-**Current status:** Slice 1 ships the **TTS path** (`nats-serve tts`) only.
-`nats-serve stt` is planned in a follow-up slice — do not rely on it yet.
+Both subcommands are now available: `nats-serve tts` (Slice 1) and `nats-serve stt` (Slice 2).
 
 ---
 
@@ -155,9 +154,7 @@ Key fields:
 | `startsecs=15` | GPU model load time; lower on fast NVMe + large VRAM, raise if startup OOM observed |
 | `user=lyra` | Match the user that owns the NKey seed file and log directory |
 
-**For the STT satellite** (once Slice 2 ships): mirror the block substituting `nats-serve stt`,
-queue group `stt-workers`, and the STT-specific seed path. Log file naming convention:
-`voicecli_nats_stt.{log,err}`.
+For the STT satellite stanza, see [STT — Required supervisord stanza](#stt--required-supervisord-stanza) below.
 
 ---
 
@@ -203,3 +200,144 @@ nats req lyra.voice.tts.request '{"request_id":"test-1","text":"hello","engine":
 If no reply arrives within the timeout, the satellite is either not running, not connected
 to the correct server, or stuck processing another request and `VOICECLI_REJECT_WHEN_FULL`
 is not set.
+
+---
+
+## STT satellite
+
+### CLI invocation
+
+```bash
+voicecli nats-serve stt [--model <model>]
+```
+
+Default model: `large-v3-turbo`. Override via `--model`, `VOICECLI_MODEL`, or `voicecli.toml [stt].model`.
+
+Precedence: `CLI flag > VOICECLI_MODEL env > voicecli.toml [stt].model > large-v3-turbo`
+
+### STT — environment variables
+
+All variables in the [Environment variables](#environment-variables) section apply unchanged
+(`NATS_URL`, `NATS_NKEY_SEED_PATH`, `NATS_CA_CERT`, `VOICECLI_MAX_CONCURRENT`,
+`VOICECLI_REJECT_WHEN_FULL`, `VOICECLI_HEARTBEAT_INTERVAL`, `VOICECLI_DRAIN_TIMEOUT`,
+`VOICECLI_ALLOW_COEXIST`). The one STT-specific variable is:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `VOICECLI_MODEL` | `large-v3-turbo` | STT model name passed to faster-whisper. Replaces `VOICECLI_ENGINE` (which is TTS-only). |
+
+### STT — defaults that differ from TTS
+
+| Parameter | TTS | STT | Note |
+|---|---|---|---|
+| `--engine` / `--model` | `qwen-fast` (via `VOICECLI_ENGINE`) | `large-v3-turbo` (via `VOICECLI_MODEL`) | Different flag name; STT has no engine registry |
+| `--max-concurrent` | `1` | `2` | Transcription is faster than synthesis and uses less VRAM per slot; `2` is safe on standalone-STT hosts |
+
+All other parameters (`--heartbeat-interval`, `--drain-timeout`, `--reject-when-full`, `--allow-coexist`) share the same defaults as TTS.
+
+### STT — NATS topology
+
+| Item | Value |
+|---|---|
+| Request subject | `lyra.voice.stt.request` |
+| Heartbeat subject | `lyra.voice.stt.heartbeat` |
+| Queue group | `stt-workers` |
+| Service name (heartbeat payload) | `stt_workers` |
+
+### STT — per-request language overrides
+
+The request payload may include any of the following optional fields to override language
+detection for that single request. They do NOT mutate satellite state — each request is
+independent.
+
+| Field | Type | Purpose |
+|---|---|---|
+| `language` | `string` | Force a specific language (e.g. `"en"`, `"fr"`). Skips detection entirely. |
+| `language_detection_threshold` | `float` | Minimum confidence to accept detected language (0–1). |
+| `language_detection_segments` | `int` | Number of audio segments used for detection. |
+| `language_fallback` | `string` | Language code to use when detection confidence is below threshold. |
+
+### STT — reply schema
+
+**Success:**
+
+```json
+{
+  "ok": true,
+  "contract_version": "1",
+  "request_id": "<id>",
+  "text": "<transcribed text>",
+  "language": "<detected or forced language code>",
+  "duration_seconds": 4.82
+}
+```
+
+**Failure:**
+
+```json
+{
+  "ok": false,
+  "contract_version": "1",
+  "request_id": "<id>",
+  "error": "<error_code>"
+}
+```
+
+Error codes:
+
+| Code | Cause |
+|---|---|
+| `malformed_request` | Missing or invalid `request_id`, missing `audio_b64`, or `request_id` fails format validation |
+| `audio_decode_failed` | `audio_b64` is not valid base64 |
+| `transcription_failed` | faster-whisper raised an exception during inference |
+| `model_load_failed` | Model could not be loaded into VRAM at startup |
+| `capacity_exceeded` | All semaphore slots busy and `VOICECLI_REJECT_WHEN_FULL=1` |
+| `payload_too_large` | Reply payload exceeds the NATS server `max_payload` limit |
+
+### STT — VRAM-sequencing guard
+
+Probe path: `~/.local/share/voicecli/stt-daemon.sock`
+
+Behaviour is identical to the TTS guard — see [VRAM sequencing](#vram-sequencing). A live
+STT socket daemon causes exit 78 unless `--allow-coexist` / `VOICECLI_ALLOW_COEXIST=1` is set.
+
+```bash
+make stt stop                            # stop voicecli_stt (socket daemon)
+supervisorctl start voicecli_nats_stt   # start NATS satellite
+```
+
+> **Co-located GPU warning — RTX 3080 (10 GB) and similar hosts**
+>
+> On hosts where TTS and STT satellites share a single GPU (e.g. `roxabituwer`:
+> TTS ~7.4 GB + STT ~2.2 GB = ~9.6 GB steady-state), set `VOICECLI_MAX_CONCURRENT=1`
+> on the STT satellite:
+>
+> ```ini
+> environment=...,VOICECLI_MAX_CONCURRENT="1"
+> ```
+>
+> or pass `--max-concurrent 1` on the command line. A second concurrent STT decode would
+> overflow the remaining VRAM headroom and OOM. The default `2` is intended for hosts
+> running the STT satellite standalone.
+
+### STT — Required supervisord stanza
+
+Same rules as TTS (`autorestart=unexpected`, `exitcodes=0,3,78`) — see
+[Required supervisord stanza](#required-supervisord-stanza) for rationale.
+
+```ini
+[program:voicecli_nats_stt]
+command=voicecli nats-serve stt
+environment=NATS_URL="nats://nats.internal:4222",NATS_NKEY_SEED_PATH="/home/lyra/.lyra/nkeys/voicecli-stt.seed",VOICECLI_MODEL="large-v3-turbo",VOICECLI_MAX_CONCURRENT="1"
+autorestart=unexpected
+exitcodes=0,3,78
+stopsignal=TERM
+stopwaitsecs=35
+startsecs=10
+user=lyra
+stdout_logfile=/home/lyra/.local/state/lyra/logs/voicecli_nats_stt.log
+stderr_logfile=/home/lyra/.local/state/lyra/logs/voicecli_nats_stt.err
+```
+
+`VOICECLI_MAX_CONCURRENT="1"` is set here because this example targets a co-located GPU
+host (TTS + STT on the same GPU). Remove or raise to `2` on standalone-STT hosts.

--- a/src/voicecli/api.py
+++ b/src/voicecli/api.py
@@ -959,6 +959,10 @@ def transcribe(
     model: str = "large-v3-turbo",
     language: str | None = None,
     output: str | Path | None = None,
+    language_detection_threshold: float | None = None,
+    language_detection_segments: int | None = None,
+    language_fallback: str | None = None,
+    _skip_daemon: bool = False,
 ):
     """Transcribe an audio file to text.
 
@@ -967,6 +971,10 @@ def transcribe(
         model: Whisper model name.
         language: Force language code.
         output: Save transcription text to file.
+        language_detection_threshold: Confidence threshold below which fallback language is used.
+        language_detection_segments: Number of segments to sample for language detection.
+        language_fallback: Language code to use when detection confidence is below threshold.
+        _skip_daemon: Bypass Unix-socket daemon and run inference locally (private).
 
     Returns:
         TranscriptionResult with .text, .language, .segments.
@@ -982,7 +990,15 @@ def transcribe(
     if not audio_path.exists():
         raise FileNotFoundError(f"Audio file not found: {audio_path}")
 
-    result: TranscriptionResult = _transcribe(audio_path, model=model, language=language)
+    result: TranscriptionResult = _transcribe(
+        audio_path,
+        model=model,
+        language=language,
+        language_detection_threshold=language_detection_threshold,
+        language_detection_segments=language_detection_segments,
+        language_fallback=language_fallback,
+        _skip_daemon=_skip_daemon,
+    )
 
     if output is not None:
         out_path = Path(output)

--- a/src/voicecli/cli.py
+++ b/src/voicecli/cli.py
@@ -1403,6 +1403,77 @@ def nats_serve_tts(
         raise typer.Exit(3)
 
 
+@nats_app.command("stt")
+def nats_serve_stt(
+    model: Annotated[Optional[str], typer.Option("--model", "-m", envvar="VOICECLI_MODEL")] = None,
+    max_concurrent: Annotated[
+        int, typer.Option("--max-concurrent", envvar="VOICECLI_MAX_CONCURRENT")
+    ] = 2,
+    reject_when_full: Annotated[
+        bool, typer.Option("--reject-when-full", envvar="VOICECLI_REJECT_WHEN_FULL")
+    ] = False,
+    heartbeat_interval: Annotated[
+        float, typer.Option("--heartbeat-interval", envvar="VOICECLI_HEARTBEAT_INTERVAL")
+    ] = 5.0,
+    drain_timeout: Annotated[
+        float, typer.Option("--drain-timeout", envvar="VOICECLI_DRAIN_TIMEOUT")
+    ] = 30.0,
+    allow_coexist: Annotated[
+        bool, typer.Option("--allow-coexist", envvar="VOICECLI_ALLOW_COEXIST")
+    ] = False,
+) -> None:
+    """Subscribe to lyra.voice.stt.request and reply with transcription."""
+    import asyncio
+    import logging
+    import os
+
+    from voicecli.nats.base import DrainTimeoutError
+    from voicecli.nats.stt_adapter import SttNatsAdapter, _resolve_model
+
+    logging.basicConfig(level=logging.INFO)
+    log = logging.getLogger("voicecli.nats-serve.stt")
+
+    resolved_model = _resolve_model(model)
+
+    sock_path = Path("~/.local/share/voicecli/stt-daemon.sock").expanduser()
+    state = _probe_socket_daemon(sock_path)
+    if state == "live":
+        if allow_coexist:
+            log.warning("coexisting with live socket daemon at %s", sock_path)
+        else:
+            log.error(
+                "live socket daemon at %s — refusing to start (use --allow-coexist or stop the daemon)",
+                sock_path,
+            )
+            raise typer.Exit(78)
+    elif state == "stale":
+        log.info("stale socket file at %s ignored", sock_path)
+
+    nats_url = os.environ.get("NATS_URL")
+    if not nats_url:
+        log.error("NATS_URL env var is required")
+        raise typer.Exit(2)
+
+    nkey_seed_path: Path | None = None
+    nkey_seed_env = os.environ.get("NATS_NKEY_SEED_PATH")
+    if nkey_seed_env:
+        nkey_seed_path = Path(nkey_seed_env).expanduser()
+
+    adapter = SttNatsAdapter(
+        default_model=resolved_model,
+        max_concurrent=max_concurrent,
+        reject_when_full=reject_when_full,
+        heartbeat_interval=heartbeat_interval,
+        drain_timeout=drain_timeout,
+    )
+
+    try:
+        asyncio.run(adapter.run(nats_url=nats_url, nkey_seed_path=nkey_seed_path))
+    except DrainTimeoutError:
+        log.error("drain timeout exceeded; some requests may have been dropped")
+        raise typer.Exit(3)
+
+
 @app.command()
 def emotions():
     """Show available emotion/expressiveness controls for each engine."""

--- a/src/voicecli/cli.py
+++ b/src/voicecli/cli.py
@@ -1388,6 +1388,16 @@ def nats_serve_tts(
     if nkey_seed_env:
         nkey_seed_path = Path(nkey_seed_env).expanduser()
 
+    if nkey_seed_path is not None:
+        mode = nkey_seed_path.stat().st_mode
+        if mode & 0o077:  # any group/other permission bit set
+            log.error(
+                "nkey seed file %s has unsafe permissions (mode %o); must be 0600",
+                nkey_seed_path,
+                mode & 0o777,
+            )
+            raise typer.Exit(2)
+
     adapter = TtsNatsAdapter(
         default_engine=resolved_engine,
         max_concurrent=max_concurrent,
@@ -1458,6 +1468,16 @@ def nats_serve_stt(
     nkey_seed_env = os.environ.get("NATS_NKEY_SEED_PATH")
     if nkey_seed_env:
         nkey_seed_path = Path(nkey_seed_env).expanduser()
+
+    if nkey_seed_path is not None:
+        mode = nkey_seed_path.stat().st_mode
+        if mode & 0o077:  # any group/other permission bit set
+            log.error(
+                "nkey seed file %s has unsafe permissions (mode %o); must be 0600",
+                nkey_seed_path,
+                mode & 0o777,
+            )
+            raise typer.Exit(2)
 
     adapter = SttNatsAdapter(
         default_model=resolved_model,

--- a/src/voicecli/nats/stt_adapter.py
+++ b/src/voicecli/nats/stt_adapter.py
@@ -68,10 +68,18 @@ def _duration_from_segments(segments: list[dict]) -> float:
     (silent audio or detection failure)."""
     if not segments:
         return 0.0
-    end = segments[-1].get("end", 0.0)
+    last = segments[-1]
+    if "end" not in last:
+        log.warning("segment_missing_end_key", extra={"segments_count": len(segments)})
+        return 0.0
+    end = last["end"]
     try:
         return float(end)
     except (TypeError, ValueError):
+        log.warning(
+            "segment_end_not_numeric",
+            extra={"segments_count": len(segments), "end_type": type(end).__name__},
+        )
         return 0.0
 
 
@@ -140,6 +148,27 @@ class SttNatsAdapter(NatsAdapterBase):
                 msg, build_reply(ok=False, request_id=request_id, error="malformed_request")
             )
             return
+
+        for key, expected_types in (
+            ("language", (str,)),
+            ("language_detection_threshold", (int, float)),
+            ("language_detection_segments", (int,)),
+            ("language_fallback", (str,)),
+        ):
+            val = payload.get(key)
+            if val is None:
+                continue
+            if key == "language_detection_segments" and isinstance(val, bool):
+                # bool is a subclass of int in Python; reject separately
+                await self.reply(
+                    msg, build_reply(ok=False, request_id=request_id, error="malformed_request")
+                )
+                return
+            if not isinstance(val, expected_types):
+                await self.reply(
+                    msg, build_reply(ok=False, request_id=request_id, error="malformed_request")
+                )
+                return
 
         overrides = {
             k: v

--- a/src/voicecli/nats/stt_adapter.py
+++ b/src/voicecli/nats/stt_adapter.py
@@ -25,6 +25,10 @@ log = logging.getLogger(__name__)
 
 DEFAULT_MODEL = "large-v3-turbo"
 SUBJECT = "lyra.voice.stt.request"
+
+# 25 MB base64 → ~18.75 MB decoded audio (~10 min at 8 kHz, ~2 min at 64 kHz).
+# Safety cap to prevent memory blowup from crafted or misrouted large payloads.
+MAX_AUDIO_B64_LEN = 25 * 1024 * 1024  # 25 MB
 HEARTBEAT_SUBJECT = "lyra.voice.stt.heartbeat"
 
 _MIME_TO_EXT: dict[str, str] = {
@@ -110,6 +114,7 @@ class SttNatsAdapter(NatsAdapterBase):
         self.reject_when_full = reject_when_full
         self._sem = asyncio.Semaphore(max_concurrent)
         self._executor = ThreadPoolExecutor(max_workers=max_concurrent)
+        self._model_warm: bool = False
 
     async def handle(self, msg: Any, payload: dict) -> None:  # type: ignore[override]
         request_id = payload.get("request_id", "")
@@ -175,6 +180,19 @@ class SttNatsAdapter(NatsAdapterBase):
         ext = _ext_from_mime(payload.get("mime_type"))
         out_path = scoped_path(request_id, ext)
         try:
+            # Fix #2: cap payload size before decode to prevent memory blowup
+            if len(audio_b64) > MAX_AUDIO_B64_LEN:
+                log.warning(
+                    "payload_too_large",
+                    extra={"request_id": request_id, "size": len(audio_b64)},
+                )
+                await self.reply(
+                    msg,
+                    build_reply(ok=False, request_id=request_id, error="payload_too_large"),
+                )
+                cleanup(out_path)
+                return
+
             # Decode audio bytes first — isolate bad-base64 from transcription failures
             try:
                 audio_bytes = base64.b64decode(audio_b64, validate=True)
@@ -184,11 +202,29 @@ class SttNatsAdapter(NatsAdapterBase):
                     msg,
                     build_reply(ok=False, request_id=request_id, error="audio_decode_failed"),
                 )
-                cleanup(out_path)
+                # Fix #4: remove redundant cleanup(out_path) here; finally block handles it
                 return
 
             out_path.write_bytes(audio_bytes)
-            self.model_loaded = self.default_model
+
+            # Fix #1: warm up the model once; distinguish load failures from inference failures
+            if not self._model_warm:
+                try:
+                    from voicecli.transcribe import _load_model
+
+                    loop = asyncio.get_running_loop()
+                    await loop.run_in_executor(self._executor, _load_model, self.default_model)
+                    self._model_warm = True
+                    # Fix #3: set model_loaded only after the model is actually warm
+                    self.model_loaded = self.default_model
+                except Exception:
+                    log.exception("model_load_failed", extra={"request_id": request_id})
+                    await self.reply(
+                        msg,
+                        build_reply(ok=False, request_id=request_id, error="model_load_failed"),
+                    )
+                    return
+
             from voicecli import api
 
             fn = functools.partial(

--- a/src/voicecli/nats/stt_adapter.py
+++ b/src/voicecli/nats/stt_adapter.py
@@ -1,0 +1,221 @@
+"""SttNatsAdapter — voicecli NATS satellite for STT transcription requests."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import functools
+import logging
+import os
+import re
+import socket
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+from voicecli.nats.base import NatsAdapterBase
+from voicecli.nats.queue_groups import STT_WORKERS
+from voicecli.nats.reply import build_reply
+from voicecli.nats.tempdir import cleanup, scoped_path
+
+# voicecli.api is NOT imported at module level — deferred to keep startup fast
+# and avoid pulling torch/faster-whisper when only inspecting the adapter (e.g. --help).
+
+log = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "large-v3-turbo"
+SUBJECT = "lyra.voice.stt.request"
+HEARTBEAT_SUBJECT = "lyra.voice.stt.heartbeat"
+
+_MIME_TO_EXT: dict[str, str] = {
+    "audio/wav": "wav",
+    "audio/x-wav": "wav",
+    "audio/mp3": "mp3",
+    "audio/mpeg": "mp3",
+    "audio/ogg": "ogg",
+    "audio/flac": "flac",
+    "audio/webm": "webm",
+}
+
+
+def _resolve_model(cli_value: str | None = None) -> str:
+    """Resolve STT model: CLI arg > VOICECLI_MODEL env > voicecli.toml [stt].model > DEFAULT_MODEL."""
+    if cli_value:
+        return cli_value
+    v = os.environ.get("VOICECLI_MODEL")
+    if v:
+        return v
+    try:
+        from voicecli.config import load_config
+
+        cfg = load_config()
+        toml_model = cfg.get("stt", {}).get("model")
+        if toml_model:
+            return toml_model
+    except Exception:
+        pass
+    return DEFAULT_MODEL
+
+
+def _duration_from_segments(segments: list[dict]) -> float:
+    """Compute duration in seconds from whisper segment timestamps.
+
+    Returns the `end` timestamp of the last segment, or 0.0 if no segments
+    (silent audio or detection failure)."""
+    if not segments:
+        return 0.0
+    end = segments[-1].get("end", 0.0)
+    try:
+        return float(end)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _ext_from_mime(mime_type: str | None) -> str:
+    """Derive file extension from mime_type.
+
+    Default 'wav'. Known mappings:
+      audio/wav → wav, audio/x-wav → wav,
+      audio/mp3 → mp3, audio/mpeg → mp3,
+      audio/ogg → ogg, audio/flac → flac, audio/webm → webm.
+    Unknown/None → 'wav'.
+    """
+    if mime_type is None:
+        return "wav"
+    return _MIME_TO_EXT.get(mime_type.lower().split(";")[0].strip(), "wav")
+
+
+class SttNatsAdapter(NatsAdapterBase):
+    def __init__(
+        self,
+        *,
+        default_model: str,
+        max_concurrent: int = 2,
+        reject_when_full: bool = False,
+        heartbeat_interval: float = 5.0,
+        drain_timeout: float = 30.0,
+    ) -> None:
+        worker_id = f"stt-{socket.gethostname()}-{os.getpid()}-{int(time.time())}"
+        super().__init__(
+            subject=SUBJECT,
+            queue_group=STT_WORKERS,
+            heartbeat_subject=HEARTBEAT_SUBJECT,
+            service="stt_workers",
+            worker_id=worker_id,
+            heartbeat_interval=heartbeat_interval,
+            drain_timeout=drain_timeout,
+        )
+        self.default_model = default_model
+        self.max_concurrent = max_concurrent
+        self.reject_when_full = reject_when_full
+        self._sem = asyncio.Semaphore(max_concurrent)
+        self._executor = ThreadPoolExecutor(max_workers=max_concurrent)
+
+    async def handle(self, msg: Any, payload: dict) -> None:  # type: ignore[override]
+        request_id = payload.get("request_id", "")
+        if not request_id:
+            await self.reply(msg, build_reply(ok=False, request_id="", error="malformed_request"))
+            return
+
+        # Reject path-traversal or oversized request IDs at ingestion
+        if not re.match(r"^[A-Za-z0-9_-]{1,128}$", request_id):
+            await self.reply(
+                msg,
+                build_reply(
+                    ok=False,
+                    request_id=request_id[:64] if request_id else "",
+                    error="malformed_request",
+                ),
+            )
+            return
+
+        audio_b64 = payload.get("audio_b64")
+        if not audio_b64 or not isinstance(audio_b64, str):
+            await self.reply(
+                msg, build_reply(ok=False, request_id=request_id, error="malformed_request")
+            )
+            return
+
+        overrides = {
+            k: v
+            for k, v in {
+                "language": payload.get("language"),
+                "language_detection_threshold": payload.get("language_detection_threshold"),
+                "language_detection_segments": payload.get("language_detection_segments"),
+                "language_fallback": payload.get("language_fallback"),
+            }.items()
+            if v is not None
+        }
+
+        if self.reject_when_full:
+            # Non-blocking acquire: avoid the race in _sem.locked()
+            try:
+                await asyncio.wait_for(self._sem.acquire(), timeout=0)
+            except asyncio.TimeoutError:
+                await self.reply(
+                    msg, build_reply(ok=False, request_id=request_id, error="capacity_exceeded")
+                )
+                return
+            try:
+                await self._run_transcription(msg, payload, request_id, audio_b64, overrides)
+            finally:
+                self._sem.release()
+        else:
+            async with self._sem:
+                await self._run_transcription(msg, payload, request_id, audio_b64, overrides)
+
+    async def _run_transcription(
+        self,
+        msg: Any,
+        payload: dict,
+        request_id: str,
+        audio_b64: str,
+        overrides: dict,
+    ) -> None:
+        ext = _ext_from_mime(payload.get("mime_type"))
+        out_path = scoped_path(request_id, ext)
+        try:
+            # Decode audio bytes first — isolate bad-base64 from transcription failures
+            try:
+                audio_bytes = base64.b64decode(audio_b64, validate=True)
+            except Exception:
+                log.warning("audio_decode_failed", extra={"request_id": request_id})
+                await self.reply(
+                    msg,
+                    build_reply(ok=False, request_id=request_id, error="audio_decode_failed"),
+                )
+                cleanup(out_path)
+                return
+
+            out_path.write_bytes(audio_bytes)
+            self.model_loaded = self.default_model
+            from voicecli import api
+
+            fn = functools.partial(
+                api.transcribe,
+                out_path,
+                model=self.default_model,
+                _skip_daemon=True,
+                **overrides,
+            )
+            loop = asyncio.get_running_loop()
+            result = await loop.run_in_executor(self._executor, fn)
+            duration_seconds = _duration_from_segments(result.segments)
+            await self.reply(
+                msg,
+                build_reply(
+                    ok=True,
+                    request_id=request_id,
+                    text=result.text,
+                    language=result.language,
+                    duration_seconds=duration_seconds,
+                ),
+            )
+        except Exception:
+            log.exception("transcription_failed", extra={"request_id": request_id})
+            await self.reply(
+                msg,
+                build_reply(ok=False, request_id=request_id, error="transcription_failed"),
+            )
+        finally:
+            cleanup(out_path)

--- a/src/voicecli/transcribe.py
+++ b/src/voicecli/transcribe.py
@@ -121,19 +121,21 @@ def transcribe(
     language_fallback: str | None = None,
     task: str = "transcribe",
     initial_prompt: str | None = None,
+    _skip_daemon: bool = False,
 ) -> TranscriptionResult:
     # Try daemon first — reuses warm model, avoids loading locally
-    daemon_result = _try_daemon(
-        audio_path,
-        language,
-        language_detection_threshold,
-        language_detection_segments,
-        language_fallback,
-        task,
-        initial_prompt,
-    )
-    if daemon_result is not None:
-        return daemon_result
+    if not _skip_daemon:
+        daemon_result = _try_daemon(
+            audio_path,
+            language,
+            language_detection_threshold,
+            language_detection_segments,
+            language_fallback,
+            task,
+            initial_prompt,
+        )
+        if daemon_result is not None:
+            return daemon_result
 
     whisper = _load_model(model)
 

--- a/src/voicecli/transcribe.py
+++ b/src/voicecli/transcribe.py
@@ -114,6 +114,7 @@ def _try_daemon(
 
 def transcribe(
     audio_path: Path,
+    *,
     model: str = DEFAULT_MODEL,
     language: str | None = None,
     language_detection_threshold: float | None = None,

--- a/tests/nats/test_stt_adapter.py
+++ b/tests/nats/test_stt_adapter.py
@@ -111,7 +111,12 @@ def _make_adapter(**kwargs) -> "SttNatsAdapter":
         "max_concurrent": 2,
     }
     defaults.update(kwargs)
-    return SttNatsAdapter(**defaults)
+    adapter = SttNatsAdapter(**defaults)
+    # Short-circuit the model warm-up step so tests don't pull faster_whisper/torch
+    # into sys.modules. Tests that need to exercise warm-up failure patch
+    # `voicecli.transcribe._load_model` to raise.
+    adapter._model_warm = True
+    return adapter
 
 
 def _patch_transcribe(mock_result: "TranscriptionResult"):
@@ -416,7 +421,7 @@ class TestSttNatsAdapter:
 
         # Assert call 2 did NOT leak any override keys
         kwargs2 = mock_transcribe.call_args_list[1].kwargs
-        assert "language" not in kwargs2 or kwargs2["language"] is None
+        assert "language" not in kwargs2
         assert "language_detection_threshold" not in kwargs2
         assert "language_detection_segments" not in kwargs2
         assert "language_fallback" not in kwargs2
@@ -576,3 +581,123 @@ class TestSttNatsAdapter:
         reply = msg.last_reply()
         assert reply["ok"] is False
         assert reply["error"] == "capacity_exceeded"
+
+    # ------------------------------------------------------------------
+    # Case 17: temp file cleaned up on successful transcription
+    # ------------------------------------------------------------------
+    def test_temp_file_cleaned_up_on_success(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange
+        request_id = "req-clean-ok"
+        adapter = _make_adapter(max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload(request_id=request_id)
+        temp_file = tmp_path / f"{request_id}.wav"
+
+        with _patch_transcribe(_fake_result()) as _:
+            with _patch_scoped_path(tmp_path):
+                asyncio.run(adapter.handle(msg, payload))
+
+        # Assert — temp file removed after successful reply
+        assert not temp_file.exists()
+
+    # ------------------------------------------------------------------
+    # Case 18: temp file cleaned up even when api.transcribe raises
+    # ------------------------------------------------------------------
+    def test_temp_file_cleaned_up_on_failure(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange
+        request_id = "req-clean-fail"
+        adapter = _make_adapter(max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload(request_id=request_id)
+        temp_file = tmp_path / f"{request_id}.wav"
+
+        import voicecli.nats.stt_adapter as _mod
+        import voicecli.api as _api  # noqa: F401
+
+        _mod.api = _api  # type: ignore[attr-defined]
+
+        with patch(
+            "voicecli.nats.stt_adapter.api.transcribe",
+            side_effect=RuntimeError("kaboom"),
+        ):
+            with _patch_scoped_path(tmp_path):
+                asyncio.run(adapter.handle(msg, payload))
+
+        # Assert — temp file removed even when transcription fails
+        assert not temp_file.exists()
+
+    # ------------------------------------------------------------------
+    # Case 19: _resolve_model — env var VOICECLI_MODEL used when CLI is None
+    # ------------------------------------------------------------------
+    def test_resolve_model_env_var_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _require_imports()
+        # Arrange
+        monkeypatch.setenv("VOICECLI_MODEL", "small")
+
+        # Act
+        resolved = _resolve_model(None)
+
+        # Assert
+        assert resolved == "small"
+
+    # ------------------------------------------------------------------
+    # Case 20: _resolve_model — DEFAULT_MODEL used when env absent and config empty
+    # ------------------------------------------------------------------
+    def test_resolve_model_default_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _require_imports()
+        # Arrange
+        monkeypatch.delenv("VOICECLI_MODEL", raising=False)
+
+        with patch("voicecli.config.load_config", return_value={}):
+            # Act
+            resolved = _resolve_model(None)
+
+        # Assert
+        assert resolved == DEFAULT_MODEL
+
+    # ------------------------------------------------------------------
+    # Case 21: _resolve_model — CLI value beats env var (CLI > env)
+    # ------------------------------------------------------------------
+    def test_resolve_model_cli_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _require_imports()
+        # Arrange — env var set, but CLI value should win
+        monkeypatch.setenv("VOICECLI_MODEL", "small")
+
+        # Act
+        resolved = _resolve_model("tiny")
+
+        # Assert
+        assert resolved == "tiny"
+
+    # ------------------------------------------------------------------
+    # Case 22: request_id length boundary — 127/128 accepted, 129 rejected
+    # ------------------------------------------------------------------
+    @pytest.mark.parametrize(
+        "rid_len, expected_ok",
+        [(127, True), (128, True), (129, False)],
+    )
+    def test_request_id_length_boundary(
+        self, tmp_path: Path, rid_len: int, expected_ok: bool
+    ) -> None:
+        _require_imports()
+        # Arrange
+        rid = "a" * rid_len
+        adapter = _make_adapter(max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload(request_id=rid)
+
+        with _patch_transcribe(_fake_result()) as mock_transcribe:
+            with _patch_scoped_path(tmp_path):
+                asyncio.run(adapter.handle(msg, payload))
+
+        # Assert
+        reply = msg.last_reply()
+        if expected_ok:
+            assert reply.get("error") is None
+            assert reply["ok"] is True
+        else:
+            assert reply["ok"] is False
+            assert reply["error"] == "malformed_request"
+            mock_transcribe.assert_not_called()

--- a/tests/nats/test_stt_adapter.py
+++ b/tests/nats/test_stt_adapter.py
@@ -1,0 +1,578 @@
+"""Tests for SttNatsAdapter (issue #44 T4).
+
+Mirrors the structure of test_tts_adapter.py.  All 16 cases exercise the
+real SttNatsAdapter code — api.transcribe is patched at the import site
+(voicecli.nats.stt_adapter.api) so actual coverage runs through the adapter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Lazy import shim — lets --collect-only succeed even before the module exists
+# ---------------------------------------------------------------------------
+
+try:
+    from voicecli.nats.stt_adapter import (
+        DEFAULT_MODEL,
+        HEARTBEAT_SUBJECT,
+        SUBJECT,
+        SttNatsAdapter,
+        _duration_from_segments,
+        _ext_from_mime,
+        _resolve_model,
+    )
+    from voicecli.nats.queue_groups import STT_WORKERS
+    from voicecli.transcribe import TranscriptionResult
+
+    _IMPORT_ERROR: ImportError | None = None
+except ImportError as _e:
+    _IMPORT_ERROR = _e
+    SttNatsAdapter = None  # type: ignore[assignment,misc]
+    _resolve_model = None  # type: ignore[assignment]
+    _duration_from_segments = None  # type: ignore[assignment]
+    _ext_from_mime = None  # type: ignore[assignment]
+    TranscriptionResult = None  # type: ignore[assignment]
+    DEFAULT_MODEL = "large-v3-turbo"  # type: ignore[assignment]
+    SUBJECT = "lyra.voice.stt.request"  # type: ignore[assignment]
+    HEARTBEAT_SUBJECT = "lyra.voice.stt.heartbeat"  # type: ignore[assignment]
+    STT_WORKERS = "stt-workers"  # type: ignore[assignment]
+
+
+def _require_imports() -> None:
+    if _IMPORT_ERROR is not None:
+        pytest.fail(f"voicecli.nats.stt_adapter not yet implemented (RED): {_IMPORT_ERROR}")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class MockMsg:
+    """Minimal NATS message stand-in: carries .reply, records respond() calls."""
+
+    def __init__(self, reply_subject: str = "_INBOX.test") -> None:
+        self.reply = reply_subject
+        self._published: list[bytes] = []
+
+    async def respond(self, data: bytes) -> None:
+        self._published.append(data)
+
+    def last_reply(self) -> dict:
+        assert self._published, "No reply published"
+        return json.loads(self._published[-1])
+
+
+def _valid_audio_b64() -> str:
+    """Return a valid base64-encoded minimal WAV-ish byte blob."""
+    return base64.b64encode(b"\x00" * 16).decode()
+
+
+def _valid_payload(
+    *,
+    request_id: str = "req-001",
+    audio_b64: str | None = None,
+    contract_version: str = "1",
+    mime_type: str = "audio/wav",
+) -> dict:
+    payload: dict = {
+        "contract_version": contract_version,
+        "request_id": request_id,
+        "audio_b64": audio_b64 if audio_b64 is not None else _valid_audio_b64(),
+        "mime_type": mime_type,
+    }
+    return payload
+
+
+def _fake_result(
+    text: str = "hello world",
+    language: str = "en",
+    end: float = 2.5,
+) -> "TranscriptionResult":
+    return TranscriptionResult(
+        text=text,
+        language=language,
+        segments=[{"start": 0.0, "end": end, "text": text}],
+    )
+
+
+def _make_adapter(**kwargs) -> "SttNatsAdapter":
+    defaults = {
+        "default_model": DEFAULT_MODEL,
+        "max_concurrent": 2,
+    }
+    defaults.update(kwargs)
+    return SttNatsAdapter(**defaults)
+
+
+def _patch_transcribe(mock_result: "TranscriptionResult"):
+    """Context manager: patch api.transcribe at the adapter import site."""
+    # The deferred `from voicecli import api` inside _run_transcription binds
+    # `api` on the stt_adapter module namespace.  We force that binding here
+    # so patch.object can reach it.
+    import voicecli.nats.stt_adapter as _mod
+    import voicecli.api as _api  # noqa: F401 — materialises the attribute
+
+    _mod.api = _api  # type: ignore[attr-defined]
+    return patch("voicecli.nats.stt_adapter.api.transcribe", return_value=mock_result)
+
+
+def _patch_scoped_path(tmp_path: Path):
+    """Redirect scoped_path to tmp_path so tests don't touch /tmp/voicecli-nats."""
+
+    def _impl(request_id: str, ext: str) -> Path:
+        p = tmp_path / f"{request_id}.{ext}"
+        return p
+
+    return patch("voicecli.nats.stt_adapter.scoped_path", side_effect=_impl)
+
+
+# ---------------------------------------------------------------------------
+# Test class
+# ---------------------------------------------------------------------------
+
+
+class TestSttNatsAdapter:
+    # ------------------------------------------------------------------
+    # Case 1: happy path
+    # ------------------------------------------------------------------
+    def test_happy_path(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange
+        adapter = _make_adapter(max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload(request_id="req-001")
+
+        with _patch_transcribe(_fake_result()) as mock_transcribe:
+            with _patch_scoped_path(tmp_path):
+                asyncio.run(adapter.handle(msg, payload))
+
+        # Assert
+        reply = msg.last_reply()
+        assert reply["ok"] is True
+        assert reply["contract_version"] == "1"
+        assert reply["request_id"] == "req-001"
+        assert reply["text"] == "hello world"
+        assert reply["language"] == "en"
+        assert reply["duration_seconds"] == pytest.approx(2.5)
+        mock_transcribe.assert_called_once()
+
+    # ------------------------------------------------------------------
+    # Case 2: missing request_id
+    # ------------------------------------------------------------------
+    def test_malformed_request_id_missing(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange
+        adapter = _make_adapter(max_concurrent=1)
+        msg = MockMsg()
+        payload = {"audio_b64": _valid_audio_b64()}
+
+        asyncio.run(adapter.handle(msg, payload))
+
+        # Assert
+        reply = msg.last_reply()
+        assert reply["ok"] is False
+        assert reply["error"] == "malformed_request"
+        assert reply["request_id"] == ""
+
+    # ------------------------------------------------------------------
+    # Case 3: request_id with invalid characters
+    # ------------------------------------------------------------------
+    def test_malformed_request_id_bad_chars(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange
+        adapter = _make_adapter(max_concurrent=1)
+        msg = MockMsg()
+        bad_id = "../etc/passwd"
+        payload = _valid_payload(request_id=bad_id)
+
+        asyncio.run(adapter.handle(msg, payload))
+
+        # Assert
+        reply = msg.last_reply()
+        assert reply["ok"] is False
+        assert reply["error"] == "malformed_request"
+        # request_id echoed as first 64 chars of the bad value
+        assert reply["request_id"] == bad_id[:64]
+
+    # ------------------------------------------------------------------
+    # Case 4: audio_b64 key absent
+    # ------------------------------------------------------------------
+    def test_malformed_audio_b64_missing(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange
+        adapter = _make_adapter(max_concurrent=1)
+        msg = MockMsg()
+        payload = {"contract_version": "1", "request_id": "req-noaudio"}
+
+        asyncio.run(adapter.handle(msg, payload))
+
+        # Assert
+        reply = msg.last_reply()
+        assert reply["ok"] is False
+        assert reply["error"] == "malformed_request"
+
+    # ------------------------------------------------------------------
+    # Case 5: audio_b64 is not a string
+    # ------------------------------------------------------------------
+    def test_malformed_audio_b64_not_str(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange
+        adapter = _make_adapter(max_concurrent=1)
+        msg = MockMsg()
+        payload = {"contract_version": "1", "request_id": "req-badtype", "audio_b64": 123}
+
+        asyncio.run(adapter.handle(msg, payload))
+
+        # Assert
+        reply = msg.last_reply()
+        assert reply["ok"] is False
+        assert reply["error"] == "malformed_request"
+
+    # ------------------------------------------------------------------
+    # Case 6: base64 decode failure — transcribe must NOT be called
+    # ------------------------------------------------------------------
+    def test_audio_decode_failed(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange
+        adapter = _make_adapter(max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload(audio_b64="!!!not-base64!!!")
+
+        with _patch_transcribe(_fake_result()) as mock_transcribe:
+            with _patch_scoped_path(tmp_path):
+                asyncio.run(adapter.handle(msg, payload))
+
+        # Assert
+        reply = msg.last_reply()
+        assert reply["ok"] is False
+        assert reply["error"] == "audio_decode_failed"
+        mock_transcribe.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # Case 7: api.transcribe raises — reply transcription_failed, no re-raise
+    # ------------------------------------------------------------------
+    def test_transcription_failed(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange
+        adapter = _make_adapter(max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload(request_id="req-boom")
+
+        import voicecli.nats.stt_adapter as _mod
+        import voicecli.api as _api  # noqa: F401
+
+        _mod.api = _api  # type: ignore[attr-defined]
+
+        with patch(
+            "voicecli.nats.stt_adapter.api.transcribe",
+            side_effect=RuntimeError("model OOM"),
+        ):
+            with _patch_scoped_path(tmp_path):
+                # Must not raise — adapter swallows the exception
+                asyncio.run(adapter.handle(msg, payload))
+
+        # Assert
+        reply = msg.last_reply()
+        assert reply["ok"] is False
+        assert reply["error"] == "transcription_failed"
+
+    # ------------------------------------------------------------------
+    # Case 8: contract_version "999" — defensive handling, still ok=true
+    # ------------------------------------------------------------------
+    def test_contract_version_defensive(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange
+        adapter = _make_adapter(max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload(request_id="req-999", contract_version="999")
+
+        with _patch_transcribe(_fake_result()) as _:
+            with _patch_scoped_path(tmp_path):
+                asyncio.run(adapter.handle(msg, payload))
+
+        # Assert — succeeds; reply stamps contract_version "1"
+        reply = msg.last_reply()
+        assert reply["ok"] is True
+        assert reply["contract_version"] == "1"
+
+    # ------------------------------------------------------------------
+    # Case 9: request_id echoed in reply
+    # ------------------------------------------------------------------
+    def test_request_id_echoed(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange
+        rid = "my-unique-req-42"
+        adapter = _make_adapter(max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload(request_id=rid)
+
+        with _patch_transcribe(_fake_result()) as _:
+            with _patch_scoped_path(tmp_path):
+                asyncio.run(adapter.handle(msg, payload))
+
+        # Assert
+        reply = msg.last_reply()
+        assert reply["request_id"] == rid
+
+    # ------------------------------------------------------------------
+    # Case 10: language forced in request, echoed in reply, passed to api
+    # ------------------------------------------------------------------
+    def test_language_forced_echoed(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange
+        adapter = _make_adapter(max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload(request_id="req-fr")
+        payload["language"] = "fr"
+
+        mock_result = _fake_result(language="fr")
+
+        with _patch_transcribe(mock_result) as mock_transcribe:
+            with _patch_scoped_path(tmp_path):
+                asyncio.run(adapter.handle(msg, payload))
+
+        # Assert reply
+        reply = msg.last_reply()
+        assert reply["ok"] is True
+        assert reply["language"] == "fr"
+
+        # Assert api.transcribe called with language="fr"
+        call_kwargs = mock_transcribe.call_args.kwargs
+        assert call_kwargs.get("language") == "fr"
+
+    # ------------------------------------------------------------------
+    # Case 11: all override fields passed through to api.transcribe
+    # ------------------------------------------------------------------
+    def test_overrides_applied(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange
+        adapter = _make_adapter(max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload(request_id="req-overrides")
+        payload["language"] = "de"
+        payload["language_detection_threshold"] = 0.7
+        payload["language_detection_segments"] = 3
+        payload["language_fallback"] = "en"
+
+        with _patch_transcribe(_fake_result(language="de")) as mock_transcribe:
+            with _patch_scoped_path(tmp_path):
+                asyncio.run(adapter.handle(msg, payload))
+
+        # Assert
+        call_kwargs = mock_transcribe.call_args.kwargs
+        assert call_kwargs.get("language") == "de"
+        assert call_kwargs.get("language_detection_threshold") == pytest.approx(0.7)
+        assert call_kwargs.get("language_detection_segments") == 3
+        assert call_kwargs.get("language_fallback") == "en"
+        assert call_kwargs.get("_skip_daemon") is True
+
+    # ------------------------------------------------------------------
+    # Case 12: override fields do not leak between sequential requests
+    # ------------------------------------------------------------------
+    def test_overrides_no_leakage(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange — same adapter instance, two sequential calls
+        adapter = _make_adapter(max_concurrent=2)
+        msg1, msg2 = MockMsg(), MockMsg()
+
+        payload1 = _valid_payload(request_id="req-with-overrides")
+        payload1["language"] = "de"
+        payload1["language_detection_threshold"] = 0.8
+        payload1["language_detection_segments"] = 5
+        payload1["language_fallback"] = "en"
+
+        payload2 = _valid_payload(request_id="req-no-overrides")
+        # payload2 has NO override fields
+
+        import voicecli.nats.stt_adapter as _mod
+        import voicecli.api as _api  # noqa: F401
+
+        _mod.api = _api  # type: ignore[attr-defined]
+
+        with patch(
+            "voicecli.nats.stt_adapter.api.transcribe",
+            return_value=_fake_result(),
+        ) as mock_transcribe:
+            with _patch_scoped_path(tmp_path):
+                asyncio.run(adapter.handle(msg1, payload1))
+                asyncio.run(adapter.handle(msg2, payload2))
+
+        # Assert call 1 had overrides
+        kwargs1 = mock_transcribe.call_args_list[0].kwargs
+        assert kwargs1.get("language") == "de"
+        assert kwargs1.get("language_detection_threshold") == pytest.approx(0.8)
+        assert kwargs1.get("language_detection_segments") == 5
+        assert kwargs1.get("language_fallback") == "en"
+
+        # Assert call 2 did NOT leak any override keys
+        kwargs2 = mock_transcribe.call_args_list[1].kwargs
+        assert "language" not in kwargs2 or kwargs2["language"] is None
+        assert "language_detection_threshold" not in kwargs2
+        assert "language_detection_segments" not in kwargs2
+        assert "language_fallback" not in kwargs2
+
+    # ------------------------------------------------------------------
+    # Case 13: first heartbeat — model_loaded is None before any request
+    # ------------------------------------------------------------------
+    def test_first_heartbeat_null_model(self) -> None:
+        _require_imports()
+        # Arrange
+        adapter = _make_adapter()
+        heartbeat_payloads: list[dict] = []
+
+        async def _fake_publish(subject: str, data: bytes) -> None:
+            if "heartbeat" in subject:
+                heartbeat_payloads.append(json.loads(data.decode()))
+
+        adapter._nats_publish = _fake_publish  # type: ignore[attr-defined]
+
+        async def _run() -> None:
+            stop = asyncio.Event()
+            hb_task = asyncio.create_task(adapter._heartbeat_loop(stop))  # type: ignore[attr-defined]
+            # Let one iteration fire
+            await asyncio.sleep(0.05)
+            stop.set()
+            await asyncio.wait_for(hb_task, timeout=1.0)
+
+        # Patch heartbeat_interval to fire immediately
+        adapter.heartbeat_interval = 0.01
+        asyncio.run(_run())
+
+        # Assert — at least one heartbeat published before any request
+        assert heartbeat_payloads, "No heartbeat published"
+        hb = heartbeat_payloads[0]
+        assert hb["model_loaded"] is None
+        assert hb["active_requests"] == 0
+        assert hb["service"] == "stt_workers"
+        assert hb["subject"] == SUBJECT
+        assert hb["queue_group"] == STT_WORKERS
+
+    # ------------------------------------------------------------------
+    # Case 14: heartbeat payload includes all required fields
+    # ------------------------------------------------------------------
+    def test_heartbeat_fields(self) -> None:
+        _require_imports()
+        # Arrange
+        adapter = _make_adapter()
+        heartbeat_payloads: list[dict] = []
+
+        async def _fake_publish(subject: str, data: bytes) -> None:
+            if "heartbeat" in subject:
+                heartbeat_payloads.append(json.loads(data.decode()))
+
+        adapter._nats_publish = _fake_publish  # type: ignore[attr-defined]
+        adapter.heartbeat_interval = 0.01
+
+        async def _run() -> None:
+            stop = asyncio.Event()
+            hb_task = asyncio.create_task(adapter._heartbeat_loop(stop))  # type: ignore[attr-defined]
+            await asyncio.sleep(0.05)
+            stop.set()
+            await asyncio.wait_for(hb_task, timeout=1.0)
+
+        asyncio.run(_run())
+
+        assert heartbeat_payloads, "No heartbeat published"
+        hb = heartbeat_payloads[0]
+        required_keys = {
+            "contract_version",
+            "worker_id",
+            "service",
+            "host",
+            "subject",
+            "queue_group",
+            "ts",
+            "model_loaded",
+            "vram_used_mb",
+            "vram_total_mb",
+            "active_requests",
+        }
+        missing = required_keys - set(hb.keys())
+        assert not missing, f"Missing heartbeat keys: {missing}"
+
+    # ------------------------------------------------------------------
+    # Case 15: max_concurrent=1, two sequential requests do not overlap
+    # ------------------------------------------------------------------
+    def test_max_concurrent_limit(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange — track order of entry/exit to confirm no overlap.
+        # api.transcribe runs via run_in_executor (sync thread), so the mock
+        # must be a plain synchronous function, not a coroutine.
+        enter_times: list[float] = []
+        exit_times: list[float] = []
+
+        def _slow_transcribe(*args, **kwargs):
+            enter_times.append(time.monotonic())
+            time.sleep(0.05)  # blocking sleep — correct for a thread-pool mock
+            exit_times.append(time.monotonic())
+            return _fake_result()
+
+        adapter = _make_adapter(max_concurrent=1)
+
+        import voicecli.nats.stt_adapter as _mod
+        import voicecli.api as _api  # noqa: F401
+
+        _mod.api = _api  # type: ignore[attr-defined]
+
+        async def _run() -> None:
+            with patch(
+                "voicecli.nats.stt_adapter.api.transcribe",
+                side_effect=_slow_transcribe,
+            ):
+                with patch(
+                    "voicecli.nats.stt_adapter.scoped_path",
+                    side_effect=lambda rid, ext: tmp_path / f"{rid}.{ext}",
+                ):
+                    msg1, msg2 = MockMsg(), MockMsg()
+                    p1 = _valid_payload(request_id="req-c1")
+                    p2 = _valid_payload(request_id="req-c2")
+                    # Fire both concurrently — semaphore serialises them
+                    await asyncio.gather(
+                        adapter.handle(msg1, p1),
+                        adapter.handle(msg2, p2),
+                    )
+
+        asyncio.run(_run())
+
+        # With max_concurrent=1, the second request must not enter before
+        # the first has exited — i.e. enter_times[1] >= exit_times[0].
+        assert len(enter_times) == 2
+        assert len(exit_times) == 2
+        assert enter_times[1] >= exit_times[0], (
+            f"Requests overlapped: enter[1]={enter_times[1]:.4f} < exit[0]={exit_times[0]:.4f}"
+        )
+
+    # ------------------------------------------------------------------
+    # Case 16: reject_when_full=True → capacity_exceeded
+    # ------------------------------------------------------------------
+    def test_reject_when_full(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange
+        adapter = _make_adapter(max_concurrent=1, reject_when_full=True)
+        msg = MockMsg()
+        payload = _valid_payload(request_id="req-cap")
+
+        async def _run() -> None:
+            # Hold the semaphore to simulate an in-flight request
+            await adapter._sem.acquire()  # type: ignore[attr-defined]
+            try:
+                await adapter.handle(msg, payload)
+            finally:
+                adapter._sem.release()  # type: ignore[attr-defined]
+
+        asyncio.run(_run())
+
+        # Assert
+        reply = msg.last_reply()
+        assert reply["ok"] is False
+        assert reply["error"] == "capacity_exceeded"

--- a/tests/nats/test_stt_adapter.py
+++ b/tests/nats/test_stt_adapter.py
@@ -672,6 +672,61 @@ class TestSttNatsAdapter:
         assert resolved == "tiny"
 
     # ------------------------------------------------------------------
+    # Case 22 (F12): heartbeat continues firing while inference is in-flight
+    # ------------------------------------------------------------------
+    def test_heartbeat_continues_during_inference(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Arrange — slow transcription (1.5 s in thread); heartbeat every 0.3 s → ≥ 1 fires
+        heartbeat_calls: list[float] = []
+
+        async def _run() -> None:
+            adapter = _make_adapter(max_concurrent=1, heartbeat_interval=0.3)
+            msg = MockMsg()
+            payload = _valid_payload(request_id="req-hb")
+
+            async def _fake_publish(subject: str, data: bytes) -> None:
+                if "heartbeat" in subject:
+                    heartbeat_calls.append(time.monotonic())
+
+            adapter._nats_publish = _fake_publish  # type: ignore[attr-defined]
+
+            # Synchronous mock — runs inside run_in_executor (correct for STT adapter)
+            def _slow_transcribe(*args, **kwargs):
+                time.sleep(1.5)
+                return TranscriptionResult(
+                    text="ok",
+                    language="en",
+                    segments=[{"start": 0.0, "end": 1.5, "text": "ok"}],
+                )
+
+            import voicecli.nats.stt_adapter as _mod
+            import voicecli.api as _api  # noqa: F401
+
+            _mod.api = _api  # type: ignore[attr-defined]
+
+            stop = asyncio.Event()
+
+            with patch(
+                "voicecli.nats.stt_adapter.api.transcribe",
+                side_effect=_slow_transcribe,
+            ):
+                with patch(
+                    "voicecli.nats.stt_adapter.scoped_path",
+                    side_effect=lambda rid, ext: tmp_path / f"{rid}.{ext}",
+                ):
+                    handle_task = asyncio.create_task(adapter.handle(msg, payload))
+                    hb_task = asyncio.create_task(adapter._heartbeat_loop(stop))  # type: ignore[attr-defined]
+
+                    await asyncio.wait_for(handle_task, timeout=5.0)
+                    stop.set()
+                    await asyncio.wait_for(hb_task, timeout=1.0)
+
+        asyncio.run(_run())
+
+        # Assert — heartbeat fired at least once during the inference window
+        assert len(heartbeat_calls) >= 1
+
+    # ------------------------------------------------------------------
     # Case 22: request_id length boundary — 127/128 accepted, 129 rejected
     # ------------------------------------------------------------------
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Add `voicecli nats-serve stt` — NATS subscriber satellite mirroring slice V1 TTS path (#43). Subscribes to `lyra.voice.stt.request` (queue `stt-workers`), runs `api.transcribe()` on a thread pool, replies with ADR-044 STT schema, emits heartbeats on `lyra.voice.stt.heartbeat`.
- Per-request language-detection overrides (`language`, `language_detection_threshold`, `language_detection_segments`, `language_fallback`) flow through without mutating satellite state — sequential-leakage test asserts no bleed.
- `api.transcribe()` + `transcribe.transcribe()` gain a private `_skip_daemon=True` kwarg so the NATS satellite never silently delegates to the `stt-serve` Unix-socket daemon (safe under `--allow-coexist`).
- `--max-concurrent` default `2` (architect rationale: transcription is faster than synthesis); docs recommend `1` when TTS + STT share a GPU.
- Unblocks lyra#689 (Machine-1 cutover slice S3 of parent lyra#658).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #44: feat(nats): voicecli nats-serve stt entry point (slice V2) | OPEN |
| Frame | [artifacts/frames/44-nats-serve-stt-frame.mdx](artifacts/frames/44-nats-serve-stt-frame.mdx) | approved |
| Spec | [artifacts/specs/44-nats-serve-stt-spec.mdx](artifacts/specs/44-nats-serve-stt-spec.mdx) | approved |
| Plan | [artifacts/plans/44-nats-serve-stt-plan.mdx](artifacts/plans/44-nats-serve-stt-plan.mdx) | approved |
| Implementation | 1 commit on \`feat/44-nats-serve-stt\` | Complete |
| Verification | Lint ✅ Format ✅ Tests ✅ (286/286, 16 new STT cases) | Passed |

## What ships

**New files:**
- \`src/voicecli/nats/stt_adapter.py\` — \`SttNatsAdapter(NatsAdapterBase)\` subscribing on \`lyra.voice.stt.request\`, plus \`_resolve_model\`, \`_ext_from_mime\`, \`_duration_from_segments\` helpers.
- \`tests/nats/test_stt_adapter.py\` — 16 test cases mirroring \`test_tts_adapter.py\` structure; patch target is \`voicecli.nats.stt_adapter.api.transcribe\` (deferred-import safe).

**Modified:**
- \`src/voicecli/api.py\` — \`transcribe()\` gains 4 optional kwargs (\`language_detection_threshold\`, \`language_detection_segments\`, \`language_fallback\`, \`_skip_daemon\`), all forwarded to the inner layer. Backward-compatible.
- \`src/voicecli/transcribe.py\` — \`transcribe()\` gains \`_skip_daemon\` local gate around \`_try_daemon()\`.
- \`src/voicecli/cli.py\` — new \`@nats_app.command(\"stt\")\` subcommand, symmetric with the TTS one; reuses existing \`_probe_socket_daemon()\` helper pointing at \`stt-daemon.sock\`.
- \`docs/NATS-SERVE.md\` — STT section with env vars, subjects, VRAM guard, supervisord stanza, and a co-located-GPU callout (\`--max-concurrent=1\` when TTS + STT share a 10 GB GPU).

## Out of scope (tracked separately)

- Mock engine + docker-compose E2E — slice V3.
- SKILL.md / CLAUDE.md polish — slice V4.
- Removing \`voicecli stt-serve\` — stays until lyra#689 cutover completes.
- Framework changes to \`NatsAdapterBase\` / heartbeat / reply builder — slice V1 froze these.

## Test Plan

- [ ] \`uv run pytest tests/nats/test_stt_adapter.py -v\` — 16 passing.
- [ ] \`uv run pytest tests/\` (excluding \`tests/test_overlay.py\` which has a pre-existing cairo system-dep issue on staging) — 286 passing.
- [ ] \`uv run voicecli nats-serve stt --help\` — shows \`--model\`, \`--max-concurrent\`, etc.
- [ ] Manual smoke (post-merge, on roxabituwer): start \`voicecli nats-serve stt --model large-v3-turbo\` with \`NATS_URL\` / \`NATS_NKEY_SEED_PATH\` set; verify heartbeat appears on \`lyra.voice.stt.heartbeat\`; publish a test STT request via \`nats-cli\` and assert reply shape matches ADR-044.
- [ ] Confirm \`voicecli stt-serve\` (Unix-socket daemon) tests remain green — \`tests/test_stt_daemon.py\` (19) and \`tests/test_stt_client.py\` (47) unchanged.

Closes #44

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`