### PR TITLE
docs(nats): slice V4 polish — SKILL.md + CLAUDE.md + real-hub compose

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,3 +163,15 @@ make -C ~/projects/lyra-stack stt stop
 voicecli clone "text" -e qwen-fast
 make -C ~/projects/lyra-stack stt start
 ```
+
+### NATS satellite vs socket daemon — pick one mode per host
+
+`voicecli nats-serve` and `voicecli serve` / `stt-serve` compete for the same GPU. The VRAM-sequencing guard refuses to start a satellite if a live socket daemon is detected (exit 78). Three coexistence modes:
+
+| Mode | When to use | How |
+|---|---|---|
+| **socket-only** | Hub and voicecli on the same host (low-latency local dev) | Run `voicecli serve` / `stt-serve`, do NOT start the NATS satellite |
+| **nats-only** (default) | Production — hub on a different host | Stop the socket daemon, run `voicecli nats-serve tts` / `stt` |
+| **allow-coexist** | Large-VRAM dev boxes (RTX 5070 Ti 16 GB, etc.) only | Pass `--allow-coexist` or set `VOICECLI_ALLOW_COEXIST=1` |
+
+Do NOT enable allow-coexist on the RTX 3080 (10 GB) production host — it will OOM under concurrent synthesis. Full guard behavior + exit codes: [docs/NATS-SERVE.md#vram-sequencing](docs/NATS-SERVE.md#vram-sequencing).

--- a/docs/NATS-SERVE.md
+++ b/docs/NATS-SERVE.md
@@ -132,6 +132,9 @@ Copy this block into your supervisord `conf.d/` directory and fill in host-speci
 ```ini
 [program:voicecli_nats_tts]
 command=voicecli nats-serve tts
+; VOICECLI_ALLOW_COEXIST is intentionally absent — do NOT set it on co-located GPU
+; hosts (e.g. RTX 3080 10 GB). Setting it bypasses the VRAM-sequencing guard and
+; will cause CUDA OOM under concurrent synthesis. See VRAM sequencing section above.
 environment=NATS_URL="nats://nats.internal:4222",NATS_NKEY_SEED_PATH="/home/lyra/.lyra/nkeys/voicecli-tts.seed",LYRA_TTS_ENGINE="qwen-fast"
 autorestart=unexpected
 exitcodes=0,3,78
@@ -367,6 +370,8 @@ Same rules as TTS (`autorestart=unexpected`, `exitcodes=0,3,78`) — see
 ```ini
 [program:voicecli_nats_stt]
 command=voicecli nats-serve stt
+; VOICECLI_ALLOW_COEXIST is intentionally absent — do NOT set it on co-located GPU
+; hosts. Bypasses the VRAM-sequencing guard and risks OOM. See VRAM sequencing above.
 environment=NATS_URL="nats://nats.internal:4222",NATS_NKEY_SEED_PATH="/home/lyra/.lyra/nkeys/voicecli-stt.seed",VOICECLI_MODEL="large-v3-turbo",VOICECLI_MAX_CONCURRENT="1"
 autorestart=unexpected
 exitcodes=0,3,78
@@ -404,9 +409,19 @@ the compose file:
 echo "$GHCR_TOKEN" | docker login ghcr.io -u <user> --password-stdin
 docker pull ghcr.io/roxabi/lyra:<digest>
 
+# Render the NATS server config from its template
+# (PUBKEY = the nkey public key derived from your seed file)
+export REPO_ROOT="$(git rev-parse --show-toplevel)"
+PUBKEY=$(nk -inkey "$REPO_ROOT/tests/e2e/fixtures/test.seed" -pubout) \
+  envsubst < "$REPO_ROOT/tests/e2e/nats-server.conf.template" \
+  > "$REPO_ROOT/tests/e2e/nats-server.conf"
+
+# Lock down the seed file — required by the satellite (refuses to start otherwise)
+# and by any well-behaved hub image. Editor defaults of 0644 will leak the seed.
+chmod 600 "$REPO_ROOT/tests/e2e/fixtures/test.seed"
+
 # Point the compose file at it and bring up the stack
 export LYRA_HUB_IMAGE="ghcr.io/roxabi/lyra:<digest>"
-export REPO_ROOT="$(git rev-parse --show-toplevel)"
 export NATS_CONF_PATH="$REPO_ROOT/tests/e2e/nats-server.conf"
 export SEED_PATH="$REPO_ROOT/tests/e2e/fixtures/test.seed"
 docker compose -f tests/e2e/docker-compose.real-hub.yml up --abort-on-container-exit

--- a/docs/NATS-SERVE.md
+++ b/docs/NATS-SERVE.md
@@ -380,3 +380,44 @@ stderr_logfile=/home/lyra/.local/state/lyra/logs/voicecli_nats_stt.err
 
 `VOICECLI_MAX_CONCURRENT="1"` is set here because this example targets a co-located GPU
 host (TTS + STT on the same GPU). Remove or raise to `2` on standalone-STT hosts.
+
+---
+
+## Local real-hub E2E
+
+The [`tests/e2e/docker-compose.nats.yml`](../tests/e2e/docker-compose.nats.yml) compose file
+runs the satellite against a **stub hub** — fast, deterministic, no external dependencies,
+and the fixture CI relies on. For a richer local smoke test against a real lyra hub image,
+use the sibling file:
+
+```
+tests/e2e/docker-compose.real-hub.yml
+```
+
+This file is **not run in CI** (the lyra image is private and requires GHCR auth) — it is
+provided for local operators who want an end-to-end sanity check with the actual hub
+before deploying. The hub image is injected via env var so no credentials are baked into
+the compose file:
+
+```bash
+# Pull the lyra hub image once (requires GHCR login)
+echo "$GHCR_TOKEN" | docker login ghcr.io -u <user> --password-stdin
+docker pull ghcr.io/roxabi/lyra:<digest>
+
+# Point the compose file at it and bring up the stack
+export LYRA_HUB_IMAGE="ghcr.io/roxabi/lyra:<digest>"
+export REPO_ROOT="$(git rev-parse --show-toplevel)"
+export NATS_CONF_PATH="$REPO_ROOT/tests/e2e/nats-server.conf"
+export SEED_PATH="$REPO_ROOT/tests/e2e/fixtures/test.seed"
+docker compose -f tests/e2e/docker-compose.real-hub.yml up --abort-on-container-exit
+```
+
+The stack starts a NATS server, the lyra hub at `$LYRA_HUB_IMAGE`, and both voicecli
+satellites (`nats-serve tts` + `nats-serve stt`) using the `mock` engine so no GPU is
+required. The hub exercises the same request/reply contract as production, which makes
+this useful for catching contract drift after lyra or voicecli changes.
+
+If the hub image is not reachable (wrong tag, no GHCR auth, private image gated) the
+compose stack will fail to pull — that is the expected failure mode and the reason this
+file is out of scope for CI. Adding CI support would require private-image auth that is
+tracked separately.

--- a/skills/voice/SKILL.md
+++ b/skills/voice/SKILL.md
@@ -308,6 +308,43 @@ voicecli serve --engine qwen --fast                   # preload smaller 0.6B mod
 
 `generate` and `clone` automatically route to the daemon when it's running — no extra flags. Falls back silently to standalone if the socket isn't present.
 
+### NATS Serve (distributed queue-group satellite)
+
+`voicecli nats-serve {tts,stt}` runs voicecli as a long-lived NATS queue-group subscriber instead of a local Unix-socket daemon — the hub and voicecli talk over NATS subjects rather than a local socket, so they can live on different hosts and be restarted independently.
+
+```bash
+voicecli nats-serve tts                               # TTS satellite (queue group: tts-workers)
+voicecli nats-serve stt                               # STT satellite (queue group: stt-workers)
+voicecli nats-serve tts --allow-coexist               # bypass VRAM guard (large-VRAM hosts only)
+voicecli nats-serve stt --model large-v3-turbo        # override STT model
+```
+
+**When to prefer NATS vs Unix socket:**
+
+| Scenario | Use |
+|---|---|
+| Hub and voicecli on the same host, no network boundary | `voicecli serve` / `stt-serve` (Unix socket) |
+| Hub and voicecli on different hosts | `voicecli nats-serve tts` / `nats-serve stt` |
+| Add satellite capacity without changing hub config | `nats-serve` (add queue-group members) |
+| Production with hub managed separately from GPU worker | `nats-serve` |
+
+**Environment variables (read at startup — restart to apply):**
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `NATS_URL` | — (required) | NATS server URL, e.g. `nats://nats.internal:4222` |
+| `NATS_NKEY_SEED_PATH` | — (required for nkey auth) | Path to NKey seed file — must be `0600` |
+| `NATS_CA_CERT` | — (optional) | PEM CA certificate for TLS verification |
+| `VOICECLI_ENGINE` / `LYRA_TTS_ENGINE` | from `voicecli.toml` | TTS engine override (`qwen`, `qwen-fast`, `chatterbox`, …) |
+| `VOICECLI_MODEL` | `large-v3-turbo` | STT model name (STT-only) |
+| `VOICECLI_MAX_CONCURRENT` | TTS `1` / STT `2` | Parallel request slots — keep at `1` on single-GPU hosts |
+| `VOICECLI_HEARTBEAT_INTERVAL` | `5.0` | Seconds between heartbeats (must stay ≤ 5) |
+| `VOICECLI_DRAIN_TIMEOUT` | `30` | Graceful-shutdown drain window (exit 3 if exceeded) |
+| `VOICECLI_REJECT_WHEN_FULL` | unset | `1` → reject new requests when all slots busy |
+| `VOICECLI_ALLOW_COEXIST` | unset | `1` → bypass VRAM-sequencing guard (dev/large-VRAM hosts) |
+
+Full operator reference: [`docs/NATS-SERVE.md`](../../docs/NATS-SERVE.md).
+
 ### Dictate (STT daemon + overlay)
 
 ```bash

--- a/tests/e2e/docker-compose.real-hub.yml
+++ b/tests/e2e/docker-compose.real-hub.yml
@@ -9,7 +9,12 @@
 # Usage:
 #   export LYRA_HUB_IMAGE=ghcr.io/roxabi/lyra:<digest>
 #   export REPO_ROOT=$(git rev-parse --show-toplevel)
+#   # Render the NATS server config from its template (PUBKEY = nkey public key derived from your seed)
+#   PUBKEY=$(nk -inkey "$REPO_ROOT/tests/e2e/fixtures/test.seed" -pubout) \
+#     envsubst < "$REPO_ROOT/tests/e2e/nats-server.conf.template" > "$REPO_ROOT/tests/e2e/nats-server.conf"
 #   export NATS_CONF_PATH=$REPO_ROOT/tests/e2e/nats-server.conf
+#   # Seed file MUST be 0600 — the satellite refuses to start otherwise, and the lyra hub may also enforce it
+#   chmod 600 "$REPO_ROOT/tests/e2e/fixtures/test.seed"
 #   export SEED_PATH=$REPO_ROOT/tests/e2e/fixtures/test.seed
 #   docker compose -f tests/e2e/docker-compose.real-hub.yml up --abort-on-container-exit
 #
@@ -52,6 +57,7 @@ services:
       VOICECLI_ENABLE_MOCK_ENGINE: "1"
       NATS_URL: "nats://nats:4222"
       NATS_NKEY_SEED_PATH: /run/secrets/nkey.seed
+    restart: on-failure
     volumes:
       - ${REPO_ROOT}:/src:ro
       - ${SEED_PATH}:/run/secrets/nkey.seed:ro
@@ -76,6 +82,7 @@ services:
       VOICECLI_ENABLE_MOCK_ENGINE: "1"
       NATS_URL: "nats://nats:4222"
       NATS_NKEY_SEED_PATH: /run/secrets/nkey.seed
+    restart: on-failure
     volumes:
       - ${REPO_ROOT}:/src:ro
       - ${SEED_PATH}:/run/secrets/nkey.seed:ro

--- a/tests/e2e/docker-compose.real-hub.yml
+++ b/tests/e2e/docker-compose.real-hub.yml
@@ -1,0 +1,85 @@
+# Local real-hub E2E — NOT run in CI.
+#
+# Runs the voicecli NATS satellites against a real lyra hub image instead of
+# the stub hub used by docker-compose.nats.yml. The hub image is injected via
+# $LYRA_HUB_IMAGE (e.g. ghcr.io/roxabi/lyra:<digest>) so no credentials are
+# baked into this file — operators must `docker login ghcr.io` + `docker pull`
+# the image themselves.
+#
+# Usage:
+#   export LYRA_HUB_IMAGE=ghcr.io/roxabi/lyra:<digest>
+#   export REPO_ROOT=$(git rev-parse --show-toplevel)
+#   export NATS_CONF_PATH=$REPO_ROOT/tests/e2e/nats-server.conf
+#   export SEED_PATH=$REPO_ROOT/tests/e2e/fixtures/test.seed
+#   docker compose -f tests/e2e/docker-compose.real-hub.yml up --abort-on-container-exit
+#
+# See docs/NATS-SERVE.md#local-real-hub-e2e for the rationale.
+
+services:
+  nats:
+    image: nats:2-alpine
+    command: ["-c", "/etc/nats/nats-server.conf"]
+    ports:
+      - "4222:4222"
+    volumes:
+      - ${NATS_CONF_PATH}:/etc/nats/nats-server.conf:ro
+
+  lyra-hub:
+    image: ${LYRA_HUB_IMAGE:?set LYRA_HUB_IMAGE to a pulled lyra image, e.g. ghcr.io/roxabi/lyra:<digest>}
+    depends_on: [nats]
+    environment:
+      NATS_URL: "nats://nats:4222"
+      NATS_NKEY_SEED_PATH: /run/secrets/nkey.seed
+    volumes:
+      - ${SEED_PATH}:/run/secrets/nkey.seed:ro
+
+  voicecli-tts:
+    image: python:3.12
+    depends_on: [nats, lyra-hub]
+    working_dir: /app
+    entrypoint: ["bash", "-lc"]
+    command:
+      - >-
+        apt-get update -qq
+        && apt-get install -y -qq --no-install-recommends portaudio19-dev libportaudio2
+        && cp -r /src/. /app
+        && pip install uv -q
+        && uv sync --extra nats --frozen
+        --no-install-package torch
+        --no-install-package torchaudio -q
+        && uv run voicecli nats-serve tts --engine mock
+    environment:
+      VOICECLI_ENABLE_MOCK_ENGINE: "1"
+      NATS_URL: "nats://nats:4222"
+      NATS_NKEY_SEED_PATH: /run/secrets/nkey.seed
+    volumes:
+      - ${REPO_ROOT}:/src:ro
+      - ${SEED_PATH}:/run/secrets/nkey.seed:ro
+      - uv-cache:/root/.cache/uv
+
+  voicecli-stt:
+    image: python:3.12
+    depends_on: [nats, lyra-hub]
+    working_dir: /app
+    entrypoint: ["bash", "-lc"]
+    command:
+      - >-
+        apt-get update -qq
+        && apt-get install -y -qq --no-install-recommends portaudio19-dev libportaudio2
+        && cp -r /src/. /app
+        && pip install uv -q
+        && uv sync --extra nats --frozen
+        --no-install-package torch
+        --no-install-package torchaudio -q
+        && uv run voicecli nats-serve stt --model mock
+    environment:
+      VOICECLI_ENABLE_MOCK_ENGINE: "1"
+      NATS_URL: "nats://nats:4222"
+      NATS_NKEY_SEED_PATH: /run/secrets/nkey.seed
+    volumes:
+      - ${REPO_ROOT}:/src:ro
+      - ${SEED_PATH}:/run/secrets/nkey.seed:ro
+      - uv-cache:/root/.cache/uv
+
+volumes:
+  uv-cache: {}


### PR DESCRIPTION
## Summary
- Slice V4 of ADR-044 NATS decoupling — operator-doc polish + optional real-hub compose for local operators.
- `skills/voice/SKILL.md`: NATS Serve section (env table, when-to-prefer, example invocations) for LLM-authored scripts.
- `CLAUDE.md`: new gotcha covering the three coexistence modes (socket-only / nats-only / allow-coexist) with cross-link to `docs/NATS-SERVE.md#vram-sequencing`.
- `docs/NATS-SERVE.md`: `## Local real-hub E2E` section referencing the new compose file.
- `tests/e2e/docker-compose.real-hub.yml`: NOT run in CI — local-only. Hub image injected via `$LYRA_HUB_IMAGE` so no credentials are committed.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #46: docs(nats): slice V4 polish — SKILL.md + CLAUDE.md + real-hub compose | OPEN |
| Implementation | 1 commit on `feat/46-nats-v4-docs-polish` | Complete |
| Verification | Lint ✅ · Acceptance (AC1–4) ✅ | Passed |

## Test Plan
- [ ] `grep -q nats-serve skills/voice/SKILL.md` — matches (8 hits).
- [ ] `CLAUDE.md` contains `docs/NATS-SERVE.md#vram-sequencing` link.
- [ ] `docs/NATS-SERVE.md` has `## Local real-hub E2E` H2 header.
- [ ] `tests/e2e/docker-compose.real-hub.yml` parses as valid YAML (`python3 -c 'import yaml; yaml.safe_load(open(...))'`) and references `${LYRA_HUB_IMAGE}`.
- [ ] Optional (local only, requires GHCR auth): `LYRA_HUB_IMAGE=<digest> docker compose -f tests/e2e/docker-compose.real-hub.yml up --abort-on-container-exit`.

## Out of scope
- Running real-hub compose in CI (requires private lyra image auth — tracked separately).

Closes #46

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`