### PR TITLE
feat(nats): forward full ADR-044 TTS field set

### DIFF
--- a/docs/NATS-SERVE.md
+++ b/docs/NATS-SERVE.md
@@ -203,6 +203,45 @@ is not set.
 
 ---
 
+## TTS request field coverage
+
+ADR-044 freezes the TTS request envelope in `lyra/artifacts/plans/688-voicecli-contract-adr-plan.mdx`. The satellite handles every field in that schema — either by forwarding it to `api.generate`, applying it as control flow, or stamping it into the reply.
+
+| Field | Type | Handling |
+|---|---|---|
+| `contract_version` | string | Defensive read — logged at WARN once per worker if ≠ `"1"`, request still processed. Outgoing replies always stamp `"1"`. |
+| `request_id` | string | Required. Rejected with `malformed_request` if missing or not matching `^[A-Za-z0-9_-]{1,128}$`. Echoed in every reply. |
+| `text` | string | Required. Rejected with `malformed_request` if missing, empty, or not a string. Forwarded as the first positional arg of `api.generate`. |
+| `engine` | string | Optional; falls back to `default_engine` from satellite startup. Validated via `validate_nats_token`; unknown engine → `engine_unavailable`. |
+| `language` | string | Forwarded to `api.generate(language=…)`. |
+| `voice` | string | Forwarded to `api.generate(voice=…)`. |
+| `speed` | float | Forwarded through `**kwargs`; `translate.py` strips for engines that do not consume it. |
+| `exaggeration` | float | Forwarded through `**kwargs`. |
+| `cfg_weight` | float | Forwarded through `**kwargs`. |
+| `accent` | string | Forwarded through `**kwargs`; recomposed into an `instruct` string by `api._apply_config_defaults`. |
+| `personality` | string | Forwarded through `**kwargs`; recomposed into the `instruct` string. |
+| `emotion` | string | Forwarded through `**kwargs`; recomposed into the `instruct` string. |
+| `chunked` | bool | Forwarded as a named `api.generate(chunked=…)` argument. Explicit `False` is preserved (not dropped). |
+| `chunk_size` | int | Forwarded as `api.generate(chunk_size=…)`. Bounded 1–10 000 by `api._validate_tts_params`. |
+| `segment_gap` | int (ms) | Forwarded as `api.generate(segment_gap=…)`. Bounded 0–30 000 ms. |
+| `crossfade` | int (ms) | Forwarded as `api.generate(crossfade=…)`. Bounded 0–10 000 ms. |
+| `fallback_language` | string | Control flow only. If primary synthesis raises `ValueError` and `fallback_language ≠ language`, the satellite retries once with `language = fallback_language` before returning `synthesis_failed`. Lyra normally resolves `fallback_language` client-side before dispatch; this branch is a defensive backstop. |
+
+### Reply fields
+
+| Field | Condition |
+|---|---|
+| `ok` | Always present. `true` on successful synthesis. |
+| `contract_version` | Always `"1"`. |
+| `request_id` | Echoed from the request. |
+| `audio_b64` | Base64-encoded WAV bytes on success. |
+| `mime_type` | `audio/wav` on success. |
+| `duration_ms` | Computed from the WAV header; `0` if unreadable. |
+| `waveform_b64` | Optional. 256-byte amplitude array (base64), computed from the generated WAV for Discord voice-message rendering. Omitted when the WAV is unreadable or the sample width is unsupported. |
+| `error` | Error code on failure (`malformed_request`, `engine_unavailable`, `capacity_exceeded`, `synthesis_failed`). |
+
+---
+
 ## STT satellite
 
 ### CLI invocation

--- a/src/voicecli/nats/tts_adapter.py
+++ b/src/voicecli/nats/tts_adapter.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import functools
 import logging
 import os
 import re
 import socket
+import struct
 import time
 import wave
 from concurrent.futures import ThreadPoolExecutor
@@ -47,6 +47,46 @@ def _wav_duration_ms(path: Path) -> int:
     except Exception:
         pass
     return 0
+
+
+def _wav_waveform_b64(path: Path, num_samples: int = 256) -> str | None:
+    """Compute a 256-byte amplitude waveform from a WAV file.
+
+    Mirrors lyra's `_wav_waveform_b64` so Discord voice-message waveforms
+    can be rendered without a second decoding pass hub-side.
+    Returns None on any error (field is optional in ADR-044).
+    """
+    try:
+        with wave.open(str(path), "rb") as wf:
+            n_channels = wf.getnchannels()
+            sampwidth = wf.getsampwidth()
+            n_frames = wf.getnframes()
+            raw = wf.readframes(n_frames)
+
+        if sampwidth == 1:
+            samples = [raw[i] - 128 for i in range(0, len(raw), n_channels)]
+            max_val = 128
+        elif sampwidth == 2:
+            samples = [
+                struct.unpack_from("<h", raw, i)[0] for i in range(0, len(raw) - 1, 2 * n_channels)
+            ]
+            max_val = 32768
+        else:
+            return None
+
+        if not samples:
+            return None
+
+        chunk = max(1, len(samples) // num_samples)
+        waveform = bytearray()
+        for i in range(num_samples):
+            sl = samples[i * chunk : i * chunk + chunk]
+            amp = sum(abs(x) for x in sl) // len(sl) if sl else 0
+            waveform.append(min(255, int(amp * 255 / max_val)))
+        return base64.b64encode(bytes(waveform)).decode("ascii")
+    except Exception:
+        log.warning("waveform_b64 computation failed", exc_info=True)
+        return None
 
 
 class TtsNatsAdapter(NatsAdapterBase):
@@ -140,6 +180,8 @@ class TtsNatsAdapter(NatsAdapterBase):
             self.model_loaded = engine
             from voicecli import api
 
+            # Engine-agnostic kwargs forwarded through api.generate **kwargs
+            # (translate.py will strip fields the target engine can't consume).
             optional_kwargs = {
                 k: v
                 for k, v in {
@@ -148,29 +190,65 @@ class TtsNatsAdapter(NatsAdapterBase):
                     "speed": payload.get("speed"),
                     "exaggeration": payload.get("exaggeration"),
                     "cfg_weight": payload.get("cfg_weight"),
+                    "accent": payload.get("accent"),
+                    "personality": payload.get("personality"),
+                    "emotion": payload.get("emotion"),
                 }.items()
                 if v is not None
             }
-            fn = functools.partial(
-                api.generate,
-                text,
-                engine=engine,
-                output=out_path,
-                **optional_kwargs,
-            )
+
+            # Named parameters of api.generate — must be passed explicitly, not via **kwargs.
+            named_kwargs: dict[str, Any] = {}
+            chunked = payload.get("chunked")
+            if chunked is not None:
+                named_kwargs["chunked"] = bool(chunked)
+            for key in ("chunk_size", "segment_gap", "crossfade"):
+                value = payload.get(key)
+                if value is not None:
+                    named_kwargs[key] = value
+
             loop = asyncio.get_running_loop()
-            await loop.run_in_executor(self._executor, fn)
+
+            def _synthesize(language: str | None) -> None:
+                kw = dict(optional_kwargs)
+                if language is not None:
+                    kw["language"] = language
+                api.generate(text, engine=engine, output=out_path, **kw, **named_kwargs)
+
+            try:
+                await loop.run_in_executor(self._executor, _synthesize, None)
+            except ValueError as exc:
+                # ADR-044 fallback_language semantics: api.generate raises ValueError for
+                # param/language validation; retry once with the fallback before giving up.
+                fallback_language = payload.get("fallback_language")
+                primary_language = payload.get("language")
+                if fallback_language and fallback_language != primary_language:
+                    log.warning(
+                        "language_synthesis_failed_retrying_with_fallback",
+                        extra={
+                            "request_id": request_id,
+                            "primary_language": primary_language,
+                            "fallback_language": fallback_language,
+                            "error": str(exc),
+                        },
+                    )
+                    await loop.run_in_executor(self._executor, _synthesize, fallback_language)
+                else:
+                    raise
+
             audio_b64 = base64.b64encode(out_path.read_bytes()).decode("ascii")
             duration_ms = _wav_duration_ms(out_path)
+            waveform_b64 = _wav_waveform_b64(out_path)
+            reply_fields: dict[str, Any] = {
+                "audio_b64": audio_b64,
+                "mime_type": "audio/wav",
+                "duration_ms": duration_ms,
+            }
+            if waveform_b64 is not None:
+                reply_fields["waveform_b64"] = waveform_b64
             await self.reply(
                 msg,
-                build_reply(
-                    ok=True,
-                    request_id=request_id,
-                    audio_b64=audio_b64,
-                    mime_type="audio/wav",
-                    duration_ms=duration_ms,
-                ),
+                build_reply(ok=True, request_id=request_id, **reply_fields),
             )
         except Exception:
             log.exception("synthesis_failed", extra={"request_id": request_id})

--- a/tests/nats/test_tts_adapter.py
+++ b/tests/nats/test_tts_adapter.py
@@ -604,3 +604,271 @@ class TestTtsNatsAdapter:
 
         # Assert
         assert resolved == "qwen"
+
+    # ------------------------------------------------------------------
+    # Issue #47 — Full ADR-044 TTS field coverage
+    # ------------------------------------------------------------------
+
+    def _run_with_capture(self, tmp_path: Path, payload: dict) -> tuple[dict, list, dict]:
+        """Invoke handle() with api.generate patched; return (reply, args, kwargs)."""
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        captured: dict = {}
+
+        def _patched_scoped_path(rid: str, ext: str) -> Path:
+            return tmp_path / f"{rid}.{ext}"
+
+        def _fake_generate(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            # Write a 1-byte stub so base64 + waveform steps succeed.
+            out = kwargs.get("output")
+            if out is not None:
+                Path(out).write_bytes(b"\x00")
+            return None
+
+        with (
+            patch("voicecli.nats.tts_adapter.scoped_path", side_effect=_patched_scoped_path),
+            patch("voicecli.nats.tts_adapter._engine_available", return_value=True),
+            patch("voicecli.api.generate", side_effect=_fake_generate),
+        ):
+            asyncio.run(adapter.handle(msg, payload))
+
+        return msg.last_reply(), captured.get("args", ()), captured.get("kwargs", {})
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("accent", "british"),
+            ("personality", "cheerful"),
+            ("emotion", "excited"),
+        ],
+    )
+    def test_forwards_instruct_parts(self, tmp_path: Path, field: str, value: str) -> None:
+        _require_imports()
+        payload = _valid_payload() | {field: value}
+        reply, _args, kwargs = self._run_with_capture(tmp_path, payload)
+        assert reply["ok"] is True
+        assert kwargs.get(field) == value
+
+    def test_forwards_chunked_true(self, tmp_path: Path) -> None:
+        _require_imports()
+        payload = _valid_payload() | {"chunked": True}
+        reply, _args, kwargs = self._run_with_capture(tmp_path, payload)
+        assert reply["ok"] is True
+        assert kwargs.get("chunked") is True
+
+    def test_forwards_chunked_false(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Explicit False must still be forwarded (covers the `is not None` guard).
+        payload = _valid_payload() | {"chunked": False}
+        reply, _args, kwargs = self._run_with_capture(tmp_path, payload)
+        assert reply["ok"] is True
+        assert kwargs.get("chunked") is False
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("chunk_size", 500),
+            ("segment_gap", 250),
+            ("crossfade", 100),
+        ],
+    )
+    def test_forwards_named_chunking_fields(self, tmp_path: Path, field: str, value: int) -> None:
+        _require_imports()
+        payload = _valid_payload() | {field: value}
+        reply, _args, kwargs = self._run_with_capture(tmp_path, payload)
+        assert reply["ok"] is True
+        assert kwargs.get(field) == value
+
+    def test_omits_unset_fields(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Minimal payload — none of the optional engine kwargs should be forwarded.
+        payload = _valid_payload()
+        reply, _args, kwargs = self._run_with_capture(tmp_path, payload)
+        assert reply["ok"] is True
+        for field in (
+            "accent",
+            "personality",
+            "emotion",
+            "chunked",
+            "chunk_size",
+            "segment_gap",
+            "crossfade",
+            "language",
+            "voice",
+        ):
+            assert field not in kwargs, f"{field} should not be forwarded when unset"
+
+    def test_fallback_language_retry_on_value_error(self, tmp_path: Path) -> None:
+        _require_imports()
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload(request_id="req-fb") | {
+            "language": "zz",
+            "fallback_language": "en",
+        }
+
+        call_languages: list[str | None] = []
+
+        def _patched_scoped_path(rid: str, ext: str) -> Path:
+            return tmp_path / f"{rid}.{ext}"
+
+        def _fake_generate(*args, **kwargs):
+            lang = kwargs.get("language")
+            call_languages.append(lang)
+            if lang == "zz":
+                raise ValueError("unsupported language: zz")
+            out = kwargs.get("output")
+            if out is not None:
+                Path(out).write_bytes(b"\x00")
+            return None
+
+        with (
+            patch("voicecli.nats.tts_adapter.scoped_path", side_effect=_patched_scoped_path),
+            patch("voicecli.nats.tts_adapter._engine_available", return_value=True),
+            patch("voicecli.api.generate", side_effect=_fake_generate),
+        ):
+            asyncio.run(adapter.handle(msg, payload))
+
+        # Asserted: primary fails, fallback succeeds, reply is ok.
+        assert call_languages == ["zz", "en"]
+        assert msg.last_reply()["ok"] is True
+
+    def test_fallback_language_no_retry_when_absent(self, tmp_path: Path) -> None:
+        _require_imports()
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        # No fallback_language provided → ValueError bubbles up as synthesis_failed.
+        payload = _valid_payload(request_id="req-nofb") | {"language": "zz"}
+
+        calls = 0
+
+        def _patched_scoped_path(rid: str, ext: str) -> Path:
+            return tmp_path / f"{rid}.{ext}"
+
+        def _fake_generate(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            raise ValueError("unsupported language: zz")
+
+        with (
+            patch("voicecli.nats.tts_adapter.scoped_path", side_effect=_patched_scoped_path),
+            patch("voicecli.nats.tts_adapter._engine_available", return_value=True),
+            patch("voicecli.api.generate", side_effect=_fake_generate),
+        ):
+            asyncio.run(adapter.handle(msg, payload))
+
+        assert calls == 1
+        reply = msg.last_reply()
+        assert reply["ok"] is False
+        assert reply["error"] == "synthesis_failed"
+
+    def test_fallback_language_skipped_when_matches_primary(self, tmp_path: Path) -> None:
+        _require_imports()
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        # fallback == primary → no retry, error is surfaced immediately.
+        payload = _valid_payload(request_id="req-same") | {
+            "language": "en",
+            "fallback_language": "en",
+        }
+        calls = 0
+
+        def _patched_scoped_path(rid: str, ext: str) -> Path:
+            return tmp_path / f"{rid}.{ext}"
+
+        def _fake_generate(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            raise ValueError("unsupported language: en")
+
+        with (
+            patch("voicecli.nats.tts_adapter.scoped_path", side_effect=_patched_scoped_path),
+            patch("voicecli.nats.tts_adapter._engine_available", return_value=True),
+            patch("voicecli.api.generate", side_effect=_fake_generate),
+        ):
+            asyncio.run(adapter.handle(msg, payload))
+
+        assert calls == 1
+        assert msg.last_reply()["ok"] is False
+
+    def test_waveform_b64_populated_on_success(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Real WAV so the waveform helper can decode frames.
+        import wave as _wave
+
+        wav_path = tmp_path / "req-wf.wav"
+
+        def _patched_scoped_path(rid: str, ext: str) -> Path:
+            return tmp_path / f"{rid}.{ext}"
+
+        def _fake_generate(*args, **kwargs):
+            out = Path(kwargs["output"])
+            with _wave.open(str(out), "wb") as wf:
+                wf.setnchannels(1)
+                wf.setsampwidth(2)
+                wf.setframerate(8000)
+                # 400 ms of silence is enough to fill 256 amplitude buckets.
+                wf.writeframes(b"\x00\x00" * 3200)
+            return None
+
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload(request_id="req-wf")
+
+        with (
+            patch("voicecli.nats.tts_adapter.scoped_path", side_effect=_patched_scoped_path),
+            patch("voicecli.nats.tts_adapter._engine_available", return_value=True),
+            patch("voicecli.api.generate", side_effect=_fake_generate),
+        ):
+            asyncio.run(adapter.handle(msg, payload))
+
+        reply = msg.last_reply()
+        assert reply["ok"] is True
+        assert "waveform_b64" in reply
+        assert len(base64.b64decode(reply["waveform_b64"])) == 256
+        assert not wav_path.exists()  # cleanup still runs
+
+    def test_waveform_b64_omitted_when_wav_unreadable(self, tmp_path: Path) -> None:
+        _require_imports()
+        # 1-byte stub is not a valid WAV → helper returns None → field omitted.
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload(request_id="req-no-wf")
+
+        def _patched_scoped_path(rid: str, ext: str) -> Path:
+            return tmp_path / f"{rid}.{ext}"
+
+        def _fake_generate(*args, **kwargs):
+            Path(kwargs["output"]).write_bytes(b"\x00")
+            return None
+
+        with (
+            patch("voicecli.nats.tts_adapter.scoped_path", side_effect=_patched_scoped_path),
+            patch("voicecli.nats.tts_adapter._engine_available", return_value=True),
+            patch("voicecli.api.generate", side_effect=_fake_generate),
+        ):
+            asyncio.run(adapter.handle(msg, payload))
+
+        reply = msg.last_reply()
+        assert reply["ok"] is True
+        assert "waveform_b64" not in reply
+
+    def test_existing_five_fields_still_forwarded(self, tmp_path: Path) -> None:
+        _require_imports()
+        # Regression check — the V1 field set must keep flowing after #47.
+        payload = _valid_payload() | {
+            "language": "en",
+            "voice": "alice",
+            "speed": 1.1,
+            "exaggeration": 0.7,
+            "cfg_weight": 0.5,
+        }
+        reply, _args, kwargs = self._run_with_capture(tmp_path, payload)
+        assert reply["ok"] is True
+        assert kwargs.get("language") == "en"
+        assert kwargs.get("voice") == "alice"
+        assert kwargs.get("speed") == 1.1
+        assert kwargs.get("exaggeration") == 0.7
+        assert kwargs.get("cfg_weight") == 0.5


### PR DESCRIPTION
## Summary
- Extends `TtsNatsAdapter` to forward every optional TTS field in ADR-044 (previously only 5 of 12 reached `api.generate`).
- Adds `waveform_b64` to the success reply so Discord voice-message rendering works hub-side without a second decode.
- Implements `fallback_language` retry semantics and documents the full field-coverage matrix in `docs/NATS-SERVE.md`.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #47: feat(nats): forward full TTS field set over NATS | Open |
| Implementation | 1 commit on `feat/47-forward-full-tts-field-set-over-nats` | Complete |
| Verification | Lint ✅ Format ✅ Tests ✅ (14 new in `test_tts_adapter.py`) | Passed |

## Test Plan
- [ ] `uv run pytest tests/nats/test_tts_adapter.py` — 41 tests pass, including new coverage for accent/personality/emotion, chunked/chunk_size/segment_gap/crossfade, fallback_language retry, and waveform_b64.
- [ ] `uv run pytest --ignore=tests/test_overlay.py --ignore=tests/e2e` — full suite stays green (338 passed).
- [ ] Smoke the forwarded fields against a live satellite with the NATS CLI (see `docs/NATS-SERVE.md#confirming-requests-reach-the-satellite`).

Closes #47

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`