### PR TITLE
chore: pin nvidia-ml-py (<14) + slim e2e CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
         run: uv run python -m pytest --ignore=tests/test_overlay.py
 
   e2e:
-    needs: [ci]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -43,12 +42,10 @@ jobs:
       - uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
           enable-cache: true
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y portaudio19-dev libcairo2-dev libgirepository-2.0-dev gir1.2-gtk-3.0
-      - name: Install dependencies
-        run: uv sync --dev --extra nats
+      - name: Install minimal e2e deps
+        # Host only drives docker compose + publishes via NATS client.
+        # Satellites install the full voicecli extra inside containers.
+        run: uv pip install --system pytest "nats-py>=2.6,<3" "nkeys>=0.1"
       - name: Seed-leak lint
         run: |
           if find tests/e2e/ \( -name '*.seed' -o -name '*.nk' \) | grep .; then
@@ -56,7 +53,7 @@ jobs:
             exit 1
           fi
       - name: Run E2E tests
-        run: uv run pytest tests/e2e/ -v
+        run: pytest tests/e2e/ -v
       - name: Dump compose logs on failure
         if: failure()
         # Use -p (project name) instead of -f (compose file) so the step

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ overlay = ["PyGObject>=3.42", "pycairo>=1.25"]
 nats = [
     "nats-py>=2.6,<3",
     "nkeys>=0.1",
-    "nvidia-ml-py>=12",
+    "nvidia-ml-py>=12,<14",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
## Summary
Two independent improvements bundled at review time:

### 1. Pin `nvidia-ml-py` upper bound (closes #59)
- `pyproject.toml`: `nvidia-ml-py>=12` → `>=12,<14`
- Protects downstream consumers (lyra) resolving voiceCLI from git source — they see pyproject spec, not our `uv.lock`. Unbounded `>=12` would silently pull `14.x` whenever it ships and potentially drop deprecated NVML symbols (same class of breakage PR #58 just fixed).

### 2. Parallelize + slim the e2e CI job
Current e2e: ~4m30s, blocked behind ci (~2m21s) via `needs:` → total ~7m wall.
- Drop `needs: [ci]` → runs in parallel
- Remove apt step (portaudio/cairo/gtk) — unused on host for NATS stub-hub
- Replace `uv sync --dev --extra nats` with `uv pip install pytest nats-py nkeys` — tests never import voicecli on the host runner; satellites still install the full extra inside containers

Expected: e2e ~45s, total CI ~2m30s.

## Test plan
- [ ] ci job still green (unchanged)
- [ ] e2e job green with the slim install
- [ ] e2e runtime drops meaningfully (compare to #58-merge baseline of ~4m30s)
- [ ] `uv sync --extra nats` still resolves locally (pin validation)