### PR TITLE
refactor(nats): move STT _resolve_model to voicecli.nats.config

### DIFF
--- a/src/voicecli/cli.py
+++ b/src/voicecli/cli.py
@@ -1439,7 +1439,8 @@ def nats_serve_stt(
     import os
 
     from voicecli.nats.base import DrainTimeoutError
-    from voicecli.nats.stt_adapter import SttNatsAdapter, _resolve_model
+    from voicecli.nats.config import _resolve_model
+    from voicecli.nats.stt_adapter import SttNatsAdapter
 
     logging.basicConfig(level=logging.INFO)
     log = logging.getLogger("voicecli.nats-serve.stt")

--- a/src/voicecli/nats/config.py
+++ b/src/voicecli/nats/config.py
@@ -8,6 +8,7 @@ import os
 log = logging.getLogger(__name__)
 
 DEFAULT_ENGINE = "qwen-fast"
+DEFAULT_MODEL = "large-v3-turbo"
 
 
 def _resolve_engine(cli_value: str | None = None) -> str:
@@ -31,3 +32,22 @@ def _resolve_engine(cli_value: str | None = None) -> str:
         # would mask ImportError / PermissionError as "config absent".
         log.debug("config fallback during _resolve_engine: %s: %s", type(e).__name__, e)
     return DEFAULT_ENGINE
+
+
+def _resolve_model(cli_value: str | None = None) -> str:
+    """Resolve STT model: CLI arg > VOICECLI_MODEL env > voicecli.toml [stt].model > DEFAULT_MODEL."""
+    if cli_value:
+        return cli_value
+    v = os.environ.get("VOICECLI_MODEL")
+    if v:
+        return v
+    try:
+        from voicecli.config import load_config
+
+        cfg = load_config()
+        toml_model = cfg.get("stt", {}).get("model")
+        if toml_model:
+            return toml_model
+    except Exception as e:
+        log.debug("config fallback during _resolve_model: %s: %s", type(e).__name__, e)
+    return DEFAULT_MODEL

--- a/src/voicecli/nats/stt_adapter.py
+++ b/src/voicecli/nats/stt_adapter.py
@@ -23,7 +23,6 @@ from voicecli.nats.tempdir import cleanup, scoped_path
 
 log = logging.getLogger(__name__)
 
-DEFAULT_MODEL = "large-v3-turbo"
 SUBJECT = "lyra.voice.stt.request"
 
 # 25 MB base64 → ~18.75 MB decoded audio (~10 min at 8 kHz, ~2 min at 64 kHz).
@@ -40,25 +39,6 @@ _MIME_TO_EXT: dict[str, str] = {
     "audio/flac": "flac",
     "audio/webm": "webm",
 }
-
-
-def _resolve_model(cli_value: str | None = None) -> str:
-    """Resolve STT model: CLI arg > VOICECLI_MODEL env > voicecli.toml [stt].model > DEFAULT_MODEL."""
-    if cli_value:
-        return cli_value
-    v = os.environ.get("VOICECLI_MODEL")
-    if v:
-        return v
-    try:
-        from voicecli.config import load_config
-
-        cfg = load_config()
-        toml_model = cfg.get("stt", {}).get("model")
-        if toml_model:
-            return toml_model
-    except Exception:
-        pass
-    return DEFAULT_MODEL
 
 
 def _duration_from_segments(segments: list[dict]) -> float:

--- a/tests/nats/test_config.py
+++ b/tests/nats/test_config.py
@@ -1,7 +1,10 @@
-"""RED-phase tests for voicecli.nats.config._resolve_engine (issue #49 T11).
+"""Tests for voicecli.nats.config resolvers (issues #49, #61).
 
-Covers: CLI arg wins; VOICECLI_ENGINE > LYRA_TTS_ENGINE > toml > DEFAULT_ENGINE;
-load_config exception is swallowed.
+Covers:
+  * _resolve_engine — CLI arg wins; VOICECLI_ENGINE > LYRA_TTS_ENGINE > toml > DEFAULT_ENGINE;
+    load_config exception is swallowed.
+  * _resolve_model — CLI arg wins; VOICECLI_MODEL > toml [stt].model > DEFAULT_MODEL;
+    load_config exception is swallowed.
 """
 
 from __future__ import annotations
@@ -9,13 +12,20 @@ from __future__ import annotations
 import pytest
 
 try:
-    from voicecli.nats.config import DEFAULT_ENGINE, _resolve_engine
+    from voicecli.nats.config import (
+        DEFAULT_ENGINE,
+        DEFAULT_MODEL,
+        _resolve_engine,
+        _resolve_model,
+    )
 
     _IMPORT_ERROR: ImportError | None = None
 except ImportError as _e:
     _IMPORT_ERROR = _e
     _resolve_engine = None  # type: ignore[assignment]
+    _resolve_model = None  # type: ignore[assignment]
     DEFAULT_ENGINE = None  # type: ignore[assignment]
+    DEFAULT_MODEL = None  # type: ignore[assignment]
 
 
 def _require_imports() -> None:
@@ -112,3 +122,75 @@ class TestResolveEngine:
 
         # Assert
         assert result == DEFAULT_ENGINE
+
+
+class TestResolveModel:
+    def test_cli_arg_wins_over_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _require_imports()
+        # Arrange — env var set, CLI arg should win
+        monkeypatch.setenv("VOICECLI_MODEL", "small")
+
+        # Act
+        result = _resolve_model("tiny")
+
+        # Assert
+        assert result == "tiny"
+
+    def test_env_var_used_when_cli_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _require_imports()
+        # Arrange
+        monkeypatch.setenv("VOICECLI_MODEL", "small")
+
+        # Act
+        result = _resolve_model(None)
+
+        # Assert
+        assert result == "small"
+
+    def test_toml_model_fallback_when_no_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _require_imports()
+        # Arrange — no env var; load_config returns stt.model
+        monkeypatch.delenv("VOICECLI_MODEL", raising=False)
+        monkeypatch.setattr(
+            "voicecli.config.load_config",
+            lambda: {"stt": {"model": "toml-model"}},
+        )
+
+        # Act
+        result = _resolve_model(None)
+
+        # Assert
+        assert result == "toml-model"
+
+    def test_default_model_when_all_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _require_imports()
+        # Arrange — no env var; toml has no stt.model entry
+        monkeypatch.delenv("VOICECLI_MODEL", raising=False)
+        monkeypatch.setattr(
+            "voicecli.config.load_config",
+            lambda: {},
+        )
+
+        # Act
+        result = _resolve_model(None)
+
+        # Assert
+        assert result == DEFAULT_MODEL
+
+    def test_load_config_exception_falls_through_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _require_imports()
+        # Arrange — no env var; load_config raises
+        monkeypatch.delenv("VOICECLI_MODEL", raising=False)
+
+        def _raise():
+            raise RuntimeError("config file not found")
+
+        monkeypatch.setattr("voicecli.config.load_config", _raise)
+
+        # Act — must not raise; exception is swallowed
+        result = _resolve_model(None)
+
+        # Assert
+        assert result == DEFAULT_MODEL

--- a/tests/nats/test_stt_adapter.py
+++ b/tests/nats/test_stt_adapter.py
@@ -21,23 +21,21 @@ import pytest
 # ---------------------------------------------------------------------------
 
 try:
+    from voicecli.nats.config import DEFAULT_MODEL
+    from voicecli.nats.queue_groups import STT_WORKERS
     from voicecli.nats.stt_adapter import (
-        DEFAULT_MODEL,
         HEARTBEAT_SUBJECT,
         SUBJECT,
         SttNatsAdapter,
         _duration_from_segments,
         _ext_from_mime,
-        _resolve_model,
     )
-    from voicecli.nats.queue_groups import STT_WORKERS
     from voicecli.transcribe import TranscriptionResult
 
     _IMPORT_ERROR: ImportError | None = None
 except ImportError as _e:
     _IMPORT_ERROR = _e
     SttNatsAdapter = None  # type: ignore[assignment,misc]
-    _resolve_model = None  # type: ignore[assignment]
     _duration_from_segments = None  # type: ignore[assignment]
     _ext_from_mime = None  # type: ignore[assignment]
     TranscriptionResult = None  # type: ignore[assignment]
@@ -627,49 +625,6 @@ class TestSttNatsAdapter:
 
         # Assert — temp file removed even when transcription fails
         assert not temp_file.exists()
-
-    # ------------------------------------------------------------------
-    # Case 19: _resolve_model — env var VOICECLI_MODEL used when CLI is None
-    # ------------------------------------------------------------------
-    def test_resolve_model_env_var_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        _require_imports()
-        # Arrange
-        monkeypatch.setenv("VOICECLI_MODEL", "small")
-
-        # Act
-        resolved = _resolve_model(None)
-
-        # Assert
-        assert resolved == "small"
-
-    # ------------------------------------------------------------------
-    # Case 20: _resolve_model — DEFAULT_MODEL used when env absent and config empty
-    # ------------------------------------------------------------------
-    def test_resolve_model_default_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        _require_imports()
-        # Arrange
-        monkeypatch.delenv("VOICECLI_MODEL", raising=False)
-
-        with patch("voicecli.config.load_config", return_value={}):
-            # Act
-            resolved = _resolve_model(None)
-
-        # Assert
-        assert resolved == DEFAULT_MODEL
-
-    # ------------------------------------------------------------------
-    # Case 21: _resolve_model — CLI value beats env var (CLI > env)
-    # ------------------------------------------------------------------
-    def test_resolve_model_cli_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        _require_imports()
-        # Arrange — env var set, but CLI value should win
-        monkeypatch.setenv("VOICECLI_MODEL", "small")
-
-        # Act
-        resolved = _resolve_model("tiny")
-
-        # Assert
-        assert resolved == "tiny"
 
     # ------------------------------------------------------------------
     # Case 22 (F12): heartbeat continues firing while inference is in-flight


### PR DESCRIPTION
## Summary
- Mirrors the TTS resolver placement from PR #58 — moves `_resolve_model` and `DEFAULT_MODEL` from `src/voicecli/nats/stt_adapter.py` into `voicecli.nats.config` alongside `_resolve_engine`, so both adapters stay free of CLI-layer precedence logic.
- Updates `cli.py` import and relocates the 3 `_resolve_model` precedence tests from `test_stt_adapter.py` into `test_config.py` as a new `TestResolveModel` class. No behavior change.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #61: refactor(nats): move STT _resolve_model to voicecli.nats.config for symmetry | OPEN |
| Implementation | 1 commit on `feat/61-move-stt-resolve-model` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (325 passed, excl. pre-existing cairo env issue in test_overlay.py) | Passed |

## Test Plan
- [ ] `uv run pytest tests/nats/test_config.py tests/nats/test_stt_adapter.py -v` → 33 passed
- [ ] Smoke: `uv run python -c "from voicecli.nats.config import _resolve_model, DEFAULT_MODEL"`
- [ ] Confirm `voicecli nats-serve stt` still resolves the model from CLI > env > toml > default

Closes #61

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`