### PR TITLE
fix(nats): concatenate chunked WAV output in TTS adapter

### DIFF
--- a/artifacts/frames/56-move-mock-engine-tests-coerce-bool-env-frame.mdx
+++ b/artifacts/frames/56-move-mock-engine-tests-coerce-bool-env-frame.mdx
@@ -1,0 +1,43 @@
+---
+title: refactor(nats): move MockEngine to tests/ + coerce_bool_env helper
+issue: 56
+status: approved
+tier: F-lite
+date: 2026-04-15
+---
+
+## Problem
+
+Two code-quality issues surfaced during code review of PR #52 (ADR-044 slice V3a):
+
+1. **MockEngine env-gate leak path**: The mock engine (`src/voicecli/engines/mock.py`) is gated by `VOICECLI_ENABLE_MOCK_ENGINE=1`. If a CI job exports this env var and a Docker image is built in that same shell, the variable could survive into a production image layer. A prod caller passing `model="mock"` would then get silent empty transcriptions with no log — a security regression.
+
+2. **Scattered boolean env checks**: `os.environ.get(...) == "1"` is used inconsistently across multiple files. Users who set `VOICECLI_ENABLE_MOCK_ENGINE=true` or `yes` would be confused when the flag silently stays off.
+
+## Who
+
+- **Primary:** voiceCLI maintainers — cleaner test infrastructure, no production leak surface
+- **Secondary:** CI pipeline — consistent env var handling across all boolean flags
+
+## Constraints
+
+- **Blocked on #50** — slice V3b–V3d uses the current env-var gate in the compose stack; moving the mock requires E2E plumbing to be in place first
+- **No API changes** — internal refactor only, no public API impact
+- **Test compatibility** — existing tests using the mock must continue to work via new fixture mechanism
+
+## Out of Scope
+
+- Enable ruff `PLC0415` project-wide (separate follow-up — needs `# noqa` sweep on ~130 lazy-import sites)
+- `output_path` validation in `api.py` (tracked separately)
+- Any changes to NATS satellite behavior beyond the mock cleanup
+
+## Complexity
+
+**Tier: F-lite** — Clear scope, single domain (infra/cleanup), well-defined acceptance criteria, 4–10 files.
+
+**Signals:**
+- size:M label
+- Single domain: test infrastructure + env helper
+- No new architecture — moving code and adding a utility
+- Explicit acceptance criteria (7 checkboxes)
+- Hard dependency on #50 (external blocker, not complexity)

--- a/artifacts/frames/57-centralize-output-path-validation-frame.mdx
+++ b/artifacts/frames/57-centralize-output-path-validation-frame.mdx
@@ -1,0 +1,40 @@
+---
+title: refactor(api): centralize output_path validation (OWASP-adjacent)
+issue: 57
+status: approved
+tier: F-lite
+date: 2026-04-15
+---
+
+## Problem
+
+Every TTS engine accepts an `output_path: Path` from the caller and writes directly without validating that the resolved path stays within an allowed base directory. For a local CLI writing to `~/.voicecli/TTS/voices_out/`, the realistic threat is misconfiguration or malicious `.md` frontmatter `output` field — not a remote attacker. This is low urgency but architecturally incorrect.
+
+Additionally, `output_path.parent.mkdir(parents=True, exist_ok=True)` is duplicated across all 6 engines (qwen, qwen_fast, chatterbox, chatterbox_turbo, voxtral, mock). Centralizing both concerns removes duplication and ensures consistent security posture.
+
+## Who
+
+- **Primary:** voiceCLI maintainers — cleaner architecture, less duplication
+- **Secondary:** Single-user CLI operators — protection against accidental misconfiguration
+
+## Constraints
+
+- **Low priority:** No active exploit path; bundle with future `api.py` refactor to avoid churn
+- **Backward-compatible:** Must support explicit `--output` CLI flag override for intentional writes outside `~/.voicecli/`
+- **Scope bounded:** 6 engines + api.py + tests — no new files beyond optional `paths.py`
+
+## Out of Scope
+
+- Input-path validation (e.g., `--ref-audio` in clone) — separate concern
+- Remote threat models — local CLI context only
+- Changing `--output` flag semantics beyond adding bypass mechanism
+
+## Complexity
+
+**Tier: F-lite** — Clear scope, single domain (api + engines), size:M label matches.
+
+**Signals:**
+- Issue body has complete acceptance criteria (4 scenarios)
+- Explicit out-of-scope boundaries
+- Known file list: 6 engines + api.py + tests
+- No architectural unknowns — straightforward extract-helper refactor

--- a/artifacts/frames/69-adopt-roxabi-nats-sdk-frame.mdx
+++ b/artifacts/frames/69-adopt-roxabi-nats-sdk-frame.mdx
@@ -1,0 +1,46 @@
+---
+title: adopt roxabi-nats v0.1.0 SDK — retire voicecli/nats/base.py port
+issue: 69
+status: approved
+tier: F-lite
+date: 2026-04-15
+---
+
+## Problem
+
+voiceCLI carries a local port of NATS transport primitives in `voicecli/nats/base.py` (and surrounding modules) that duplicates code now maintained in `roxabi-nats`. This port was extracted from Lyra into a standalone SDK (ADR-045) specifically to end drift between projects. The local port creates maintenance burden and risks divergence from the canonical implementation.
+
+The extraction PR (Roxabi/lyra#724) mandated this follow-up: voiceCLI must adopt the SDK to eliminate duplicate code and lock to the maintained contract.
+
+## Who
+
+- **Primary:** voiceCLI developers — simpler NATS adapter code, single source of truth
+- **Secondary:** Lyra developers — unified NATS contract across projects, no drift
+
+## Constraints
+
+- **SDK pin:** `roxabi-nats` v0.1.0 via git source, subdirectory, tag
+- **Stable contract:** Only `roxabi_nats.__all__` (`NatsAdapterBase`, `nats_connect`, `CONTRACT_VERSION`) is stable
+- **Unstable internals:** `_`-prefixed submodules (`_serialize`, `_sanitize`, `_validate`, `_version_check`) may change pre-v1.0
+- **CI gates:** pytest, ruff, pyright must pass
+- **e2e:** docker-compose real-hub test must pass
+- **Issue hygiene:** #54 closed as superseded; #53 and #55 rescoped
+
+## Out of Scope
+
+- **#53 typed adapter ingress** — keep, but implement on top of roxabi-nats contract (not rewriting codec)
+- **#54 centralize nkey seed loading** — superseded by `roxabi_nats.nats_connect`
+- **#55 extend ADR-044** — rescoped to update against new SDK surface (separate issue)
+- **Registry refactor** — Roxabi/lyra#729 is a future v0.2.0 breaking change, not blocking this adoption
+
+## Complexity
+
+**Tier: F-lite** — Clear scope with well-defined acceptance criteria, single domain (Python NATS), no architectural unknowns.
+
+### Signals observed
+
+- Single domain (backend/infra)
+- AC fully specified in issue
+- Replacement path documented (imports → SDK)
+- No new patterns introduced
+- Files affected: ~10 (nats/*.py, cli.py, pyproject.toml, tests)

--- a/artifacts/plans/56-move-mock-engine-tests-coerce-bool-env-plan.mdx
+++ b/artifacts/plans/56-move-mock-engine-tests-coerce-bool-env-plan.mdx
@@ -1,0 +1,174 @@
+---
+title: "Plan: refactor(nats): move MockEngine to tests/ + coerce_bool_env helper"
+issue: 56
+spec: artifacts/specs/56-move-mock-engine-tests-coerce-bool-env-spec.mdx
+complexity: 4/10
+tier: F-lite
+generated: 2026-04-15T12:00:00Z
+---
+
+## Summary
+
+Move MockEngine entirely into test scope and centralize boolean env-var parsing. Five atomic slices: (1) env helper, (2) migrate overlay check, (3) remove production mock branches, (4) move MockEngine + fixture, (5) docs.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph S1["S1: Env Helper"]
+        E1[src/voicecli/env.py] --> E2[tests/test_env.py]
+    end
+
+    subgraph S2["S2: Migrate Overlay"]
+        O1[src/voicecli/overlay.py] --> E1
+    end
+
+    subgraph S3["S3: Remove Mock Branches"]
+        T1[src/voicecli/transcribe.py]
+        G1[src/voicecli/engine.py]
+    end
+
+    subgraph S4["S4: Move MockEngine"]
+        M1[tests/engines/mock.py] --> C1[tests/conftest.py]
+        D1[x src/voicecli/engines/mock.py]
+    end
+
+    subgraph S5["S5: Docs"]
+        D2[docs/NATS-SERVE.md]
+    end
+
+    S1 --> S2
+    S2 --> S3
+    S3 --> S4
+    S4 --> S5
+```
+
+```mermaid
+flowchart LR
+    subgraph Files["Source Files"]
+        E[env.py]
+        O[overlay.py]
+        T[transcribe.py]
+        G[engine.py]
+        M[mock.py]
+    end
+
+    subgraph Tests["Test Files"]
+        TE[test_env.py]
+        TG[test_mock_engine_gate.py]
+        CF[conftest.py]
+    end
+
+    E --> TE
+    E --> O
+    G --> TG
+    M --> CF
+    CF --> TG
+```
+
+## Bootstrap Context
+
+- Existing `MockEngine` at `src/voicecli/engines/mock.py` is self-contained (no external deps beyond struct)
+- Engine registry in `engine.py:_get_registry()` uses lazy imports per-engine
+- Transcribe has two mock branches: line 128 (short-circuit) and line 232 (_load_model guard)
+- Overlay uses `VOICECLI_OVERLAY_TEST` at line 424
+- No existing `tests/conftest.py` — will create
+
+## Agents
+
+| Agent | Tasks | Files |
+|-------|-------|-------|
+| backend-dev | 4 | env.py, overlay.py, engine.py, transcribe.py |
+| tester | 5 | test_env.py, mock.py, conftest.py, test_mock_engine_gate.py |
+| doc-writer | 1 | NATS-SERVE.md |
+
+## Consistency Report
+
+| Aspect | Covered | Total | Status |
+|--------|---------|-------|--------|
+| Success Criteria | 11 | 11 | ✓ Complete |
+| Slices | 5 | 5 | ✓ Complete |
+| Files | 9 | 9 | ✓ Complete |
+| Uncovered | 0 | — | — |
+| Untraced | 0 | — | — |
+
+## Micro-Tasks
+
+### Slice V1: `coerce_bool_env()` helper
+
+| # | Phase | Description | File | Agent | Time | [P] | Diff | Verify | Expected |
+|---|-------|-------------|------|-------|------|-----|------|--------|----------|
+| T1 | RED | Create `src/voicecli/env.py` with `coerce_bool_env()` stub | `src/voicecli/env.py` | backend-dev | 3m | Y | 2 | `grep -q "def coerce_bool_env" src/voicecli/env.py` | exit 0 |
+| T2 | RED | Create `tests/test_env.py` with failing tests for true/false/unset cases | `tests/test_env.py` | tester | 5m | Y | 3 | `uv run pytest tests/test_env.py -v 2>&1 \| grep -c FAILED` | ≥3 |
+| T3 | GREEN | Implement `coerce_bool_env()` to pass tests | `src/voicecli/env.py` | backend-dev | 3m | N | 2 | `uv run pytest tests/test_env.py -v` | 0 failed |
+| T4 | REFACTOR | Add `TRUE_VALUES` frozen constant, docstring polish | `src/voicecli/env.py` | backend-dev | 2m | N | 1 | `grep -q "TRUE_VALUES.*frozenset" src/voicecli/env.py` | exit 0 |
+| T5 | RED-GATE | Verify all tests pass, no regressions | — | tester | 2m | N | 1 | `uv run pytest tests/test_env.py` | 0 failed |
+
+**Dependencies:** T2 → T3 → T4 → T5
+
+### Slice V2: Migrate `VOICECLI_OVERLAY_TEST`
+
+| # | Phase | Description | File | Agent | Time | [P] | Diff | Verify | Expected |
+|---|-------|-------------|------|-------|------|-----|------|--------|----------|
+| T6 | RED | Add failing test for overlay using `coerce_bool_env` | `tests/test_overlay.py` | tester | 3m | Y | 2 | `uv run pytest tests/test_overlay.py -k overlay_env -v 2>&1 \| grep -c FAILED` | ≥1 |
+| T7 | GREEN | Replace `os.environ.get(...) == "1"` with `coerce_bool_env()` at line 424 | `src/voicecli/overlay.py` | backend-dev | 2m | N | 2 | `grep -q "from voicecli.env import coerce_bool_env" src/voicecli/overlay.py` | exit 0 |
+| T8 | RED-GATE | Verify overlay tests pass | — | tester | 2m | N | 1 | `uv run pytest tests/test_overlay.py` | 0 failed |
+
+**Dependencies:** T1 → T6 → T7 → T8
+
+### Slice V3: Remove production mock branches
+
+| # | Phase | Description | File | Agent | Time | [P] | Diff | Verify | Expected |
+|---|-------|-------------|------|-------|------|-----|------|--------|----------|
+| T9 | RED | Add failing test: `available_engines()` never returns "mock" without fixture | `tests/test_mock_engine_gate.py` | tester | 3m | Y | 2 | `uv run pytest tests/test_mock_engine_gate.py::test_env_unset_from_start -v` | pass |
+| T10 | GREEN | Delete mock branch from `_get_registry()` (lines 117–120) | `src/voicecli/engine.py` | backend-dev | 2m | N | 2 | `grep -c "VOICECLI_ENABLE_MOCK_ENGINE" src/voicecli/engine.py` | 0 |
+| T11 | GREEN | Delete mock branch from `transcribe()` (line 128) | `src/voicecli/transcribe.py` | backend-dev | 2m | Y | 2 | `grep -c "mock.*VOICECLI_ENABLE_MOCK_ENGINE" src/voicecli/transcribe.py` | 1 |
+| T12 | GREEN | Delete mock branch from `_load_model()` (line 232) | `src/voicecli/transcribe.py` | backend-dev | 2m | N | 2 | `grep -c "VOICECLI_ENABLE_MOCK_ENGINE" src/voicecli/transcribe.py` | 0 |
+| T13 | RED-GATE | Verify mock never appears in prod registry | — | tester | 2m | N | 1 | `uv run pytest tests/test_mock_engine_gate.py -k "env_unset"` | 0 failed |
+
+**Dependencies:** T9 → T10 → T11 → T12 → T13
+
+### Slice V4: Move MockEngine + create fixture (atomic)
+
+| # | Phase | Description | File | Agent | Time | [P] | Diff | Verify | Expected |
+|---|-------|-------------|------|-------|------|-----|------|--------|----------|
+| T14 | RED | Create `tests/engines/` dir, copy `mock.py` with updated import path | `tests/engines/mock.py` | tester | 3m | Y | 3 | `test -f tests/engines/mock.py` | exit 0 |
+| T15 | GREEN | Create `tests/conftest.py` with `mock_engine` fixture | `tests/conftest.py` | tester | 5m | N | 3 | `grep -q "def mock_engine" tests/conftest.py` | exit 0 |
+| T16 | GREEN | Update `tests/test_mock_engine_gate.py` to use fixture instead of env var | `tests/test_mock_engine_gate.py` | tester | 4m | N | 3 | `grep -q "mock_engine" tests/test_mock_engine_gate.py` | exit 0 |
+| T17 | GREEN | Delete `src/voicecli/engines/mock.py` | `src/voicecli/engines/mock.py` | backend-dev | 1m | N | 1 | `test ! -f src/voicecli/engines/mock.py` | exit 0 |
+| T18 | RED-GATE | Verify all mock gate tests pass with fixture | — | tester | 3m | N | 1 | `uv run pytest tests/test_mock_engine_gate.py` | 0 failed |
+
+**Dependencies:** T14 → T15 → T16 → T17 → T18
+
+### Slice V5: Update E2E compose docs
+
+| # | Phase | Description | File | Agent | Time | [P] | Diff | Verify | Expected |
+|---|-------|-------------|------|-------|------|-----|------|--------|----------|
+| T19 | GREEN | Add "CI Hygiene for Mock Engine" section to `docs/NATS-SERVE.md` | `docs/NATS-SERVE.md` | doc-writer | 4m | Y | 2 | `grep -q "CI Hygiene" docs/NATS-SERVE.md` | exit 0 |
+| T20 | RED-GATE | Full test suite passes | — | tester | 3m | N | 1 | `uv run pytest tests/` | 0 failed |
+
+**Dependencies:** T18 → T19 → T20
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T1: 10 — Create env.py with coerce_bool_env stub
+- T2: 11 — Create failing tests for coerce_bool_env
+- T3: 12 — Implement coerce_bool_env
+- T4: 13 — Refactor env.py with TRUE_VALUES constant
+- T5: 14 — Verify env tests pass
+- T6: 15 — Add failing overlay env test
+- T7: 16 — Migrate overlay to coerce_bool_env
+- T8: 17 — Verify overlay tests pass
+- T9: 18 — Add failing test for mock-free registry
+- T10: 19 — Remove mock branch from engine.py
+- T11: 20 — Remove mock branch from transcribe()
+- T12: 21 — Remove mock branch from _load_model()
+- T13: 22 — Verify mock never in prod registry
+- T14: 23 — Create tests/engines/mock.py
+- T15: 24 — Create mock_engine fixture
+- T16: 25 — Update test_mock_engine_gate.py
+- T17: 26 — Delete src/voicecli/engines/mock.py
+- T18: 27 — Verify mock gate tests pass
+- T19: 28 — Add CI Hygiene docs
+- T20: 29 — Run full test suite

--- a/artifacts/plans/69-adopt-roxabi-nats-sdk-plan.mdx
+++ b/artifacts/plans/69-adopt-roxabi-nats-sdk-plan.mdx
@@ -1,0 +1,236 @@
+---
+title: "Plan: adopt roxabi-nats v0.1.0 SDK"
+issue: 69
+spec: artifacts/specs/69-adopt-roxabi-nats-sdk-spec.mdx
+complexity: 6/10
+tier: F-lite
+generated: "2026-04-15T00:00:00Z"
+---
+
+## Summary
+
+Migrate voiceCLI's NATS primitives to `roxabi-nats` SDK v0.1.0. The SDK has an incompatible constructor signature requiring adapter refactoring. Delete local port files, update CLI error handling, and retain voiceCLI-specific helpers.
+
+## Architecture
+
+### Data Flow (Post-Migration)
+
+```mermaid
+flowchart TD
+    subgraph pyproject["pyproject.toml"]
+        DEP["[tool.uv.sources]<br/>roxabi-nats = {git, subdirectory, tag}"]
+    end
+
+    subgraph sdk["roxabi_nats SDK"]
+        BASE["NatsAdapterBase<br/>envelope_name, schema_version"]
+        CONNECT["nats_connect(url)<br/>reads NATS_NKEY_SEED_PATH"]
+        VAL["_validate.validate_nats_token<br/>(internal)"]
+    end
+
+    subgraph adapters["voicecli/nats/"]
+        TTS["TtsNatsAdapter<br/>envelope_name='tts'<br/>schema_version='1'"]
+        STT["SttNatsAdapter<br/>envelope_name='stt'<br/>schema_version='1'"]
+    end
+
+    subgraph local["voiceCLI Local (retained)"]
+        REPLY["reply.py<br/>build_reply, encode_reply"]
+        QUEUE["queue_groups.py<br/>TTS_WORKERS, STT_WORKERS"]
+        TEMP["tempdir.py<br/>scoped_path, cleanup"]
+        CFG["config.py<br/>_resolve_engine, _resolve_model"]
+    end
+
+    subgraph cli["cli.py"]
+        NSERVE["nats-serve tts/stt<br/>catch asyncio.TimeoutError"]
+    end
+
+    DEP -->|uv sync| BASE
+    DEP -->|uv sync| CONNECT
+    DEP -->|uv sync| VAL
+    BASE -->|extends| TTS
+    BASE -->|extends| STT
+    REPLY --> TTS
+    REPLY --> STT
+    QUEUE --> TTS
+    QUEUE --> STT
+    TEMP --> TTS
+    TEMP --> STT
+    CFG --> NSERVE
+    TTS --> NSERVE
+    STT --> NSERVE
+    VAL --> TTS
+```
+
+### File × Function Map
+
+```mermaid
+flowchart LR
+    subgraph pyproject["pyproject.toml"]
+        dep["add roxabi-nats source"]
+    end
+
+    subgraph tts["tts_adapter.py"]
+        timport["update imports"]
+        tctor["update __init__"]
+        tval["import validate from SDK"]
+    end
+
+    subgraph stt["stt_adapter.py"]
+        simport["update imports"]
+        sctor["update __init__"]
+    end
+
+    subgraph cli["cli.py"]
+        cimport["remove DrainTimeoutError import"]
+        ccatch["catch asyncio.TimeoutError"]
+    end
+
+    subgraph deleted["DELETE"]
+        base["base.py"]
+        conn["connect.py"]
+        ver["_version_check.py"]
+        nvml["nvml.py"]
+    end
+
+    subgraph tests["tests/nats/"]
+        tbase["test_base.py - UPDATE"]
+        tconn["test_connect.py - UPDATE"]
+        tnvml["test_nvml.py - DELETE"]
+    end
+
+    dep --> timport
+    dep --> simport
+    timport --> tctor
+    simport --> sctor
+    tctor --> ccatch
+    sctor --> ccatch
+    ccatch --> base
+    base -.->|delete| deleted
+    conn -.->|delete| deleted
+    ver -.->|delete| deleted
+    nvml -.->|delete| deleted
+    tbase -.->|update| tests
+    tconn -.->|update| tests
+    tnvml -.->|delete| tests
+```
+
+## Bootstrap Context
+
+- **SDK Source:** `https://github.com/Roxabi/lyra.git`, subdirectory `packages/roxabi-nats`, tag `roxabi-nats/v0.1.0`
+- **SDK Public API:** `NatsAdapterBase`, `nats_connect`, `CONTRACT_VERSION` (from `__all__`)
+- **SDK Constructor:** `(subject, queue_group, envelope_name, schema_version, timeout=30.0, drain_timeout=30.0, *, heartbeat_subject, heartbeat_interval=5.0)`
+- **SDK Internal:** `_validate.validate_nats_token` — importable but may change pre-v1.0
+- **Behavior Change:** SDK's `run()` waits for hub readiness (30s timeout); voiceCLI currently skips this
+
+## Agents
+
+| Agent | Tasks | Files |
+|-------|-------|-------|
+| backend-dev | 5 | tts_adapter.py, stt_adapter.py, cli.py, pyproject.toml, __init__.py |
+| tester | 3 | test_base.py, test_connect.py, test_nvml.py |
+
+## Consistency Report
+
+- **Covered:** 17/17 success criteria
+- **Uncovered:** 0
+- **Untraced:** 0
+- **Exemptions:** None
+
+## Micro-Tasks
+
+### Slice S1: Dependency
+
+| # | Description | File | Code Snippet | Verify | Expected | Time | Agent | Trace | Phase |
+|---|-------------|------|--------------|--------|----------|------|-------|-------|-------|
+| 1 | Add roxabi-nats git source to pyproject.toml | `pyproject.toml` | `[tool.uv.sources]\nroxabi-nats = { git = "https://github.com/Roxabi/lyra.git", subdirectory = "packages/roxabi-nats", tag = "roxabi-nats/v0.1.0" }` | `uv sync && python -c "from roxabi_nats import NatsAdapterBase; print('OK')"` | `OK` | 3m | backend-dev | SC-1, U1 | RED |
+| 2 | Add roxabi-nats to [project.optional-dependencies] nats | `pyproject.toml` | `[project.optional-dependencies]\nnats = ["roxabi-nats", "nats-py>=2.6,<3", "nkeys>=0.1"]` | `uv sync` | success | 2m | backend-dev | SC-1 | GREEN |
+
+### Slice S2: TTS Constructor
+
+| # | Description | File | Code Snippet | Verify | Expected | Time | Agent | Trace | Phase |
+|---|-------------|------|--------------|--------|----------|------|-------|-------|-------|
+| 3 | Update TtsNatsAdapter import | `tts_adapter.py` | `from roxabi_nats import NatsAdapterBase` | `python -c "from voicecli.nats.tts_adapter import TtsNatsAdapter"` | no import error | 2m | backend-dev | SC-4, N1 | RED |
+| 4 | Update TtsNatsAdapter constructor | `tts_adapter.py` | `super().__init__(\n    subject=SUBJECT,\n    queue_group=TTS_WORKERS,\n    envelope_name="tts",\n    schema_version="1",\n    heartbeat_subject=HEARTBEAT_SUBJECT,\n    heartbeat_interval=heartbeat_interval,\n    drain_timeout=drain_timeout,\n)` | `python -c "from voicecli.nats.tts_adapter import TtsNatsAdapter; TtsNatsAdapter(default_engine='qwen-fast')"` | no error | 5m | backend-dev | SC-2, M1 | GREEN |
+| 5 | Import validate_nats_token from SDK | `tts_adapter.py` | `from roxabi_nats._validate import validate_nats_token` | `python -c "from voicecli.nats.tts_adapter import validate_nats_token; print('OK')"` | `OK` | 2m | backend-dev | SC-6, N2 | GREEN |
+
+### Slice S3: STT Constructor
+
+| # | Description | File | Code Snippet | Verify | Expected | Time | Agent | Trace | Phase |
+|---|-------------|------|--------------|--------|----------|------|-------|-------|-------|
+| 6 | Update SttNatsAdapter import | `stt_adapter.py` | `from roxabi_nats import NatsAdapterBase` | `python -c "from voicecli.nats.stt_adapter import SttNatsAdapter"` | no import error | 2m | backend-dev | SC-5, N1 | RED |
+| 7 | Update SttNatsAdapter constructor | `stt_adapter.py` | `super().__init__(\n    subject=SUBJECT,\n    queue_group=STT_WORKERS,\n    envelope_name="stt",\n    schema_version="1",\n    heartbeat_subject=HEARTBEAT_SUBJECT,\n    heartbeat_interval=heartbeat_interval,\n    drain_timeout=drain_timeout,\n)` | `python -c "from voicecli.nats.stt_adapter import SttNatsAdapter; SttNatsAdapter(default_model='large-v3')"` | no error | 5m | backend-dev | SC-3, M2 | GREEN |
+
+### Slice S4: CLI Error Handling
+
+| # | Description | File | Code Snippet | Verify | Expected | Time | Agent | Trace | Phase |
+|---|-------------|------|--------------|--------|----------|------|-------|-------|-------|
+| 8 | Remove DrainTimeoutError import in CLI | `cli.py` | `# remove: from voicecli.nats.base import DrainTimeoutError` | `grep -c "DrainTimeoutError" src/voicecli/cli.py` | `0` | 2m | backend-dev | SC-8, M3 | RED |
+| 9 | Catch asyncio.TimeoutError instead | `cli.py` | `except asyncio.TimeoutError:\n    log.error("drain timeout exceeded")\n    raise typer.Exit(3)` | `grep -c "asyncio.TimeoutError" src/voicecli/cli.py` | `2` | 3m | backend-dev | SC-8, M3 | GREEN |
+
+### Slice S5: Delete Port Files
+
+| # | Description | File | Code Snippet | Verify | Expected | Time | Agent | Trace | Phase |
+|---|-------------|------|--------------|--------|----------|------|-------|-------|-------|
+| 10 | Delete base.py | `base.py` | `rm src/voicecli/nats/base.py` | `ls src/voicecli/nats/base.py 2>&1` | `No such file` | 1m | backend-dev | SC-9, D1 | GREEN |
+| 11 | Delete connect.py | `connect.py` | `rm src/voicecli/nats/connect.py` | `ls src/voicecli/nats/connect.py 2>&1` | `No such file` | 1m | backend-dev | SC-9, D1 | GREEN |
+| 12 | Delete _version_check.py | `_version_check.py` | `rm src/voicecli/nats/_version_check.py` | `ls src/voicecli/nats/_version_check.py 2>&1` | `No such file` | 1m | backend-dev | SC-9, D1 | GREEN |
+| 13 | Delete nvml.py | `nvml.py` | `rm src/voicecli/nats/nvml.py` | `ls src/voicecli/nats/nvml.py 2>&1` | `No such file` | 1m | backend-dev | SC-9, D1 | GREEN |
+| 14 | Update __init__.py exports | `__init__.py` | `"""voicecli NATS adapters."""\nfrom voicecli.nats.tts_adapter import TtsNatsAdapter\nfrom voicecli.nats.stt_adapter import SttNatsAdapter\n\n__all__ = ["TtsNatsAdapter", "SttNatsAdapter"]` | `python -c "from voicecli.nats import TtsNatsAdapter, SttNatsAdapter"` | no error | 2m | backend-dev | SC-10 | GREEN |
+
+### Slice S6: Test Updates
+
+| # | Description | File | Code Snippet | Verify | Expected | Time | Agent | Trace | Phase |
+|---|-------------|------|--------------|--------|----------|------|-------|-------|-------|
+| 15 | Delete test_nvml.py | `test_nvml.py` | `rm tests/nats/test_nvml.py` | `ls tests/nats/test_nvml.py 2>&1` | `No such file` | 1m | tester | — | GREEN |
+| 16 | Update test_base.py constructor params | `test_base.py` | Update `_make_adapter` to use `envelope_name`, `schema_version` instead of `service`, `worker_id` | `uv run pytest tests/nats/test_base.py -v` | pass | 10m | tester | — | GREEN |
+| 17 | Update test_connect.py for SDK behavior | `test_connect.py` | Remove or adjust tests for `_read_nkey_seed` (SDK reads from env var) | `uv run pytest tests/nats/test_connect.py -v` | pass | 15m | tester | — | GREEN |
+
+### Slice S7: CI Verify
+
+| # | Description | File | Code Snippet | Verify | Expected | Time | Agent | Trace | Phase |
+|---|-------------|------|--------------|--------|----------|------|-------|-------|-------|
+| 18 | Run pytest | — | — | `uv run pytest` | all pass | 5m | tester | SC-11, V1 | GREEN |
+| 19 | Run ruff check | — | — | `uv run ruff check .` | no errors | 2m | tester | SC-12, V2 | GREEN |
+| 20 | Run ruff format --check | — | — | `uv run ruff format --check .` | no changes | 2m | tester | SC-13, V3 | GREEN |
+| 21 | Run pyright | — | — | `uv run pyright` | no errors | 5m | tester | SC-14, V4 | GREEN |
+
+### Slice S8: e2e Verify
+
+| # | Description | File | Code Snippet | Verify | Expected | Time | Agent | Trace | Phase |
+|---|-------------|------|--------------|--------|----------|------|-------|-------|-------|
+| 22 | Run e2e docker-compose test | — | — | `uv run pytest tests/e2e/` | pass | 10m | tester | SC-15, V5 | GREEN |
+
+### RED-GATE Sentinels
+
+| Slice | Sentinel Task |
+|-------|---------------|
+| S2 | #3 (import) must pass before #4 (constructor) |
+| S3 | #6 (import) must pass before #7 (constructor) |
+| S4 | #8 (remove import) must pass before #9 (add new handler) |
+| S5 | All #10-14 complete before S6 tests |
+| S6 | All test updates complete before S7 CI |
+
+## Task IDs
+
+<!-- Generated by /plan. Used by /implement to resume tasks on session restart. -->
+- T9: Add roxabi-nats git source to pyproject.toml
+- T10: Add roxabi-nats to [project.optional-dependencies] nats
+- T11: Update TtsNatsAdapter import
+- T12: Update TtsNatsAdapter constructor
+- T13: Import validate_nats_token from SDK
+- T14: Update SttNatsAdapter import
+- T15: Update SttNatsAdapter constructor
+- T16: Remove DrainTimeoutError import in CLI
+- T17: Catch asyncio.TimeoutError instead
+- T18: Delete base.py
+- T19: Delete connect.py
+- T20: Delete _version_check.py
+- T21: Delete nvml.py
+- T22: Update __init__.py exports
+- T23: Delete test_nvml.py
+- T24: Update test_base.py constructor params
+- T25: Update test_connect.py for SDK behavior
+- T26: Run pytest
+- T27: Run ruff check
+- T28: Run ruff format --check
+- T29: Run pyright
+- T30: Run e2e docker-compose test

--- a/artifacts/specs/56-move-mock-engine-tests-coerce-bool-env-spec.mdx
+++ b/artifacts/specs/56-move-mock-engine-tests-coerce-bool-env-spec.mdx
@@ -1,0 +1,353 @@
+---
+title: refactor(nats): move MockEngine to tests/ + coerce_bool_env helper
+issue: 56
+status: approved
+tier: F-lite
+date: 2026-04-15
+promoted_from: artifacts/frames/56-move-mock-engine-tests-coerce-bool-env-frame.mdx
+---
+
+## Context
+
+Long-term follow-up from PR #52 (slice V3a of ADR-044). Two code-quality issues surfaced during code review:
+
+1. **MockEngine env-gate leak path** — `src/voicecli/engines/mock.py` is gated by `VOICECLI_ENABLE_MOCK_ENGINE=1`. If a CI job exports this env var and a Docker image is built in that same shell, the variable could survive into a production image layer. A prod caller passing `model="mock"` would get silent empty transcriptions with no log.
+
+2. **Scattered boolean env checks** — `os.environ.get(...) == "1"` pattern is used in 4 sites across 3 files. Users setting `VOICECLI_ENABLE_MOCK_ENGINE=true` or `yes` would see the flag silently stay off.
+
+Blocked on #50 (E2E compose infrastructure) which uses the current env-var gate in docker-compose.nats.yml.
+
+## Goal
+
+**As a voiceCLI maintainer**, I want the MockEngine isolated to test scope and boolean env vars centralized, **so that** production code has no leak path and env flags are discoverable and consistently parsed.
+
+## Users
+
+| User | Impact |
+|------|--------|
+| voiceCLI maintainers | Cleaner test infrastructure, no production leak surface |
+| CI pipeline | Consistent env var handling across all boolean flags |
+| E2E compose tests | Continue using env var activation in test containers |
+
+## Out of Scope
+
+- Changing any non-mock engine behavior
+- Modifying NATS protocol or satellite architecture
+- Altering the existing `MockEngine` implementation (move-only, no refactor)
+- Adding new boolean env vars beyond the 4 existing sites
+- Updating user-facing documentation (env vars are internal)
+- Removing `VOICECLI_ENABLE_MOCK_ENGINE` from E2E docker-compose files (test containers need it)
+
+## Expected Behavior
+
+### Before
+
+```
+VOICECLI_ENABLE_MOCK_ENGINE=1 voicecli generate "hello" -e mock
+→ produces silent WAV (mock engine in production code, gated by env)
+
+os.environ.get("VOICECLI_ENABLE_MOCK_ENGINE") == "1" in engine.py, transcribe.py
+os.environ.get("VOICECLI_OVERLAY_TEST") == "1" in overlay.py
+```
+
+### After
+
+```
+# Production code — mock engine completely absent
+voicecli generate "hello" -e mock
+→ ValueError: Unknown engine 'mock'
+
+# Test scope — mock activated by pytest fixture
+pytest tests/test_mock_engine_gate.py
+→ mock engine registered via conftest fixture, tests pass
+
+# Boolean env vars — unified helper
+coerce_bool_env("VOICECLI_OVERLAY_TEST")  → accepts "1"/"true"/"yes"/"on"
+```
+
+## Data Model & Consumers
+
+```mermaid
+classDiagram
+    class TTSEngine {
+        <<abstract>>
+        +name: str
+        +generate(text, voice, output_path, **kwargs) Path
+        +clone(text, ref_audio, output_path, ref_text, **kwargs) Path
+        +list_voices() list~str~
+    }
+
+    class MockEngine {
+        +name = "mock"
+        +generate(...) Path
+        +clone(...) Path
+        +list_voices() list~str~
+    }
+
+    TTSEngine <|-- MockEngine
+
+    class coerce_bool_env {
+        <<function>>
+        +coerce_bool_env(var: str, default: bool = False) bool
+    }
+
+    note for MockEngine "Moved to tests/engines/mock.py\nActivated only by pytest fixture"
+```
+
+```mermaid
+flowchart LR
+    subgraph Production["Production Code"]
+        A[engine.py<br/>_get_registry] --> B[Registry dict]
+        B --> C[qwen, qwen-fast,<br/>chatterbox, voxtral]
+    end
+
+    subgraph TestScope["Test Scope"]
+        D[tests/conftest.py<br/>mock_engine fixture] --> E[patch _get_registry]
+        E --> F[Registry + mock]
+    end
+
+    subgraph EnvHelper["Env Helper"]
+        G[env.py<br/>coerce_bool_env] --> H["1, true, yes, on<br/>→ True"]
+    end
+
+    D -.-> G
+    A -.-> G
+
+    style MockEngine fill:#f9f,stroke:#333
+```
+
+## Edge Cases
+
+| Scenario | Handling |
+|----------|----------|
+| User has `VOICECLI_ENABLE_MOCK_ENGINE=true` in shell currently | After S4: no effect — production code no longer reads this var |
+| Existing test mocks `_get_registry` independently | Fixture patches registry after construction; coexistence untested → document in conftest |
+| Docker image built with env var in previous layer | Irrelevant after S4 — production code no longer reads `VOICECLI_ENABLE_MOCK_ENGINE` |
+| `coerce_bool_env` called with empty string `""` | Returns `False` (not in accepted set) — document in docstring |
+| CI shell exports env var before Docker build | CI hygiene: `unset VOICECLI_ENABLE_MOCK_ENGINE` before `docker build` |
+
+## Breadboard
+
+### Affordances
+
+| Component | Affordance | Current | Target |
+|-----------|------------|---------|--------|
+| `src/voicecli/env.py` | Boolean env parsing | N/A | **Created** |
+| `src/voicecli/engine.py:_get_registry()` | Mock branch | `if env == "1": registry["mock"] = MockEngine` | **Removed** |
+| `src/voicecli/transcribe.py:transcribe()` | Mock branch (line 128) | Top-of-function check | **Removed** |
+| `src/voicecli/transcribe.py:_load_model()` | Mock branch (line 232) | Model loading check | **Removed** |
+| `src/voicecli/overlay.py` | Boolean env check | `os.environ.get(...) == "1"` | **Migrated to coerce_bool_env** |
+| `tests/engines/mock.py` | Test import | N/A | **Created** (moved from src) |
+| `src/voicecli/engines/mock.py` | Production import | Available | **Deleted** |
+| `tests/conftest.py` | Mock fixture | N/A | **Created** |
+
+### Wiring
+
+| Source | Wire | Sink |
+|--------|------|------|
+| `tests/conftest.py` | `monkeypatch.setattr(_get_registry)` | `engine._get_registry()` |
+| `src/voicecli/engine.py` | `from voicecli.env import coerce_bool_env` | Boolean env checks (future) |
+| `src/voicecli/overlay.py` | `from voicecli.env import coerce_bool_env` | `VOICECLI_OVERLAY_TEST` |
+
+**Note:** E2E docker-compose files retain `VOICECLI_ENABLE_MOCK_ENGINE` env var — this is the intended activation mechanism for standalone test containers. The "leak path" concern is addressed by CI hygiene (unset before production builds), not by code removal.
+
+## Slices
+
+| Slice | Description | Files | Verifies |
+|-------|-------------|-------|----------|
+| **S1** | `coerce_bool_env()` helper | `src/voicecli/env.py`, `tests/test_env.py` | Unit tests for "1"/"true"/"yes"/"on"/"TRUE"/etc |
+| **S2** | Migrate `VOICECLI_OVERLAY_TEST` | `src/voicecli/overlay.py` | Env check replaced with helper |
+| **S3** | Remove production mock branches | `src/voicecli/engine.py`, `src/voicecli/transcribe.py` | No mock refs in production code |
+| **S4** | Move `MockEngine` + create fixture (atomic) | `tests/engines/mock.py` (new), `src/voicecli/engines/mock.py` (delete), `tests/conftest.py` | Import path updated, tests pass with fixture |
+| **S5** | Update E2E compose docs | `tests/e2e/docker-compose.nats.yml`, `tests/e2e/docker-compose.real-hub.yml`, `docs/NATS-SERVE.md` | Document CI hygiene for leak prevention |
+
+### Slice Details
+
+#### S1: `coerce_bool_env()` helper
+
+```python
+# src/voicecli/env.py
+"""Environment variable utilities."""
+
+import os
+from typing import Final
+
+TRUE_VALUES: Final = frozenset(("1", "true", "yes", "on"))
+
+
+def coerce_bool_env(var: str, *, default: bool = False) -> bool:
+    """Parse boolean env var — accepts 1/true/yes/on (case-insensitive).
+
+    Args:
+        var: Environment variable name.
+        default: Value to return if the variable is unset.
+
+    Returns:
+        True if the variable value is in {"1", "true", "yes", "on"} (case-insensitive).
+        False otherwise, including empty string or unset (returns default).
+    """
+    val = os.environ.get(var)
+    if val is None:
+        return default
+    return val.lower() in TRUE_VALUES
+```
+
+```python
+# tests/test_env.py
+"""Unit tests for env.py."""
+
+import os
+import pytest
+from voicecli.env import coerce_bool_env
+
+
+class TestCoerceBoolEnv:
+    def test_true_values(self, monkeypatch):
+        """Accepted values return True."""
+        for val in ("1", "true", "TRUE", "True", "yes", "YES", "on", "ON"):
+            monkeypatch.setenv("TEST_VAR", val)
+            assert coerce_bool_env("TEST_VAR") is True
+
+    def test_false_values(self, monkeypatch):
+        """Non-accepted values return False."""
+        for val in ("0", "false", "no", "off", "", "random", "2"):
+            monkeypatch.setenv("TEST_VAR", val)
+            assert coerce_bool_env("TEST_VAR") is False
+
+    def test_unset_returns_default(self, monkeypatch):
+        """Unset variable returns default."""
+        monkeypatch.delenv("TEST_VAR", raising=False)
+        assert coerce_bool_env("TEST_VAR") is False
+        assert coerce_bool_env("TEST_VAR", default=True) is True
+```
+
+#### S2: Migrate `VOICECLI_OVERLAY_TEST`
+
+```python
+# src/voicecli/overlay.py (change at line ~424)
+# Before:
+if os.environ.get("VOICECLI_OVERLAY_TEST") == "1":
+
+# After:
+from voicecli.env import coerce_bool_env
+if coerce_bool_env("VOICECLI_OVERLAY_TEST"):
+```
+
+#### S3: Remove production mock branches
+
+**engine.py:_get_registry()** — delete entire mock branch:
+
+```python
+# DELETE these lines (~117-120):
+if os.environ.get("VOICECLI_ENABLE_MOCK_ENGINE") == "1":
+    from voicecli.engines.mock import MockEngine
+    registry["mock"] = MockEngine
+```
+
+**transcribe.py** — delete two mock branches:
+
+```python
+# DELETE at line ~128:
+if model == "mock" and os.environ.get("VOICECLI_ENABLE_MOCK_ENGINE") == "1":
+    logger.info("Mock transcription requested — returning empty string")
+    return ""
+
+# DELETE at line ~232 (in _load_model):
+if model == "mock" and os.environ.get("VOICECLI_ENABLE_MOCK_ENGINE") == "1":
+    return None  # Mock doesn't need a real model
+```
+
+#### S4: Move MockEngine + create fixture (atomic)
+
+```python
+# tests/engines/mock.py (moved from src/voicecli/engines/mock.py)
+"""Mock TTS engine for testing."""
+
+from pathlib import Path
+from voicecli.engine import TTSEngine
+
+
+class MockEngine(TTSEngine):
+    """Mock engine that produces empty WAV files."""
+
+    name = "mock"
+
+    def generate(self, text: str, voice: str, output_path: Path, **kwargs) -> Path:
+        """Write an empty WAV file."""
+        # ... (existing implementation, unchanged)
+        return output_path
+
+    def clone(self, text: str, ref_audio: Path, output_path: Path, ref_text: str = None, **kwargs) -> Path:
+        """Write an empty WAV file."""
+        return output_path
+
+    def list_voices(self) -> list[str]:
+        return ["mock-voice"]
+```
+
+```python
+# tests/conftest.py (add to existing file)
+"""Pytest fixtures for voiceCLI tests."""
+
+import pytest
+
+
+@pytest.fixture
+def mock_engine(monkeypatch):
+    """Register MockEngine in the registry for the test scope.
+
+    This fixture patches _get_registry() to include the mock engine,
+    which is isolated to test scope (not in production code).
+    """
+    from voicecli.engine import _get_registry
+    from tests.engines.mock import MockEngine
+
+    original_registry = _get_registry()
+    original_registry["mock"] = MockEngine
+
+    monkeypatch.setattr("voicecli.engine._REGISTRY_CACHE", original_registry)
+    yield
+
+    # Cleanup: remove mock from cache
+    if "mock" in original_registry:
+        del original_registry["mock"]
+```
+
+**Delete:** `src/voicecli/engines/mock.py`
+
+#### S5: Update E2E compose docs
+
+Update `docs/NATS-SERVE.md` with CI hygiene guidance:
+
+```markdown
+## CI Hygiene for Mock Engine
+
+The `VOICECLI_ENABLE_MOCK_ENGINE` env var must **never** be present in a production
+Docker build context. To prevent accidental leakage:
+
+1. **Explicit unset before build:**
+   ```bash
+   unset VOICECLI_ENABLE_MOCK_ENGINE
+   docker build -t voicecli:prod .
+   ```
+
+2. **Separate build stage:** Use a dedicated CI job for production builds that
+   never runs E2E tests (which export the env var).
+
+The mock engine is isolated to test scope via the `tests/engines/mock.py` location
+and pytest fixture activation. Production code has no reference to `MockEngine`.
+```
+
+## Success Criteria
+
+- [ ] `coerce_bool_env()` helper exists at `src/voicecli/env.py`, unit-tested at `tests/test_env.py`
+- [ ] `VOICECLI_OVERLAY_TEST` check in `src/voicecli/overlay.py` uses `coerce_bool_env()`
+- [ ] `src/voicecli/engines/mock.py` removed from production code
+- [ ] `tests/engines/mock.py` contains the `MockEngine` implementation (moved)
+- [ ] `_get_registry()` has no env-var branch and no reference to `MockEngine`
+- [ ] `transcribe.transcribe()` has no mock branch (both sites removed)
+- [ ] `transcribe._load_model()` has no mock branch
+- [ ] `tests/conftest.py` contains `mock_engine` fixture that registers MockEngine
+- [ ] `pytest tests/test_mock_engine_gate.py` passes (prod never returns "mock", fixture activates correctly)
+- [ ] `pytest tests/` passes with 0 failures
+- [ ] CI hygiene guidance added to `docs/NATS-SERVE.md`

--- a/artifacts/specs/69-adopt-roxabi-nats-sdk-spec.mdx
+++ b/artifacts/specs/69-adopt-roxabi-nats-sdk-spec.mdx
@@ -1,0 +1,246 @@
+---
+title: adopt roxabi-nats v0.1.0 SDK — retire voicecli/nats/base.py port
+issue: 69
+status: approved
+tier: F-lite
+date: 2026-04-15
+promoted_from: artifacts/frames/69-adopt-roxabi-nats-sdk-frame.mdx
+---
+
+## Context
+
+voiceCLI's local NATS port (`voicecli/nats/base.py` and surrounding modules) duplicates code now maintained in `roxabi-nats` SDK. The extraction (ADR-045, PR #724) created a canonical SDK to eliminate drift. This spec defines the migration to adopt the SDK.
+
+**API Compatibility Note:** SDK v0.1.0's `NatsAdapterBase` has a different constructor signature than voiceCLI's local version. This migration requires adapter refactoring, not just import swapping.
+
+## Goal
+
+Replace local NATS primitives with `roxabi-nats` SDK, refactor adapters to match SDK signatures, retain voiceCLI-specific helpers, and verify CI/e2e pass.
+
+## Users
+
+- **Primary:** voiceCLI developers — simpler NATS adapter code, single source of truth
+- **Secondary:** Lyra developers — unified NATS contract across projects, no drift
+
+## Constraints
+
+- **Dependency:** `roxabi-nats` pinned to tag `roxabi-nats/v0.1.0` (not latest)
+- **SDK contract:** Only `__all__` exports (`NatsAdapterBase`, `nats_connect`, `CONTRACT_VERSION`) are stable
+- **Internal modules:** `_validate` is internal but required for token validation
+- **Behavior change:** SDK's `run()` waits for hub readiness; voiceCLI currently skips this
+- **VRAM loss:** SDK's heartbeat lacks VRAM fields — acceptable trade-off
+
+## Out of Scope
+
+- Changes to adapter request handling semantics
+- New features in NATS adapters
+- Hub contract changes
+- Migration of Lyra's NATS code (separate issue)
+- #53 typed adapter ingress (keep, implement on top of SDK later)
+- #54 centralize nkey seed loading (superseded by SDK's `nats_connect`)
+- #55 extend ADR-044 (rescoped separately)
+
+## Expected Behavior
+
+1. Developer adds `roxabi-nats` git dependency to `pyproject.toml`
+2. Adapters refactored to match SDK `NatsAdapterBase` constructor signature
+3. All imports of `voicecli.nats.base.NatsAdapterBase` resolve to `roxabi_nats.NatsAdapterBase`
+4. `nats_connect` imported from SDK; `nkey_seed_path` set via env var
+5. Local port files deleted; voiceCLI-specific helpers retained
+6. CLI error handling updated for `asyncio.TimeoutError` (replaces `DrainTimeoutError`)
+7. CI runs green: `pytest`, `ruff`, `pyright`
+8. e2e docker-compose test passes
+
+## Data Model & Consumers
+
+### SDK vs voiceCLI Constructor Comparison
+
+| Param | SDK `NatsAdapterBase` | voiceCLI Local | Migration Action |
+|-------|----------------------|----------------|------------------|
+| `subject` | ✓ positional | ✓ positional | Unchanged |
+| `queue_group` | ✓ positional | ✓ positional | Unchanged |
+| `envelope_name` | ✓ **required** | ✗ | **Add** — `"tts"` / `"stt"` |
+| `schema_version` | ✓ **required** | ✗ | **Add** — `"1"` |
+| `heartbeat_subject` | ✓ keyword, optional | ✓ positional | Make keyword |
+| `service` | ✗ | ✓ | **Remove** — SDK auto-generates |
+| `worker_id` | ✗ | ✓ | **Remove** — SDK auto-generates |
+| `timeout` | ✓ (hub wait) | ✗ | Accept default 30s |
+| `drain_timeout` | ✓ | ✓ | Unchanged |
+
+### Data Structure (Post-Migration)
+
+```mermaid
+classDiagram
+    class NatsAdapterBase {
+        <<SDK>>
+        +subject: str
+        +queue_group: str
+        +envelope_name: str
+        +schema_version: str
+        +heartbeat_subject: str
+        +run(nats_url, stop)
+        +handle(msg, payload) None
+        +heartbeat_payload() dict
+    }
+
+    class TtsNatsAdapter {
+        +default_engine: str
+        +max_concurrent: int
+        +reject_when_full: bool
+        +handle(msg, payload) None
+        -_run_synthesis(...)
+    }
+
+    class SttNatsAdapter {
+        +default_model: str
+        +handle(msg, payload) None
+        -_run_transcription(...)
+    }
+
+    NatsAdapterBase <|-- TtsNatsAdapter
+    NatsAdapterBase <|-- SttNatsAdapter
+```
+
+### Consumer Map
+
+```mermaid
+flowchart LR
+    subgraph "SDK Imports (this issue)"
+        SDK[roxabi_nats]
+        BASE[NatsAdapterBase]
+        CONNECT[nats_connect]
+    end
+
+    subgraph "voiceCLI Local (retained)"
+        REPLY[reply.py]
+        QUEUE[queue_groups.py]
+        TEMP[tempdir.py]
+        CONFIG[config.py]
+        VAL[_validate.py - internal import]
+    end
+
+    subgraph "Adapters"
+        TTS[TtsNatsAdapter]
+        STT[SttNatsAdapter]
+    end
+
+    SDK --> BASE
+    SDK --> CONNECT
+    BASE --> TTS
+    BASE --> STT
+    REPLY --> TTS
+    REPLY --> STT
+    QUEUE --> TTS
+    QUEUE --> STT
+    TEMP --> TTS
+    TEMP --> STT
+    CONFIG --> CLI
+    VAL --> TTS
+```
+
+### Consumer Summary
+
+| Consumer | SDK Imports | Local Imports | Migration |
+|----------|-------------|---------------|-----------|
+| `TtsNatsAdapter` | `NatsAdapterBase`, `nats_connect` | `build_reply`, `TTS_WORKERS`, `cleanup`, `scoped_path`, `validate_nats_token` | Update constructor, keep local imports |
+| `SttNatsAdapter` | `NatsAdapterBase`, `nats_connect` | `build_reply`, `STT_WORKERS`, `cleanup`, `scoped_path` | Update constructor, keep local imports |
+| `cli.py` | — | `_resolve_engine`, `_resolve_model` | No change |
+
+## Breadboard
+
+### Affordance Table
+
+| ID | Element | Handler | Data |
+|----|---------|---------|------|
+| U1 | `pyproject.toml` dependency | uv sync | git source, subdirectory, tag |
+| N1 | SDK import | Python import resolver | `from roxabi_nats import NatsAdapterBase` |
+| N2 | Internal import | Python import resolver | `from roxabi_nats._validate import validate_nats_token` |
+| M1 | TTS constructor refactor | Code change | Add `envelope_name="tts"`, `schema_version="1"` |
+| M2 | STT constructor refactor | Code change | Add `envelope_name="stt"`, `schema_version="1"` |
+| M3 | CLI error handling | Code change | Catch `asyncio.TimeoutError` instead of `DrainTimeoutError` |
+| D1 | Delete port files | File deletion | `base.py`, `connect.py`, `_version_check.py` |
+| V1 | pytest | CI runner | Unit + integration tests |
+| V2 | ruff check | CI runner | Lint check |
+| V3 | ruff format --check | CI runner | Format check |
+| V4 | pyright | CI runner | Type checking |
+| V5 | docker-compose | e2e test runner | Stub-hub integration |
+
+### Wiring
+
+```
+U1 ──enables──> N1, N2
+N1 ──requires──> M1, M2 (constructor signature)
+M3 ──replaces──> DrainTimeoutError handling
+D1 ──follows──> M1, M2, M3 (all refactors complete)
+V1-V4 ──verify──> U1, N1, M1-M3, D1
+V5 ──verifies──> End-to-end NATS flow
+```
+
+## Slices
+
+| Slice | Scope | Demo | Depends on |
+|-------|-------|------|------------|
+| **S1: Dependency** | Add `roxabi-nats` to `pyproject.toml`, run `uv sync` | `from roxabi_nats import NatsAdapterBase` succeeds | — |
+| **S2: TTS Constructor** | Update `TtsNatsAdapter.__init__` to pass `envelope_name`, `schema_version` | Adapter instantiates without error | S1 |
+| **S3: STT Constructor** | Update `SttNatsAdapter.__init__` to pass `envelope_name`, `schema_version` | Adapter instantiates without error | S1 |
+| **S4: Validate Import** | Update `tts_adapter.py` to import `validate_nats_token` from `roxabi_nats._validate` | Import succeeds, validation works | S1 |
+| **S5: CLI Error Handling** | Update `cli.py` to catch `asyncio.TimeoutError` for drain timeout (exit code 3) | `nats-serve` handles timeout correctly | S2, S3 |
+| **S6: Delete Port** | Remove `base.py`, `connect.py`, `_version_check.py` | No orphaned files, imports still work | S5 |
+| **S7: CI Verify** | Run `pytest`, `ruff check`, `ruff format --check`, `pyright` | All green | S6 |
+| **S8: e2e Verify** | Run docker-compose stub-hub test (CI e2e job) | Test passes | S7 |
+
+## Files to Delete vs Retain
+
+### Delete (SDK replaces)
+
+- `voicecli/nats/base.py` — replaced by `roxabi_nats.NatsAdapterBase`
+- `voicecli/nats/connect.py` — replaced by `roxabi_nats.nats_connect`
+- `voicecli/nats/_version_check.py` — replaced by SDK internal
+
+### Retain (voiceCLI-specific)
+
+- `voicecli/nats/reply.py` — `build_reply`, `encode_reply` (not in SDK)
+- `voicecli/nats/queue_groups.py` — `TTS_WORKERS`, `STT_WORKERS` constants
+- `voicecli/nats/tempdir.py` — `scoped_path`, `cleanup` helpers
+- `voicecli/nats/config.py` — `_resolve_engine`, `_resolve_model`
+- `voicecli/nats/tts_adapter.py` — stays with updated imports + constructor
+- `voicecli/nats/stt_adapter.py` — stays with updated imports + constructor
+- `voicecli/nats/__init__.py` — stays (update exports)
+- `voicecli/nats/_validate.py` — stays (used locally, SDK internal is importable)
+
+### Special Case: `nvml.py`
+
+- SDK's `heartbeat_payload()` does NOT include VRAM fields
+- voiceCLI's heartbeat currently includes `vram_used_mb`, `vram_total_mb`
+- **Decision:** Delete `nvml.py`, accept VRAM field loss in heartbeat (hub can query GPU directly)
+
+## Success Criteria
+
+- [ ] `pyproject.toml` declares `roxabi-nats` via git source: `git = "https://github.com/Roxabi/lyra.git"`, `subdirectory = "packages/roxabi-nats"`, `tag = "roxabi-nats/v0.1.0"`
+- [ ] `TtsNatsAdapter.__init__` passes `envelope_name="tts"` and `schema_version="1"` to SDK base class
+- [ ] `SttNatsAdapter.__init__` passes `envelope_name="stt"` and `schema_version="1"` to SDK base class
+- [ ] `TtsNatsAdapter` imports `NatsAdapterBase` from `roxabi_nats` (not `voicecli.nats.base`)
+- [ ] `SttNatsAdapter` imports `NatsAdapterBase` from `roxabi_nats` (not `voicecli.nats.base`)
+- [ ] `tts_adapter.py` imports `validate_nats_token` from `roxabi_nats._validate`
+- [ ] All NATS connections use `roxabi_nats.nats_connect`
+- [ ] `cli.py` catches `asyncio.TimeoutError` for drain timeout (replaces `DrainTimeoutError`)
+- [ ] Port files deleted: `voicecli/nats/base.py`, `voicecli/nats/connect.py`, `voicecli/nats/_version_check.py`, `voicecli/nats/nvml.py`
+- [ ] Local helpers retained: `reply.py`, `queue_groups.py`, `tempdir.py`, `config.py`, `_validate.py`
+- [ ] `pytest` passes (unit + integration tests)
+- [ ] `ruff check .` passes (no lint errors)
+- [ ] `ruff format --check .` passes (no format changes needed)
+- [ ] `pyright` passes (no type errors)
+- [ ] e2e docker-compose stub-hub test passes
+- [ ] Issue #54 closed with comment "Superseded by #69 — SDK's `nats_connect` centralizes nkey loading"
+- [ ] Issues #53 and #55 commented with rescope note
+
+## Edge Cases
+
+| Scenario | Handling |
+|----------|----------|
+| SDK import fails | CI catches at S1 (import test) |
+| Constructor signature wrong | S2/S3 demo catches at instantiation |
+| `validate_nats_token` internal import breaks | Accept — SDK README documents internal modules may change pre-v1.0 |
+| VRAM fields missing in heartbeat | Accept trade-off — hub can query GPU directly |
+| Hub readiness wait changes startup | Accept — satellites now wait up to 30s for hub before subscribing |
+| e2e test flake | Re-run; if persistent, block on infra |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ packages = ["src/voicecli"]
 [tool.ruff]
 target-version = "py312"
 line-length = 100
+exclude = [".claude/"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["F401"]

--- a/src/voicecli/nats/tts_adapter.py
+++ b/src/voicecli/nats/tts_adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import logging
 import os
 import re
@@ -34,6 +35,62 @@ def _engine_available(engine: str) -> bool:
     from voicecli.engine import _get_registry
 
     return engine in _get_registry()
+
+
+def _collect_chunked_output(out_path: Path) -> list[Path]:
+    """Return sorted chunk paths if a .done marker exists, else empty list.
+
+    When api.generate() runs in chunked mode it writes:
+        {stem}_001.wav, {stem}_002.wav, … {stem}_NNN.wav
+        {stem}.done  (sentinel written after all chunks)
+
+    The adapter expects a single file at *out_path* ({stem}.wav). If the
+    engine wrote chunks instead, this function returns them in order so the
+    caller can concatenate them.
+    """
+    done_path = out_path.with_suffix(".done")
+    if not done_path.exists():
+        return []
+    stem = out_path.stem
+    parent = out_path.parent
+    chunks = sorted(parent.glob(f"{stem}_*.wav"))
+    return chunks
+
+
+def _concat_wav_chunks(chunks: list[Path], out_path: Path) -> None:
+    """Concatenate WAV chunk files into *out_path* using the stdlib wave module.
+
+    All chunks must share the same format (channels, sample width, frame rate).
+    Raises ValueError if the chunk list is empty or format is inconsistent.
+    """
+    if not chunks:
+        raise ValueError("concat_wav_chunks: chunk list is empty")
+
+    with wave.open(str(chunks[0]), "rb") as first:
+        params = first.getparams()
+
+    with wave.open(str(out_path), "wb") as out_wav:
+        out_wav.setparams(params)
+        for chunk_path in chunks:
+            with wave.open(str(chunk_path), "rb") as chunk_wav:
+                if (
+                    chunk_wav.getnchannels() != params.nchannels
+                    or chunk_wav.getsampwidth() != params.sampwidth
+                    or chunk_wav.getframerate() != params.framerate
+                ):
+                    raise ValueError(
+                        f"chunk format mismatch in {chunk_path}: "
+                        f"expected {params.nchannels}ch/{params.sampwidth}sw/{params.framerate}Hz"
+                    )
+                out_wav.writeframes(chunk_wav.readframes(chunk_wav.getnframes()))
+
+
+def _cleanup_chunks(out_path: Path, chunks: list[Path]) -> None:
+    """Remove chunk files and the .done sentinel. Idempotent."""
+    done_path = out_path.with_suffix(".done")
+    for p in [*chunks, done_path]:
+        with contextlib.suppress(FileNotFoundError):
+            p.unlink()
 
 
 def _wav_duration_ms(path: Path) -> int:
@@ -235,6 +292,14 @@ class TtsNatsAdapter(NatsAdapterBase):
                     await loop.run_in_executor(self._executor, _synthesize, fallback_language)
                 else:
                     raise
+
+            # If the engine ran in chunked mode it writes {stem}_NNN.wav files
+            # plus a {stem}.done sentinel instead of {stem}.wav directly.
+            # Detect and concatenate chunks into out_path before encoding.
+            chunks = _collect_chunked_output(out_path)
+            if chunks:
+                _concat_wav_chunks(chunks, out_path)
+                _cleanup_chunks(out_path, chunks)
 
             audio_b64 = base64.b64encode(out_path.read_bytes()).decode("ascii")
             duration_ms = _wav_duration_ms(out_path)

--- a/tests/nats/test_tts_adapter.py
+++ b/tests/nats/test_tts_adapter.py
@@ -895,3 +895,132 @@ class TestTtsNatsAdapter:
         assert kwargs.get("speed") == 1.1
         assert kwargs.get("exaggeration") == 0.7
         assert kwargs.get("cfg_weight") == 0.5
+
+    # ------------------------------------------------------------------
+    # Chunked output — chatterbox writes {stem}_NNN.wav + .done
+    # ------------------------------------------------------------------
+
+    def _make_silent_wav_bytes(self, n_frames: int = 2205) -> bytes:
+        """Build a minimal silent WAV (22050 Hz, 16-bit, mono)."""
+        import struct as _struct
+        import wave as _wave
+        import io
+
+        buf = io.BytesIO()
+        with _wave.open(buf, "wb") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(22050)
+            wf.writeframes(b"\x00\x00" * n_frames)
+        return buf.getvalue()
+
+    def test_chunked_output_single_chunk_succeeds(self, tmp_path: Path) -> None:
+        """Engine writes {stem}_001.wav + {stem}.done — adapter concatenates and encodes."""
+        _require_imports()
+        request_id = "req-chunk1"
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload(request_id=request_id)
+        wav_bytes = self._make_silent_wav_bytes()
+
+        def _patched_scoped_path(rid: str, ext: str) -> Path:
+            return tmp_path / f"{rid}.{ext}"
+
+        def _fake_generate(*args, **kwargs):
+            out = Path(kwargs["output"])
+            # Write chunk file and done marker (mimics api._generate_chunked behaviour)
+            chunk = out.parent / f"{out.stem}_001.wav"
+            chunk.write_bytes(wav_bytes)
+            done = out.with_suffix(".done")
+            done.write_text("done\n")
+            # out_path itself ({stem}.wav) is intentionally NOT written
+            return None
+
+        with (
+            patch("voicecli.nats.tts_adapter.scoped_path", side_effect=_patched_scoped_path),
+            patch("voicecli.nats.tts_adapter._engine_available", return_value=True),
+            patch("voicecli.api.generate", side_effect=_fake_generate),
+        ):
+            asyncio.run(adapter.handle(msg, payload))
+
+        reply = msg.last_reply()
+        assert reply["ok"] is True, f"expected ok=True, got: {reply}"
+        assert reply["mime_type"] == "audio/wav"
+        assert "audio_b64" in reply
+        decoded = base64.b64decode(reply["audio_b64"])
+        # Decoded bytes must be a valid WAV (RIFF header)
+        assert decoded[:4] == b"RIFF"
+        # Chunk files and .done sentinel must be cleaned up
+        assert not (tmp_path / f"{request_id}_001.wav").exists()
+        assert not (tmp_path / f"{request_id}.done").exists()
+
+    def test_chunked_output_multiple_chunks_concatenated(self, tmp_path: Path) -> None:
+        """Engine writes {stem}_001.wav + {stem}_002.wav + {stem}.done — adapter
+        concatenates all chunks and the resulting audio is longer than a single chunk."""
+        _require_imports()
+        request_id = "req-chunk2"
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload(request_id=request_id)
+        chunk_frames = 2205  # 100 ms of silence per chunk @ 22050 Hz
+        wav_bytes = self._make_silent_wav_bytes(chunk_frames)
+
+        def _patched_scoped_path(rid: str, ext: str) -> Path:
+            return tmp_path / f"{rid}.{ext}"
+
+        def _fake_generate(*args, **kwargs):
+            out = Path(kwargs["output"])
+            for i in (1, 2):
+                chunk = out.parent / f"{out.stem}_{i:03d}.wav"
+                chunk.write_bytes(wav_bytes)
+            done = out.with_suffix(".done")
+            done.write_text("done\n")
+            return None
+
+        with (
+            patch("voicecli.nats.tts_adapter.scoped_path", side_effect=_patched_scoped_path),
+            patch("voicecli.nats.tts_adapter._engine_available", return_value=True),
+            patch("voicecli.api.generate", side_effect=_fake_generate),
+        ):
+            asyncio.run(adapter.handle(msg, payload))
+
+        reply = msg.last_reply()
+        assert reply["ok"] is True, f"expected ok=True, got: {reply}"
+        # duration_ms must reflect both chunks (≥ 200 ms of silence)
+        assert reply["duration_ms"] >= 200
+        decoded = base64.b64decode(reply["audio_b64"])
+        assert decoded[:4] == b"RIFF"
+        # All chunk files and .done must be cleaned up
+        for i in (1, 2):
+            assert not (tmp_path / f"{request_id}_{i:03d}.wav").exists()
+        assert not (tmp_path / f"{request_id}.done").exists()
+
+    def test_non_chunked_output_unaffected(self, tmp_path: Path) -> None:
+        """Engine writes {stem}.wav directly (no .done) — existing path unchanged."""
+        _require_imports()
+        request_id = "req-nochunk"
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        payload = _valid_payload(request_id=request_id)
+        wav_bytes = self._make_silent_wav_bytes()
+
+        def _patched_scoped_path(rid: str, ext: str) -> Path:
+            return tmp_path / f"{rid}.{ext}"
+
+        def _fake_generate(*args, **kwargs):
+            # Standard non-chunked: write directly to out_path
+            out = Path(kwargs["output"])
+            out.write_bytes(wav_bytes)
+            return None
+
+        with (
+            patch("voicecli.nats.tts_adapter.scoped_path", side_effect=_patched_scoped_path),
+            patch("voicecli.nats.tts_adapter._engine_available", return_value=True),
+            patch("voicecli.api.generate", side_effect=_fake_generate),
+        ):
+            asyncio.run(adapter.handle(msg, payload))
+
+        reply = msg.last_reply()
+        assert reply["ok"] is True
+        decoded = base64.b64decode(reply["audio_b64"])
+        assert decoded[:4] == b"RIFF"


### PR DESCRIPTION
## Summary

- **Root cause**: chatterbox engine (and any other engine with `chunked=True` in config) writes `{request_id}_001.wav`, `{request_id}_002.wav`, … + `{request_id}.done` via `api._generate_chunked()`. The adapter was reading `{request_id}.wav` (never written), hitting `FileNotFoundError`, and returning `synthesis_failed`.
- **Fix (Option A)**: after `api.generate()` returns, detect the `.done` sentinel; concatenate all `{stem}_NNN.wav` chunks into `out_path` using stdlib `wave`; clean up chunks + sentinel; then continue with the existing encode → reply path. The non-chunked path is completely unaffected.
- **New tests**: `test_chunked_output_single_chunk_succeeds`, `test_chunked_output_multiple_chunks_concatenated` (verifies duration doubles for 2 chunks), `test_non_chunked_output_unaffected`. All 44 tests pass.

## Bundled lint cleanup

At reviewer request, two pre-existing lint issues were folded into this branch:

- **`transcribe.py` F401** — unused `import os` removed (confirmed absent on current branch; resolved via prior rebase onto staging).
- **`test_overlay.py` E402** — imports below GTK mock block correctly suppressed with `# noqa: E402` (already present on current branch).
- **ruff scope** — `.claude/` worktree directory added to ruff `exclude` list so ephemeral agent worktrees do not produce false-positive E402 errors in CI (`chore(lint)` commit `8b584f8`).

`uv run ruff check .` — `All checks passed!`

## Test plan

- [x] `uv run ruff check .` — clean (all checks passed)
- [x] `uv run pyright src/voicecli/nats/tts_adapter.py` — 0 errors
- [x] `uv run pytest tests/nats/test_tts_adapter.py -v` — 44/44 passed
- [ ] Deploy to Machine 1 staging and re-run lyra #689 voice-smoke round-trip test

🤖 Generated with [Claude Code](https://claude.com/claude-code)