### PR TITLE
refactor(api): centralize output_path validation

### DIFF
--- a/artifacts/specs/57-centralize-output-path-validation-spec.mdx
+++ b/artifacts/specs/57-centralize-output-path-validation-spec.mdx
@@ -1,0 +1,158 @@
+---
+title: refactor(api): centralize output_path validation (OWASP-adjacent)
+issue: 57
+status: approved
+tier: F-lite
+date: 2026-04-15
+promoted_from: artifacts/frames/57-centralize-output-path-validation-frame.mdx
+---
+
+## Context
+
+Promoted from [frame](../frames/57-centralize-output-path-validation-frame.mdx). Follow-up from PR #52 (security-auditor review).
+
+## Goal
+
+Centralize output path validation in `api.py` to prevent path traversal and remove duplicated `mkdir` calls across 5 TTS engines.
+
+## Users
+
+- **Primary:** voiceCLI maintainers — single validation point, less duplication
+- **Secondary:** CLI operators — protection against misconfiguration
+
+## Expected Behavior
+
+1. `voicecli generate "text" --output ../../etc/evil.wav` → error: path escapes allowed base
+2. `voicecli generate "text" --output /tmp/test.wav` → allowed (absolute path bypass via CLI)
+3. `voicecli generate "text" --output ./custom/test.wav` → validated against base (inside → works)
+4. `voicecli generate "text"` → works as before, auto-created directory
+5. Non-CLI caller (e.g., Lyra) passes `output` → validated against base (no bypass)
+
+> **Note:** Frontmatter `output:` field is **not supported** — `TTSDocument` has no `output` attribute. This eliminates the frontmatter attack vector. Only CLI `--output` can override path.
+
+## Edge Cases
+
+| Case | Input | Expected | Test |
+|------|-------|----------|------|
+| Symlink escape | `--output ~/voices_out/link.wav` where `link` → `/etc/` | Blocked (resolve follows symlink) | Unit test |
+| Relative path inside base | `--output ./subdir/test.wav` | Works (validated, stays in base) | Unit test |
+| Relative path escapes base | `--output ../../escape.wav` | Blocked | Unit test |
+| Absolute path inside base | `--output /home/user/.voicecli/TTS/voices_out/x.wav` | Works (inside base) | Unit test |
+| Absolute path outside base | `--output /tmp/test.wav` | Bypassed (CLI flag) | Unit test |
+| Non-CLI caller | `api.generate(..., output=Path("/tmp/x.wav"))` | Blocked (no bypass) | Unit test |
+
+## Data Model & Consumers
+
+```mermaid
+classDiagram
+    class OutputPath {
+        +Path raw
+        +Path resolved
+        +Path allowed_base
+        +bool cli_bypass
+        +validate() Path
+    }
+
+    class TTSResult {
+        +Path wav_path
+        +Path mp3_path
+        +list~Path~ chunk_paths
+    }
+
+    OutputPath --> TTSResult : produces wav_path
+```
+
+```mermaid
+flowchart LR
+    subgraph "This Issue"
+        CLI[cli.py] -->|"output + _cli_bypass=True"| API[api.py]
+        Other[Lyra / other callers] -->|"output + _cli_bypass=False"| API
+        API -->|"validate"| VP[_validate_output_path]
+        VP -->|"mkdir + check"| Engines[5 engines]
+        API -->|"validate"| Transcribe[transcribe]
+    end
+
+    style VP fill:#4a9,stroke:#333
+    style Engines fill:#999,stroke:#333
+```
+
+| Consumer | Fields Used | When | Status |
+|----------|-------------|------|--------|
+| `api.generate()` | `output`, `_cli_bypass` | Entry point | This issue |
+| `api.clone()` | `output`, `_cli_bypass` | Entry point | This issue |
+| `api.transcribe()` | `output` | Entry point | This issue |
+| Engines | validated `output_path` | After validation | This issue (mkdir removed) |
+
+## Breadboard
+
+### Affordances
+
+| ID | Location | Element | Description |
+|----|----------|---------|-------------|
+| U1 | `cli.py` | `--output` flag | Passes `output` + `_cli_bypass=True` to API |
+| U2 | `cli.py` | stdin/text input | Passes `_cli_bypass=False` (default) |
+| U3 | External | `api.generate()` call | Non-CLI callers get `_cli_bypass=False` |
+| N1 | `api.py` | `_validate_output_path()` | Validates + mkdirs, returns resolved path |
+| N2 | `api.py` | `_cli_bypass` param | Private bool, default `False` |
+| S1 | `engines/*.py` | `.generate()` / `.clone()` | No mkdir, receives validated path |
+
+### Wiring
+
+| From | To | Trigger | Data |
+|------|-----|---------|------|
+| U1 | `api.generate()` | CLI invocation | `output`, `_cli_bypass=True` |
+| U3 | `api.generate()` | Library call | `output`, `_cli_bypass=False` |
+| `api.generate()` | N1 | Before engine dispatch | `output`, `allowed_base`, `_cli_bypass` |
+| N1 | S1 | After validation | `resolved_path` |
+
+## Slices
+
+| # | Name | Files | Demo | Dependencies |
+|---|------|-------|------|--------------|
+| 1 | Add validator helper | `api.py` | Unit tests pass | None |
+| 2 | Wire into generate/clone/transcribe | `api.py` | Integration test | Slice 1 |
+| 3 | Remove mkdir from engines + api chunked helpers | `engines/*.py`, `api.py` | All tests pass | Slice 2 |
+| 4 | Add CLI bypass param | `api.py`, `cli.py` | Manual demo | Slice 2 |
+
+## Success Criteria
+
+### Validator
+
+- [ ] `_validate_output_path()` helper exists in `api.py`
+- [ ] Helper validates path stays within `allowed_base` (default: `~/.voicecli/TTS/voices_out/`)
+- [ ] Helper creates parent directories with `mkdir(parents=True, exist_ok=True)`
+- [ ] Helper raises `ValueError` with clear message on path escape attempt
+- [ ] Helper follows symlinks via `resolve()` and validates resolved path
+
+### API Integration
+
+- [ ] `api.generate()` calls validator before dispatching to engine
+- [ ] `api.clone()` calls validator before dispatching to engine
+- [ ] `api.transcribe()` calls validator for output path
+
+### CLI Bypass
+
+- [ ] `api.generate()` / `api.clone()` accept `_cli_bypass: bool = False` private parameter
+- [ ] `cli.py` passes `_cli_bypass=True` when `--output` flag is used
+- [ ] Non-CLI callers default to `_cli_bypass=False` (strict validation)
+
+### Engine Cleanup
+
+- [ ] All 5 engines remove local `mkdir` calls
+- [ ] `_generate_chunked()` in `api.py` removes local `mkdir` call
+- [ ] `_clone_chunked()` in `api.py` removes local `mkdir` call
+
+### Tests
+
+- [ ] Unit test: valid path inside base → works
+- [ ] Unit test: path with `..` escaping base → raises `ValueError`
+- [ ] Unit test: absolute path outside base without bypass → raises `ValueError`
+- [ ] Unit test: absolute path outside base with bypass → works
+- [ ] Unit test: relative path inside base → works (validated)
+- [ ] Unit test: relative path escaping base → raises `ValueError`
+- [ ] Unit test: symlink pointing outside base → raises `ValueError`
+- [ ] Unit test: nested non-existent directory inside base → auto-created
+
+## Open Questions
+
+None — expert review concerns addressed.

--- a/docs/architecture/adr/001-output-path-trust-model.mdx
+++ b/docs/architecture/adr/001-output-path-trust-model.mdx
@@ -1,0 +1,205 @@
+---
+title: "ADR-001: Output-path trust model for generate, clone, and transcribe"
+description: Replace the _cli_bypass boolean with an explicit allowed_base parameter and an UNRESTRICTED sentinel to encode each caller's containment contract at the call site.
+---
+
+## Status
+
+Accepted
+
+## Context
+
+`_validate_output_path` was extracted in PR #74 (issue #57) to centralize the
+`mkdir` + path-traversal guard that had been scattered inline across five engines
+and two chunked helpers.
+
+The extraction introduced a `_cli_bypass: bool` parameter to handle callers that
+should not be constrained to `OUTPUT_DIR`. Three distinct caller semantics were
+collapsed into that flag:
+
+| Caller | Intended semantics |
+|---|---|
+| `cli.generate` / `cli.clone` | Human explicitly chose a path — write anywhere |
+| NATS adapter (`_run_synthesis`) | Server controls the path via `scoped_path(request_id, "wav")` — write to temp scratch dir |
+| `api.generate` / `api.clone` (library, no override) | Stay inside `OUTPUT_DIR` |
+| `api.transcribe` (library, no override) | Stay inside `STT_OUTPUT_DIR`, not `OUTPUT_DIR` |
+
+The `_cli_bypass: bool` flag conflated cases 1 and 2 (both pass `True` today),
+leaked a private naming convention into the public `generate()` and `clone()`
+signatures, caused `mkdir` to run unconditionally outside the guard, surfaced the
+resolved temp-dir path in error messages, and silently applied `OUTPUT_DIR` as the
+base for STT output (wrong domain).
+
+Four review findings traced directly to this design:
+
+- **F5** — `_cli_bypass` as a named parameter on public API functions
+- **F7** — `mkdir` executes even when the bypass short-circuits validation
+- **F8** — error message exposes the resolved scratch-dir path
+- **STT base asymmetry** — `transcribe()` inherits the TTS `OUTPUT_DIR`
+
+## Options Considered
+
+### Option A: Typed enum `OutputPolicy`
+
+```python
+class OutputPolicy(enum.Enum):
+    LIBRARY   = "library"    # validate against allowed_base, create dirs
+    TRUSTED   = "trusted"    # skip validation, create dirs
+```
+
+Pass `policy: OutputPolicy` as a required parameter.
+
+- **Pros:** Self-documenting, IDE-completable, extensible
+- **Cons:** Enum import on every call site; adds a new public type; the distinction
+  between `LIBRARY` + a custom base vs. `TRUSTED` is still encoded in two
+  parameters; over-engineered for a thin CLI
+
+### Option B: Dual functions — `validate_contained_path` + `resolve_trusted_path`
+
+Two separate functions with disjoint contracts.
+
+- **Pros:** No conditional logic; each function is maximally obvious
+- **Cons:** Caller must choose the right function — the same error-prone decision
+  is pushed to every call site; doubles the surface to test; `transcribe` still
+  needs a way to supply a different base
+
+### Option C: `allowed_base: Path | None` + `UNRESTRICTED` sentinel (recommended)
+
+Keep a single function. Replace `cli_bypass: bool` with `allowed_base: Path`.
+Add a module-level sentinel `UNRESTRICTED = object()` (or use `None` for trusted,
+with the default being `OUTPUT_DIR`).
+
+After evaluation, the cleanest flat form is:
+
+```python
+# In utils.py — alongside OUTPUT_DIR
+STT_OUTPUT_DIR = Path.home() / ".voicecli" / "STT" / "texts_out"
+
+# Sentinel — type-checked via `is`
+UNRESTRICTED: Path = object()  # type: ignore[assignment]
+```
+
+```python
+def _validate_output_path(
+    output_path: Path,
+    *,
+    allowed_base: Path,
+) -> Path:
+    """Resolve output_path and enforce containment within allowed_base.
+
+    Pass allowed_base=UNRESTRICTED to skip containment check (CLI --output).
+    mkdir is always called after a successful check or for UNRESTRICTED paths.
+
+    Returns the resolved absolute Path.
+    Raises ValueError when path escapes allowed_base.
+    """
+    resolved = output_path.expanduser().resolve()
+
+    if allowed_base is not UNRESTRICTED:
+        base = allowed_base.expanduser().resolve()
+        try:
+            resolved.relative_to(base)
+        except ValueError:
+            raise ValueError(
+                f"output path escapes allowed directory "
+                f"(allowed: {base}). Pass an explicit --output to write elsewhere."
+            )
+
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    return resolved
+```
+
+- **Pros:**
+  - No new public type; `allowed_base` is descriptive and required — no silent
+    default to the wrong domain
+  - STT base is expressed directly at the `transcribe()` call site
+  - `UNRESTRICTED` sentinel communicates intent without a boolean
+  - Error message references the semantic base name, not a temp path
+  - `mkdir` placement is unchanged but its guard is now the `allowed_base is not
+    UNRESTRICTED` branch — logically correct and testable
+  - `generate()` / `clone()` signatures lose the `_cli_bypass` parameter entirely
+- **Cons:** `UNRESTRICTED` is a sentinel that requires `is`-comparison (not `==`);
+  that is documented in the docstring
+
+## Decision
+
+Option C — `allowed_base: Path` required parameter with `UNRESTRICTED` sentinel.
+
+`_cli_bypass` is removed from all public API functions. Each caller declares its
+own containment contract explicitly.
+
+### Call-site examples
+
+**CLI (`cli.py` — human override, write anywhere):**
+```python
+from voicecli.utils import UNRESTRICTED
+
+# output is guaranteed non-None here (Typer parsed it)
+out = _validate_output_path(Path(output), allowed_base=UNRESTRICTED)
+```
+
+**NATS adapter (`tts_adapter.py` — server-controlled scratch path):**
+```python
+from voicecli.utils import UNRESTRICTED
+
+# scoped_path is already pre-validated; adapter controls lifecycle
+api.generate(text, engine=engine, output=out_path, allowed_base=UNRESTRICTED, ...)
+```
+
+Alternatively — and this is the preferred shape — the NATS adapter does NOT pass
+`allowed_base` at all. Instead `api.generate()` / `api.clone()` can accept
+`output_path_base: Path = OUTPUT_DIR` and the adapter just passes its
+`scoped_path(...)` as `output`. The adapter already validates `request_id` format
+and owns the temp dir, so the containment check against `scoped_path`'s parent is
+redundant. Passing `UNRESTRICTED` is explicit and documents intent.
+
+**Library default (no caller override — stay in TTS output dir):**
+```python
+# In api.generate(), output is None branch falls through to default_output_path()
+# which already writes inside OUTPUT_DIR — _validate_output_path is only called
+# when output is not None.
+if output is not None:
+    out = _validate_output_path(Path(output), allowed_base=OUTPUT_DIR)
+else:
+    out = default_output_path(prefix)
+```
+
+**STT / transcribe (different base domain):**
+```python
+from voicecli.utils import STT_OUTPUT_DIR
+
+if output is not None:
+    out_path = _validate_output_path(Path(output), allowed_base=STT_OUTPUT_DIR)
+    out_path.write_text(result.text, encoding="utf-8")
+```
+
+## Consequences
+
+### Positive
+
+- `generate()` and `clone()` public signatures no longer carry a `_cli_bypass`
+  parameter — the API is clean for library consumers
+- Each caller's trust model is visible at the call site; no inference required
+- `transcribe()` uses the correct STT base — the domain mismatch is fixed
+  structurally, not by a comment
+- Error messages reference the meaningful base directory name
+- `default_output_path()` asymmetry (it calls `mkdir` internally, while
+  `_validate_output_path` does so only after validation) is now irrelevant for the
+  auto-path branch because `_validate_output_path` is only reached when `output`
+  is explicitly provided
+
+### Negative
+
+- `UNRESTRICTED` sentinel requires `is`-comparison; callers must import it from
+  `utils` alongside `OUTPUT_DIR` / `STT_OUTPUT_DIR`
+- `_validate_output_path` remains a required-keyword-arg function — callers cannot
+  call it without naming `allowed_base`, which is the point but requires a
+  one-time update to all existing call sites (3 in `api.py`)
+
+### Neutral
+
+- `STT_OUTPUT_DIR` is a new export from `utils.py`; it mirrors `OUTPUT_DIR` and
+  documents the STT domain explicitly
+- The `UNRESTRICTED` sentinel type annotation (`Path = object()`) requires a
+  `type: ignore[assignment]`; alternatively it can be typed as `object` and the
+  parameter typed `Path | object` — implementation detail left to the developer

--- a/docs/architecture/adr/meta.json
+++ b/docs/architecture/adr/meta.json
@@ -1,0 +1,1 @@
+{ "title": "ADRs", "pages": ["001-output-path-trust-model"] }

--- a/src/voicecli/api.py
+++ b/src/voicecli/api.py
@@ -521,6 +521,7 @@ def _generate_chunked(
 ) -> list[Path]:
     """Generate speech in chunks. Returns list of chunk paths."""
     from voicecli.utils import smart_chunk
+
     paths: list[Path] = []
 
     if segments and len(segments) > 1:
@@ -598,6 +599,7 @@ def _clone_chunked(
 ) -> list[Path]:
     """Clone voice in chunks. Returns list of chunk paths."""
     from voicecli.utils import smart_chunk
+
     paths: list[Path] = []
 
     if segments and len(segments) > 1:

--- a/src/voicecli/api.py
+++ b/src/voicecli/api.py
@@ -10,6 +10,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
+from voicecli.utils import OUTPUT_DIR
+
 log = logging.getLogger(__name__)
 
 
@@ -92,6 +94,41 @@ def _validate_tts_params(
             _check_str(field, extra_kwargs.get(field))
         _check_float("exaggeration", extra_kwargs.get("exaggeration"), 0.0, 2.0)
         _check_float("cfg_weight", extra_kwargs.get("cfg_weight"), 0.0, 1.0)
+
+
+def _validate_output_path(
+    output_path: Path,
+    *,
+    allowed_base: Path | None = None,
+    cli_bypass: bool = False,
+) -> Path:
+    """Validate output path stays within allowed_base, create parent dirs.
+
+    Args:
+        output_path: Target output path.
+        allowed_base: Base directory for validation (default: OUTPUT_DIR).
+        cli_bypass: Skip validation for CLI --output override.
+
+    Returns:
+        Resolved absolute path.
+
+    Raises:
+        ValueError: If path escapes allowed_base and cli_bypass is False.
+    """
+    resolved = output_path.expanduser().resolve()
+    base = (allowed_base or OUTPUT_DIR).expanduser().resolve()
+
+    if not cli_bypass:
+        try:
+            resolved.relative_to(base)
+        except ValueError:
+            raise ValueError(
+                f"Output path escapes allowed directory: {resolved} "
+                f"is outside {base}. Use --output for explicit override."
+            )
+
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    return resolved
 
 
 @dataclass
@@ -348,7 +385,6 @@ def _resolve_ref(ref: Path | str | None) -> Path:
 
 # ── Daemon helpers ───────────────────────────────────────────────────────────
 
-
 _DAEMON_WAIT_SECS = 60.0
 _DAEMON_POLL_INTERVAL = 2.0
 
@@ -485,8 +521,6 @@ def _generate_chunked(
 ) -> list[Path]:
     """Generate speech in chunks. Returns list of chunk paths."""
     from voicecli.utils import smart_chunk
-
-    out.parent.mkdir(parents=True, exist_ok=True)
     paths: list[Path] = []
 
     if segments and len(segments) > 1:
@@ -564,8 +598,6 @@ def _clone_chunked(
 ) -> list[Path]:
     """Clone voice in chunks. Returns list of chunk paths."""
     from voicecli.utils import smart_chunk
-
-    out.parent.mkdir(parents=True, exist_ok=True)
     paths: list[Path] = []
 
     if segments and len(segments) > 1:
@@ -649,6 +681,7 @@ def generate(
     segment_gap: int | None = None,
     crossfade: int | None = None,
     plain: bool = False,
+    _cli_bypass: bool = False,
     **kwargs,
 ) -> TTSResult:
     """Generate speech from text or a markdown file using a built-in voice.
@@ -725,12 +758,16 @@ def generate(
     script_stem = resolved["script_stem"]
     extra = resolved["extra_kwargs"]
 
+    # Validate output path BEFORE loading engine (security)
+    prefix = build_output_prefix(r_engine, script=script_stem, voice=r_voice, language=r_language)
+    if output is not None:
+        out = _validate_output_path(Path(output), cli_bypass=_cli_bypass)
+    else:
+        out = default_output_path(prefix)
+
     eng = get_engine(r_engine)
     if r_fast and r_engine in QWEN_ENGINES:
         eng._small = True
-
-    prefix = build_output_prefix(r_engine, script=script_stem, voice=r_voice, language=r_language)
-    out = Path(output) if output is not None else default_output_path(prefix)
 
     if r_chunked:
         daemon_fn = _make_chunk_daemon_fn(r_engine) if r_engine in QWEN_ENGINES else None
@@ -807,6 +844,7 @@ def clone(
     segment_gap: int | None = None,
     crossfade: int | None = None,
     plain: bool = False,
+    _cli_bypass: bool = False,
     **kwargs,
 ) -> TTSResult:
     """Clone a voice from reference audio and synthesize text.
@@ -884,12 +922,16 @@ def clone(
     script_stem = resolved["script_stem"]
     extra = resolved["extra_kwargs"]
 
+    # Validate output path BEFORE loading engine (security)
+    prefix = build_output_prefix(r_engine, script=script_stem, language=r_language, clone=True)
+    if output is not None:
+        out = _validate_output_path(Path(output), cli_bypass=_cli_bypass)
+    else:
+        out = default_output_path(prefix)
+
     eng = get_engine(r_engine)
     if r_fast and r_engine in QWEN_ENGINES:
         eng._small = True
-
-    prefix = build_output_prefix(r_engine, script=script_stem, language=r_language, clone=True)
-    out = Path(output) if output is not None else default_output_path(prefix)
 
     if r_chunked:
         daemon_fn = _make_chunk_daemon_fn(r_engine) if r_engine in QWEN_ENGINES else None
@@ -1001,8 +1043,7 @@ def transcribe(
     )
 
     if output is not None:
-        out_path = Path(output)
-        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path = _validate_output_path(Path(output))
         out_path.write_text(result.text, encoding="utf-8")
 
     return result

--- a/src/voicecli/api.py
+++ b/src/voicecli/api.py
@@ -10,7 +10,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
-from voicecli.utils import OUTPUT_DIR
+from voicecli.utils import OUTPUT_DIR, STT_OUTPUT_DIR, _Unrestricted
 
 log = logging.getLogger(__name__)
 
@@ -99,34 +99,38 @@ def _validate_tts_params(
 def _validate_output_path(
     output_path: Path,
     *,
-    allowed_base: Path | None = None,
-    cli_bypass: bool = False,
+    allowed_base: Path | _Unrestricted,
 ) -> Path:
-    """Validate output path stays within allowed_base, create parent dirs.
+    """Validate output path stays within allowed_base; create parent dirs.
 
     Args:
         output_path: Target output path.
-        allowed_base: Base directory for validation (default: OUTPUT_DIR).
-        cli_bypass: Skip validation for CLI --output override.
+        allowed_base: Base directory the path must stay within, or
+            ``UNRESTRICTED`` when the caller owns the trust boundary (CLI
+            ``--output`` override, server-controlled scratch path). Pass
+            ``UNRESTRICTED`` explicitly — there is no implicit default, so
+            each caller declares its trust model.
 
     Returns:
-        Resolved absolute path.
+        Resolved absolute path. For ``UNRESTRICTED`` no parent dirs are
+        created (caller is responsible).
 
     Raises:
-        ValueError: If path escapes allowed_base and cli_bypass is False.
+        ValueError: If ``output_path`` escapes ``allowed_base``.
     """
     resolved = output_path.expanduser().resolve()
-    base = (allowed_base or OUTPUT_DIR).expanduser().resolve()
 
-    if not cli_bypass:
-        try:
-            resolved.relative_to(base)
-        except ValueError:
-            raise ValueError(
-                f"Output path escapes allowed directory: {resolved} "
-                f"is outside {base}. Use --output for explicit override."
-            )
+    if isinstance(allowed_base, _Unrestricted):
+        return resolved
 
+    base = allowed_base.expanduser().resolve()
+    try:
+        resolved.relative_to(base)
+    except ValueError:
+        raise ValueError(
+            f"Output path is outside the allowed directory {allowed_base}. "
+            "Pass an explicit --output to override."
+        )
     resolved.parent.mkdir(parents=True, exist_ok=True)
     return resolved
 
@@ -683,7 +687,7 @@ def generate(
     segment_gap: int | None = None,
     crossfade: int | None = None,
     plain: bool = False,
-    _cli_bypass: bool = False,
+    allowed_base: Path | _Unrestricted = OUTPUT_DIR,
     **kwargs,
 ) -> TTSResult:
     """Generate speech from text or a markdown file using a built-in voice.
@@ -702,6 +706,9 @@ def generate(
         segment_gap: Silence between segments (ms).
         crossfade: Fade between segments (ms).
         plain: Ignore [tags] and directives.
+        allowed_base: Base directory ``output`` must stay within
+            (default: ``OUTPUT_DIR``). Pass ``UNRESTRICTED`` when the caller
+            has already vetted the path (CLI ``--output``, server scratch dir).
         **kwargs: Additional engine-specific parameters.
 
     Returns:
@@ -763,8 +770,9 @@ def generate(
     # Validate output path BEFORE loading engine (security)
     prefix = build_output_prefix(r_engine, script=script_stem, voice=r_voice, language=r_language)
     if output is not None:
-        out = _validate_output_path(Path(output), cli_bypass=_cli_bypass)
+        out = _validate_output_path(Path(output), allowed_base=allowed_base)
     else:
+        # default_output_path writes inside OUTPUT_DIR by construction
         out = default_output_path(prefix)
 
     eng = get_engine(r_engine)
@@ -846,7 +854,7 @@ def clone(
     segment_gap: int | None = None,
     crossfade: int | None = None,
     plain: bool = False,
-    _cli_bypass: bool = False,
+    allowed_base: Path | _Unrestricted = OUTPUT_DIR,
     **kwargs,
 ) -> TTSResult:
     """Clone a voice from reference audio and synthesize text.
@@ -866,6 +874,9 @@ def clone(
         segment_gap: Silence between segments (ms).
         crossfade: Fade between segments (ms).
         plain: Ignore [tags] and directives.
+        allowed_base: Base directory ``output`` must stay within
+            (default: ``OUTPUT_DIR``). Pass ``UNRESTRICTED`` when the caller
+            has already vetted the path.
         **kwargs: Additional engine-specific parameters.
 
     Returns:
@@ -927,8 +938,9 @@ def clone(
     # Validate output path BEFORE loading engine (security)
     prefix = build_output_prefix(r_engine, script=script_stem, language=r_language, clone=True)
     if output is not None:
-        out = _validate_output_path(Path(output), cli_bypass=_cli_bypass)
+        out = _validate_output_path(Path(output), allowed_base=allowed_base)
     else:
+        # default_output_path writes inside OUTPUT_DIR by construction
         out = default_output_path(prefix)
 
     eng = get_engine(r_engine)
@@ -1007,7 +1019,7 @@ def transcribe(
     language_detection_segments: int | None = None,
     language_fallback: str | None = None,
     _skip_daemon: bool = False,
-    _cli_bypass: bool = False,
+    allowed_base: Path | _Unrestricted = STT_OUTPUT_DIR,
 ):
     """Transcribe an audio file to text.
 
@@ -1020,8 +1032,9 @@ def transcribe(
         language_detection_segments: Number of segments to sample for language detection.
         language_fallback: Language code to use when detection confidence is below threshold.
         _skip_daemon: Bypass Unix-socket daemon and run inference locally (private).
-        _cli_bypass: Skip output-path base-directory check — set by trusted CLI
-            callers who have already vetted *output* (private).
+        allowed_base: Base directory ``output`` must stay within
+            (default: ``STT_OUTPUT_DIR``). Pass ``UNRESTRICTED`` for an
+            explicit caller-provided path.
 
     Returns:
         TranscriptionResult with .text, .language, .segments.
@@ -1048,7 +1061,7 @@ def transcribe(
     )
 
     if output is not None:
-        out_path = _validate_output_path(Path(output), cli_bypass=_cli_bypass)
+        out_path = _validate_output_path(Path(output), allowed_base=allowed_base)
         out_path.write_text(result.text, encoding="utf-8")
 
     return result

--- a/src/voicecli/api.py
+++ b/src/voicecli/api.py
@@ -1007,6 +1007,7 @@ def transcribe(
     language_detection_segments: int | None = None,
     language_fallback: str | None = None,
     _skip_daemon: bool = False,
+    _cli_bypass: bool = False,
 ):
     """Transcribe an audio file to text.
 
@@ -1019,6 +1020,8 @@ def transcribe(
         language_detection_segments: Number of segments to sample for language detection.
         language_fallback: Language code to use when detection confidence is below threshold.
         _skip_daemon: Bypass Unix-socket daemon and run inference locally (private).
+        _cli_bypass: Skip output-path base-directory check — set by trusted CLI
+            callers who have already vetted *output* (private).
 
     Returns:
         TranscriptionResult with .text, .language, .segments.
@@ -1045,7 +1048,7 @@ def transcribe(
     )
 
     if output is not None:
-        out_path = _validate_output_path(Path(output))
+        out_path = _validate_output_path(Path(output), cli_bypass=_cli_bypass)
         out_path.write_text(result.text, encoding="utf-8")
 
     return result

--- a/src/voicecli/cli.py
+++ b/src/voicecli/cli.py
@@ -617,6 +617,7 @@ def generate(
             segment_gap=segment_gap,
             crossfade=crossfade,
             plain=plain,
+            _cli_bypass=output is not None,
             **extra,
         )
         typer.echo(f"Saved to {result.wav_path}")
@@ -742,6 +743,7 @@ def clone(
             segment_gap=segment_gap,
             crossfade=crossfade,
             plain=plain,
+            _cli_bypass=output is not None,
             **extra,
         )
         typer.echo(f"Saved to {result.wav_path}")

--- a/src/voicecli/cli.py
+++ b/src/voicecli/cli.py
@@ -6,6 +6,7 @@ import typer
 
 from voicecli import __version__
 from voicecli.engine import QWEN_ENGINES, available_engines, get_engine
+from voicecli.utils import OUTPUT_DIR, UNRESTRICTED
 
 
 def _version_callback(value: bool) -> None:
@@ -617,7 +618,7 @@ def generate(
             segment_gap=segment_gap,
             crossfade=crossfade,
             plain=plain,
-            _cli_bypass=output is not None,
+            allowed_base=UNRESTRICTED if output is not None else OUTPUT_DIR,
             **extra,
         )
         typer.echo(f"Saved to {result.wav_path}")
@@ -743,7 +744,7 @@ def clone(
             segment_gap=segment_gap,
             crossfade=crossfade,
             plain=plain,
-            _cli_bypass=output is not None,
+            allowed_base=UNRESTRICTED if output is not None else OUTPUT_DIR,
             **extra,
         )
         typer.echo(f"Saved to {result.wav_path}")

--- a/src/voicecli/engines/chatterbox.py
+++ b/src/voicecli/engines/chatterbox.py
@@ -101,8 +101,6 @@ class ChatterboxEngine(TTSEngine):
         default_gap = kwargs.get("segment_gap", 0)
         default_crossfade = kwargs.get("crossfade", 0)
 
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-
         if segments and len(segments) > 1:
             base_kwargs = dict(
                 language_id=language,
@@ -149,8 +147,6 @@ class ChatterboxEngine(TTSEngine):
         segments: list[Segment] | None = kwargs.get("segments")
         default_gap = kwargs.get("segment_gap", 0)
         default_crossfade = kwargs.get("crossfade", 0)
-
-        output_path.parent.mkdir(parents=True, exist_ok=True)
 
         if segments and len(segments) > 1:
             base_kwargs = dict(

--- a/src/voicecli/engines/chatterbox_turbo.py
+++ b/src/voicecli/engines/chatterbox_turbo.py
@@ -92,8 +92,6 @@ class ChatterboxTurboEngine(TTSEngine):
         default_gap = kwargs.get("segment_gap", 0)
         default_crossfade = kwargs.get("crossfade", 0)
 
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-
         if segments and len(segments) > 1:
             base_kwargs = dict(
                 exaggeration=exaggeration,
@@ -136,8 +134,6 @@ class ChatterboxTurboEngine(TTSEngine):
         segments: list[Segment] | None = kwargs.get("segments")
         default_gap = kwargs.get("segment_gap", 0)
         default_crossfade = kwargs.get("crossfade", 0)
-
-        output_path.parent.mkdir(parents=True, exist_ok=True)
 
         if segments and len(segments) > 1:
             base_kwargs = dict(

--- a/src/voicecli/engines/qwen.py
+++ b/src/voicecli/engines/qwen.py
@@ -156,8 +156,6 @@ class QwenEngine(TTSEngine):
         default_gap = kwargs.get("segment_gap", 0)
         default_crossfade = kwargs.get("crossfade", 0)
 
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-
         # Multi-segment mode
         if segments and len(segments) > 1:
             base_kwargs = dict(language=language, speaker=voice)
@@ -195,8 +193,6 @@ class QwenEngine(TTSEngine):
             base_kwargs["ref_text"] = ref_text
         else:
             base_kwargs["x_vector_only_mode"] = True
-
-        output_path.parent.mkdir(parents=True, exist_ok=True)
 
         # Multi-segment mode
         if segments and len(segments) > 1:

--- a/src/voicecli/engines/qwen_fast.py
+++ b/src/voicecli/engines/qwen_fast.py
@@ -130,8 +130,6 @@ class QwenFastEngine(QwenEngine):
         if not ref_text:
             base_kwargs["xvec_only"] = True
 
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-
         # Multi-segment mode
         if segments and len(segments) > 1:
             audio, sr = self._generate_segmented(

--- a/src/voicecli/engines/voxtral.py
+++ b/src/voicecli/engines/voxtral.py
@@ -149,7 +149,6 @@ class VoxtralEngine(TTSEngine):
         cfg_alpha = kwargs.get("cfg_alpha", 1.2)
 
         resolved_voice = _resolve_voice(voice, language)
-        output_path.parent.mkdir(parents=True, exist_ok=True)
 
         if segments and len(segments) > 1:
             audio = self._generate_segmented(

--- a/src/voicecli/nats/tts_adapter.py
+++ b/src/voicecli/nats/tts_adapter.py
@@ -270,7 +270,9 @@ class TtsNatsAdapter(NatsAdapterBase):
                 kw = dict(optional_kwargs)
                 if language is not None:
                     kw["language"] = language
-                api.generate(text, engine=engine, output=out_path, _cli_bypass=True, **kw, **named_kwargs)
+                api.generate(
+                    text, engine=engine, output=out_path, _cli_bypass=True, **kw, **named_kwargs
+                )
 
             try:
                 await loop.run_in_executor(self._executor, _synthesize, None)

--- a/src/voicecli/nats/tts_adapter.py
+++ b/src/voicecli/nats/tts_adapter.py
@@ -270,7 +270,7 @@ class TtsNatsAdapter(NatsAdapterBase):
                 kw = dict(optional_kwargs)
                 if language is not None:
                     kw["language"] = language
-                api.generate(text, engine=engine, output=out_path, **kw, **named_kwargs)
+                api.generate(text, engine=engine, output=out_path, _cli_bypass=True, **kw, **named_kwargs)
 
             try:
                 await loop.run_in_executor(self._executor, _synthesize, None)

--- a/src/voicecli/nats/tts_adapter.py
+++ b/src/voicecli/nats/tts_adapter.py
@@ -267,11 +267,18 @@ class TtsNatsAdapter(NatsAdapterBase):
             loop = asyncio.get_running_loop()
 
             def _synthesize(language: str | None) -> None:
+                from voicecli.utils import UNRESTRICTED
+
                 kw = dict(optional_kwargs)
                 if language is not None:
                     kw["language"] = language
                 api.generate(
-                    text, engine=engine, output=out_path, _cli_bypass=True, **kw, **named_kwargs
+                    text,
+                    engine=engine,
+                    output=out_path,
+                    allowed_base=UNRESTRICTED,
+                    **kw,
+                    **named_kwargs,
                 )
 
             try:

--- a/src/voicecli/utils.py
+++ b/src/voicecli/utils.py
@@ -2,6 +2,29 @@ from datetime import datetime
 from pathlib import Path
 
 OUTPUT_DIR = Path.home() / ".voicecli" / "TTS" / "voices_out"
+STT_OUTPUT_DIR = Path.home() / ".voicecli" / "STT" / "texts_out"
+
+
+class _Unrestricted:
+    """Sentinel for output-path trust boundary owned by the caller.
+
+    When passed as `allowed_base`, `_validate_output_path` skips both the
+    containment check and parent-dir auto-creation. Intended for CLI `--output`
+    and server-controlled scratch paths (NATS satellite).
+    """
+
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "UNRESTRICTED"
+
+
+UNRESTRICTED = _Unrestricted()
 
 # Map full language names to ISO 639-1 codes (shared across engines and utils)
 LANG_MAP = {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from voicecli.utils import UNRESTRICTED
+
 
 def test_import_lightweight():
     """Importing voicecli should NOT trigger heavy imports (torch, soundfile, etc.)."""
@@ -39,7 +41,9 @@ def test_generate_returns_tts_result(tmp_path):
         patch("voicecli.engine.get_engine", return_value=mock_engine),
         patch("voicecli.config.load_defaults", return_value={}),
     ):
-        result = generate("Hello world", output=out_path, engine="chatterbox", _cli_bypass=True)
+        result = generate(
+            "Hello world", output=out_path, engine="chatterbox", allowed_base=UNRESTRICTED
+        )
 
     assert isinstance(result, TTSResult)
     assert result.wav_path == out_path
@@ -61,7 +65,9 @@ def test_generate_md_input(tmp_path):
         patch("voicecli.engine.get_engine", return_value=mock_engine),
         patch("voicecli.config.load_defaults", return_value={}),
     ):
-        result = generate(str(md_file), output=out_path, engine="chatterbox", _cli_bypass=True)
+        result = generate(
+            str(md_file), output=out_path, engine="chatterbox", allowed_base=UNRESTRICTED
+        )
 
     assert isinstance(result, TTSResult)
     mock_engine.generate.assert_called_once()
@@ -111,11 +117,13 @@ def test_path_params_accept_str_and_path(tmp_path):
         patch("voicecli.config.load_defaults", return_value={}),
     ):
         # str output
-        result = generate("Hello", output=str(out_path), engine="chatterbox", _cli_bypass=True)
+        result = generate(
+            "Hello", output=str(out_path), engine="chatterbox", allowed_base=UNRESTRICTED
+        )
         assert isinstance(result, TTSResult)
 
         # Path output
-        result = generate("Hello", output=out_path, engine="chatterbox", _cli_bypass=True)
+        result = generate("Hello", output=out_path, engine="chatterbox", allowed_base=UNRESTRICTED)
         assert isinstance(result, TTSResult)
 
 
@@ -172,7 +180,11 @@ def test_clone_happy_path(tmp_path):
         patch("voicecli.config.load_defaults", return_value={}),
     ):
         result = clone(
-            "Hello world", ref=str(ref_file), output=out_path, engine="chatterbox", _cli_bypass=True
+            "Hello world",
+            ref=str(ref_file),
+            output=out_path,
+            engine="chatterbox",
+            allowed_base=UNRESTRICTED,
         )
 
     assert isinstance(result, TTSResult)
@@ -218,7 +230,7 @@ def test_transcribe_writes_output(tmp_path):
     with (
         patch("voicecli.transcribe.transcribe", return_value=mock_result),
     ):
-        transcribe(str(audio_file), output=str(out_file), _cli_bypass=True)
+        transcribe(str(audio_file), output=str(out_file), allowed_base=UNRESTRICTED)
 
     assert out_file.read_text() == "Transcribed text"
 
@@ -240,7 +252,11 @@ def test_generate_chunked_returns_chunk_paths(tmp_path):
         patch("voicecli.utils.smart_chunk", return_value=["Hello world"]),
     ):
         result = generate(
-            "Hello world", output=out_path, chunked=True, engine="chatterbox", _cli_bypass=True
+            "Hello world",
+            output=out_path,
+            chunked=True,
+            engine="chatterbox",
+            allowed_base=UNRESTRICTED,
         )
 
     assert isinstance(result, TTSResult)
@@ -264,7 +280,7 @@ def test_generate_mp3(tmp_path):
         patch("voicecli.utils.wav_to_mp3", return_value=mp3_path),
     ):
         result = generate(
-            "Hello world", output=out_path, mp3=True, engine="chatterbox", _cli_bypass=True
+            "Hello world", output=out_path, mp3=True, engine="chatterbox", allowed_base=UNRESTRICTED
         )
 
     assert isinstance(result, TTSResult)
@@ -287,7 +303,11 @@ def test_generate_plain_strips_tags(tmp_path):
         patch("voicecli.config.load_defaults", return_value={}),
     ):
         result = generate(
-            str(md_file), output=out_path, plain=True, engine="chatterbox", _cli_bypass=True
+            str(md_file),
+            output=out_path,
+            plain=True,
+            engine="chatterbox",
+            allowed_base=UNRESTRICTED,
         )
 
     assert isinstance(result, TTSResult)
@@ -308,7 +328,7 @@ def test_generate_async_returns_tts_result(tmp_path):
         patch("voicecli.config.load_defaults", return_value={}),
     ):
         result = asyncio.run(
-            generate_async("Hello", output=out_path, engine="chatterbox", _cli_bypass=True)
+            generate_async("Hello", output=out_path, engine="chatterbox", allowed_base=UNRESTRICTED)
         )
 
     assert isinstance(result, TTSResult)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -207,12 +207,10 @@ def test_transcribe_file_not_found():
 def test_transcribe_writes_output(tmp_path):
     """transcribe() with output should write text to file."""
     from voicecli.api import transcribe
-    from voicecli.utils import OUTPUT_DIR
 
     audio_file = tmp_path / "audio.wav"
     audio_file.write_bytes(b"RIFF" + b"\x00" * 100)
-    # Use a path inside OUTPUT_DIR to pass validation
-    out_file = OUTPUT_DIR / "test_result.txt"
+    out_file = tmp_path / "result.txt"
 
     mock_result = MagicMock()
     mock_result.text = "Transcribed text"
@@ -220,11 +218,9 @@ def test_transcribe_writes_output(tmp_path):
     with (
         patch("voicecli.transcribe.transcribe", return_value=mock_result),
     ):
-        transcribe(str(audio_file), output=str(out_file))
+        transcribe(str(audio_file), output=str(out_file), _cli_bypass=True)
 
     assert out_file.read_text() == "Transcribed text"
-    # Cleanup
-    out_file.unlink(missing_ok=True)
 
 
 def test_generate_chunked_returns_chunk_paths(tmp_path):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -39,7 +39,7 @@ def test_generate_returns_tts_result(tmp_path):
         patch("voicecli.engine.get_engine", return_value=mock_engine),
         patch("voicecli.config.load_defaults", return_value={}),
     ):
-        result = generate("Hello world", output=out_path, engine="chatterbox")
+        result = generate("Hello world", output=out_path, engine="chatterbox", _cli_bypass=True)
 
     assert isinstance(result, TTSResult)
     assert result.wav_path == out_path
@@ -61,7 +61,7 @@ def test_generate_md_input(tmp_path):
         patch("voicecli.engine.get_engine", return_value=mock_engine),
         patch("voicecli.config.load_defaults", return_value={}),
     ):
-        result = generate(str(md_file), output=out_path, engine="chatterbox")
+        result = generate(str(md_file), output=out_path, engine="chatterbox", _cli_bypass=True)
 
     assert isinstance(result, TTSResult)
     mock_engine.generate.assert_called_once()
@@ -111,11 +111,11 @@ def test_path_params_accept_str_and_path(tmp_path):
         patch("voicecli.config.load_defaults", return_value={}),
     ):
         # str output
-        result = generate("Hello", output=str(out_path), engine="chatterbox")
+        result = generate("Hello", output=str(out_path), engine="chatterbox", _cli_bypass=True)
         assert isinstance(result, TTSResult)
 
         # Path output
-        result = generate("Hello", output=out_path, engine="chatterbox")
+        result = generate("Hello", output=out_path, engine="chatterbox", _cli_bypass=True)
         assert isinstance(result, TTSResult)
 
 
@@ -171,7 +171,7 @@ def test_clone_happy_path(tmp_path):
         patch("voicecli.engine.get_engine", return_value=mock_engine),
         patch("voicecli.config.load_defaults", return_value={}),
     ):
-        result = clone("Hello world", ref=str(ref_file), output=out_path, engine="chatterbox")
+        result = clone("Hello world", ref=str(ref_file), output=out_path, engine="chatterbox", _cli_bypass=True)
 
     assert isinstance(result, TTSResult)
     assert result.wav_path == out_path
@@ -205,10 +205,12 @@ def test_transcribe_file_not_found():
 def test_transcribe_writes_output(tmp_path):
     """transcribe() with output should write text to file."""
     from voicecli.api import transcribe
+    from voicecli.utils import OUTPUT_DIR
 
     audio_file = tmp_path / "audio.wav"
     audio_file.write_bytes(b"RIFF" + b"\x00" * 100)
-    out_file = tmp_path / "result.txt"
+    # Use a path inside OUTPUT_DIR to pass validation
+    out_file = OUTPUT_DIR / "test_result.txt"
 
     mock_result = MagicMock()
     mock_result.text = "Transcribed text"
@@ -219,6 +221,8 @@ def test_transcribe_writes_output(tmp_path):
         transcribe(str(audio_file), output=str(out_file))
 
     assert out_file.read_text() == "Transcribed text"
+    # Cleanup
+    out_file.unlink(missing_ok=True)
 
 
 def test_generate_chunked_returns_chunk_paths(tmp_path):
@@ -237,7 +241,7 @@ def test_generate_chunked_returns_chunk_paths(tmp_path):
         patch("voicecli.config.load_defaults", return_value={}),
         patch("voicecli.utils.smart_chunk", return_value=["Hello world"]),
     ):
-        result = generate("Hello world", output=out_path, chunked=True, engine="chatterbox")
+        result = generate("Hello world", output=out_path, chunked=True, engine="chatterbox", _cli_bypass=True)
 
     assert isinstance(result, TTSResult)
     assert result.chunk_paths is not None
@@ -259,7 +263,7 @@ def test_generate_mp3(tmp_path):
         patch("voicecli.config.load_defaults", return_value={}),
         patch("voicecli.utils.wav_to_mp3", return_value=mp3_path),
     ):
-        result = generate("Hello world", output=out_path, mp3=True, engine="chatterbox")
+        result = generate("Hello world", output=out_path, mp3=True, engine="chatterbox", _cli_bypass=True)
 
     assert isinstance(result, TTSResult)
     assert result.mp3_path == mp3_path
@@ -280,7 +284,7 @@ def test_generate_plain_strips_tags(tmp_path):
         patch("voicecli.engine.get_engine", return_value=mock_engine),
         patch("voicecli.config.load_defaults", return_value={}),
     ):
-        result = generate(str(md_file), output=out_path, plain=True, engine="chatterbox")
+        result = generate(str(md_file), output=out_path, plain=True, engine="chatterbox", _cli_bypass=True)
 
     assert isinstance(result, TTSResult)
     call_text = mock_engine.generate.call_args[0][0]
@@ -299,7 +303,7 @@ def test_generate_async_returns_tts_result(tmp_path):
         patch("voicecli.engine.get_engine", return_value=mock_engine),
         patch("voicecli.config.load_defaults", return_value={}),
     ):
-        result = asyncio.run(generate_async("Hello", output=out_path, engine="chatterbox"))
+        result = asyncio.run(generate_async("Hello", output=out_path, engine="chatterbox", _cli_bypass=True))
 
     assert isinstance(result, TTSResult)
     assert result.wav_path == out_path

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -171,7 +171,9 @@ def test_clone_happy_path(tmp_path):
         patch("voicecli.engine.get_engine", return_value=mock_engine),
         patch("voicecli.config.load_defaults", return_value={}),
     ):
-        result = clone("Hello world", ref=str(ref_file), output=out_path, engine="chatterbox", _cli_bypass=True)
+        result = clone(
+            "Hello world", ref=str(ref_file), output=out_path, engine="chatterbox", _cli_bypass=True
+        )
 
     assert isinstance(result, TTSResult)
     assert result.wav_path == out_path
@@ -241,7 +243,9 @@ def test_generate_chunked_returns_chunk_paths(tmp_path):
         patch("voicecli.config.load_defaults", return_value={}),
         patch("voicecli.utils.smart_chunk", return_value=["Hello world"]),
     ):
-        result = generate("Hello world", output=out_path, chunked=True, engine="chatterbox", _cli_bypass=True)
+        result = generate(
+            "Hello world", output=out_path, chunked=True, engine="chatterbox", _cli_bypass=True
+        )
 
     assert isinstance(result, TTSResult)
     assert result.chunk_paths is not None
@@ -263,7 +267,9 @@ def test_generate_mp3(tmp_path):
         patch("voicecli.config.load_defaults", return_value={}),
         patch("voicecli.utils.wav_to_mp3", return_value=mp3_path),
     ):
-        result = generate("Hello world", output=out_path, mp3=True, engine="chatterbox", _cli_bypass=True)
+        result = generate(
+            "Hello world", output=out_path, mp3=True, engine="chatterbox", _cli_bypass=True
+        )
 
     assert isinstance(result, TTSResult)
     assert result.mp3_path == mp3_path
@@ -284,7 +290,9 @@ def test_generate_plain_strips_tags(tmp_path):
         patch("voicecli.engine.get_engine", return_value=mock_engine),
         patch("voicecli.config.load_defaults", return_value={}),
     ):
-        result = generate(str(md_file), output=out_path, plain=True, engine="chatterbox", _cli_bypass=True)
+        result = generate(
+            str(md_file), output=out_path, plain=True, engine="chatterbox", _cli_bypass=True
+        )
 
     assert isinstance(result, TTSResult)
     call_text = mock_engine.generate.call_args[0][0]
@@ -303,7 +311,9 @@ def test_generate_async_returns_tts_result(tmp_path):
         patch("voicecli.engine.get_engine", return_value=mock_engine),
         patch("voicecli.config.load_defaults", return_value={}),
     ):
-        result = asyncio.run(generate_async("Hello", output=out_path, engine="chatterbox", _cli_bypass=True))
+        result = asyncio.run(
+            generate_async("Hello", output=out_path, engine="chatterbox", _cli_bypass=True)
+        )
 
     assert isinstance(result, TTSResult)
     assert result.wav_path == out_path

--- a/tests/test_output_path_validation.py
+++ b/tests/test_output_path_validation.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from voicecli.api import _validate_output_path, clone, generate
+from voicecli.utils import OUTPUT_DIR, UNRESTRICTED
 
 
 class TestValidateOutputPath:
@@ -23,7 +24,7 @@ class TestValidateOutputPath:
         base = tmp_path / "base"
         base.mkdir()
         evil = base / ".." / "escape.wav"
-        with pytest.raises(ValueError, match="escapes"):
+        with pytest.raises(ValueError, match="outside"):
             _validate_output_path(evil, allowed_base=base)
 
     def test_absolute_path_outside_base_raises(self, tmp_path):
@@ -31,16 +32,16 @@ class TestValidateOutputPath:
         base = tmp_path / "base"
         base.mkdir()
         outside = tmp_path / "outside" / "test.wav"
-        with pytest.raises(ValueError, match="escapes"):
+        with pytest.raises(ValueError, match="outside"):
             _validate_output_path(outside, allowed_base=base)
 
-    def test_absolute_path_outside_base_with_bypass(self, tmp_path):
-        """Bypass allows absolute path outside base."""
-        base = tmp_path / "base"
-        base.mkdir()
+    def test_unrestricted_allows_absolute_path_outside_base(self, tmp_path):
+        """UNRESTRICTED allows absolute path outside base and skips mkdir."""
         outside = tmp_path / "outside" / "test.wav"
-        result = _validate_output_path(outside, allowed_base=base, cli_bypass=True)
+        result = _validate_output_path(outside, allowed_base=UNRESTRICTED)
         assert result == outside.resolve()
+        # UNRESTRICTED does NOT auto-create parent dirs (caller owns boundary)
+        assert not outside.parent.exists()
 
     def test_relative_path_inside_base_works(self, tmp_path):
         """Relative path staying inside base works."""
@@ -51,14 +52,16 @@ class TestValidateOutputPath:
         assert result.parent.exists()
 
     def test_symlink_escaping_base_raises(self, tmp_path):
-        """Symlink pointing outside base is blocked."""
+        """Symlink pointing outside base is blocked after resolve()."""
         base = tmp_path / "base"
         base.mkdir()
         outside = tmp_path / "outside"
         outside.mkdir()
+        target = outside / "evil.wav"
+        target.touch()
         link = base / "link.wav"
-        link.symlink_to(outside / "evil.wav")
-        with pytest.raises(ValueError, match="escapes"):
+        link.symlink_to(target)
+        with pytest.raises(ValueError, match="outside"):
             _validate_output_path(link, allowed_base=base)
 
     def test_nested_nonexistent_dir_created(self, tmp_path):
@@ -68,6 +71,18 @@ class TestValidateOutputPath:
         out = base / "a" / "b" / "c" / "test.wav"
         result = _validate_output_path(out, allowed_base=base)
         assert result.parent.exists()
+
+    def test_default_output_dir_branch(self, tmp_path, monkeypatch):
+        """Default OUTPUT_DIR base is honored when no allowed_base override is provided by callers."""
+        # Redirect OUTPUT_DIR → tmp_path so the test is hermetic.
+        fake_base = tmp_path / "voices_out"
+        fake_base.mkdir()
+        monkeypatch.setattr("voicecli.api.OUTPUT_DIR", fake_base)
+        inside = fake_base / "x.wav"
+        result = _validate_output_path(inside, allowed_base=fake_base)
+        assert result == inside.resolve()
+        # Default OUTPUT_DIR constant in utils.py points into ~/.voicecli/TTS/voices_out
+        assert "voices_out" in str(OUTPUT_DIR)
 
 
 class TestGenerateOutputValidation:
@@ -84,14 +99,15 @@ class TestGenerateOutputValidation:
         with (
             patch("voicecli.config.load_defaults", return_value={}),
             patch("voicecli.engine.get_engine", side_effect=Exception("should not reach")),
-            pytest.raises(ValueError, match="escapes"),
+            pytest.raises(ValueError, match="outside"),
         ):
             generate("test", output=evil)
 
-    def test_generate_bypass_with_cli_flag(self, tmp_path):
-        """generate() allows outside path with _cli_bypass=True."""
+    def test_generate_unrestricted_base_allows_outside_path(self, tmp_path):
+        """generate(allowed_base=UNRESTRICTED) accepts outside path."""
         # Arrange
         outside = tmp_path / "outside" / "test.wav"
+        outside.parent.mkdir(parents=True, exist_ok=True)
         mock_engine = MagicMock()
         mock_engine.generate.return_value = outside
 
@@ -100,7 +116,9 @@ class TestGenerateOutputValidation:
             patch("voicecli.config.load_defaults", return_value={}),
             patch("voicecli.engine.get_engine", return_value=mock_engine),
         ):
-            result = generate("test", output=outside, _cli_bypass=True, engine="chatterbox")
+            result = generate(
+                "test", output=outside, allowed_base=UNRESTRICTED, engine="chatterbox"
+            )
 
         # Assert
         assert result.wav_path == outside.resolve()
@@ -122,14 +140,15 @@ class TestCloneOutputValidation:
         with (
             patch("voicecli.config.load_defaults", return_value={}),
             patch("voicecli.engine.get_engine", side_effect=Exception("should not reach")),
-            pytest.raises(ValueError, match="escapes"),
+            pytest.raises(ValueError, match="outside"),
         ):
             clone("test", ref=ref, output=evil)
 
-    def test_clone_bypass_with_cli_flag(self, tmp_path):
-        """clone() allows outside path with _cli_bypass=True (mirror of generate)."""
+    def test_clone_unrestricted_base_allows_outside_path(self, tmp_path):
+        """clone(allowed_base=UNRESTRICTED) accepts outside path (mirror of generate)."""
         # Arrange
         outside = tmp_path / "outside" / "test.wav"
+        outside.parent.mkdir(parents=True, exist_ok=True)
         ref = tmp_path / "ref.wav"
         ref.write_bytes(b"fake audio")
         mock_engine = MagicMock()
@@ -140,17 +159,23 @@ class TestCloneOutputValidation:
             patch("voicecli.config.load_defaults", return_value={}),
             patch("voicecli.engine.get_engine", return_value=mock_engine),
         ):
-            result = clone("test", ref=ref, output=outside, _cli_bypass=True, engine="chatterbox")
+            result = clone(
+                "test",
+                ref=ref,
+                output=outside,
+                allowed_base=UNRESTRICTED,
+                engine="chatterbox",
+            )
 
         # Assert
         assert result.wav_path == outside.resolve()
 
 
 class TestCLIBypass:
-    """Tests that CLI commands forward _cli_bypass=True when --output is set."""
+    """Tests that CLI commands forward allowed_base=UNRESTRICTED when --output is set."""
 
-    def test_generate_cli_forwards_cli_bypass_when_output_set(self, tmp_path):
-        """`voicecli generate --output X` must pass _cli_bypass=True to api.generate."""
+    def test_generate_cli_sets_unrestricted_when_output_set(self, tmp_path):
+        """`voicecli generate --output X` must pass allowed_base=UNRESTRICTED to api.generate."""
         from typer.testing import CliRunner
 
         from voicecli.cli import app
@@ -163,10 +188,10 @@ class TestCLIBypass:
             result = runner.invoke(app, ["generate", "hello", "--output", str(outside)])
 
         assert result.exit_code == 0, result.output
-        assert mock_gen.call_args.kwargs.get("_cli_bypass") is True
+        assert mock_gen.call_args.kwargs.get("allowed_base") is UNRESTRICTED
 
-    def test_generate_cli_does_not_bypass_without_output(self):
-        """`voicecli generate` (no --output) must pass _cli_bypass=False."""
+    def test_generate_cli_uses_output_dir_without_output(self):
+        """`voicecli generate` (no --output) must pass allowed_base=OUTPUT_DIR."""
         from typer.testing import CliRunner
 
         from voicecli.cli import app
@@ -178,10 +203,10 @@ class TestCLIBypass:
             result = runner.invoke(app, ["generate", "hello"])
 
         assert result.exit_code == 0, result.output
-        assert mock_gen.call_args.kwargs.get("_cli_bypass") is False
+        assert mock_gen.call_args.kwargs.get("allowed_base") == OUTPUT_DIR
 
-    def test_clone_cli_forwards_cli_bypass_when_output_set(self, tmp_path):
-        """`voicecli clone --output X` must pass _cli_bypass=True to api.clone."""
+    def test_clone_cli_sets_unrestricted_when_output_set(self, tmp_path):
+        """`voicecli clone --output X` must pass allowed_base=UNRESTRICTED to api.clone."""
         from typer.testing import CliRunner
 
         from voicecli.cli import app
@@ -198,4 +223,4 @@ class TestCLIBypass:
             )
 
         assert result.exit_code == 0, result.output
-        assert mock_clone.call_args.kwargs.get("_cli_bypass") is True
+        assert mock_clone.call_args.kwargs.get("allowed_base") is UNRESTRICTED

--- a/tests/test_output_path_validation.py
+++ b/tests/test_output_path_validation.py
@@ -1,10 +1,11 @@
 """Tests for output path validation (#57)."""
 
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from voicecli.api import _validate_output_path
+from voicecli.api import _validate_output_path, clone, generate
 
 
 class TestValidateOutputPath:
@@ -74,14 +75,12 @@ class TestGenerateOutputValidation:
 
     def test_generate_rejects_escape_path(self, tmp_path):
         """generate() rejects path escaping base."""
-        from unittest.mock import MagicMock, patch
-
-        from voicecli.api import generate
-
+        # Arrange
         base = tmp_path / "base"
         base.mkdir()
         evil = base / ".." / "escape.wav"
 
+        # Act + Assert
         with (
             patch("voicecli.config.load_defaults", return_value={}),
             patch("voicecli.engine.get_engine", side_effect=Exception("should not reach")),
@@ -91,21 +90,20 @@ class TestGenerateOutputValidation:
 
     def test_generate_bypass_with_cli_flag(self, tmp_path):
         """generate() allows outside path with _cli_bypass=True."""
-        from unittest.mock import MagicMock, patch
-
-        from voicecli.api import generate
-
+        # Arrange
         outside = tmp_path / "outside" / "test.wav"
         mock_engine = MagicMock()
         mock_engine.generate.return_value = outside
 
+        # Act
         with (
             patch("voicecli.config.load_defaults", return_value={}),
             patch("voicecli.engine.get_engine", return_value=mock_engine),
         ):
-            # Should NOT raise - bypass active
-            # Use chatterbox engine to avoid daemon path
-            generate("test", output=outside, _cli_bypass=True, engine="chatterbox")
+            result = generate("test", output=outside, _cli_bypass=True, engine="chatterbox")
+
+        # Assert
+        assert result.wav_path == outside.resolve()
 
 
 class TestCloneOutputValidation:
@@ -113,16 +111,14 @@ class TestCloneOutputValidation:
 
     def test_clone_rejects_escape_path(self, tmp_path):
         """clone() rejects path escaping base."""
-        from unittest.mock import patch
-
-        from voicecli.api import clone
-
+        # Arrange
         base = tmp_path / "base"
         base.mkdir()
         evil = base / ".." / "escape.wav"
         ref = tmp_path / "ref.wav"
         ref.write_bytes(b"fake audio")
 
+        # Act + Assert
         with (
             patch("voicecli.config.load_defaults", return_value={}),
             patch("voicecli.engine.get_engine", side_effect=Exception("should not reach")),
@@ -130,21 +126,76 @@ class TestCloneOutputValidation:
         ):
             clone("test", ref=ref, output=evil)
 
+    def test_clone_bypass_with_cli_flag(self, tmp_path):
+        """clone() allows outside path with _cli_bypass=True (mirror of generate)."""
+        # Arrange
+        outside = tmp_path / "outside" / "test.wav"
+        ref = tmp_path / "ref.wav"
+        ref.write_bytes(b"fake audio")
+        mock_engine = MagicMock()
+        mock_engine.clone.return_value = outside
+
+        # Act
+        with (
+            patch("voicecli.config.load_defaults", return_value={}),
+            patch("voicecli.engine.get_engine", return_value=mock_engine),
+        ):
+            result = clone("test", ref=ref, output=outside, _cli_bypass=True, engine="chatterbox")
+
+        # Assert
+        assert result.wav_path == outside.resolve()
+
 
 class TestCLIBypass:
-    """Tests for CLI bypass functionality."""
+    """Tests that CLI commands forward _cli_bypass=True when --output is set."""
 
-    @pytest.mark.skip(reason="Requires CLI _cli_bypass integration (V4-T16)")
-    def test_cli_output_flag_bypasses_validation(self, tmp_path, monkeypatch):
-        """CLI --output flag should bypass validation for outside paths."""
-        import subprocess
+    def test_generate_cli_forwards_cli_bypass_when_output_set(self, tmp_path):
+        """`voicecli generate --output X` must pass _cli_bypass=True to api.generate."""
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
 
         outside = tmp_path / "outside" / "test.wav"
-        # This would fail without bypass
-        result = subprocess.run(
-            ["uv", "run", "voicecli", "generate", "test", "--output", str(outside)],
-            capture_output=True,
-            text=True,
-        )
-        # Should NOT contain "escapes" error
-        assert "escapes" not in result.stderr
+        fake_result = MagicMock(wav_path=outside, mp3_path=None)
+
+        with patch("voicecli.api.generate", return_value=fake_result) as mock_gen:
+            runner = CliRunner()
+            result = runner.invoke(app, ["generate", "hello", "--output", str(outside)])
+
+        assert result.exit_code == 0, result.output
+        assert mock_gen.call_args.kwargs.get("_cli_bypass") is True
+
+    def test_generate_cli_does_not_bypass_without_output(self):
+        """`voicecli generate` (no --output) must pass _cli_bypass=False."""
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        fake_result = MagicMock(wav_path=Path("/tmp/out.wav"), mp3_path=None)
+
+        with patch("voicecli.api.generate", return_value=fake_result) as mock_gen:
+            runner = CliRunner()
+            result = runner.invoke(app, ["generate", "hello"])
+
+        assert result.exit_code == 0, result.output
+        assert mock_gen.call_args.kwargs.get("_cli_bypass") is False
+
+    def test_clone_cli_forwards_cli_bypass_when_output_set(self, tmp_path):
+        """`voicecli clone --output X` must pass _cli_bypass=True to api.clone."""
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        ref = tmp_path / "ref.wav"
+        ref.write_bytes(b"fake audio")
+        outside = tmp_path / "outside" / "test.wav"
+        fake_result = MagicMock(wav_path=outside, mp3_path=None)
+
+        with patch("voicecli.api.clone", return_value=fake_result) as mock_clone:
+            runner = CliRunner()
+            result = runner.invoke(
+                app, ["clone", "hello", "--ref", str(ref), "--output", str(outside)]
+            )
+
+        assert result.exit_code == 0, result.output
+        assert mock_clone.call_args.kwargs.get("_cli_bypass") is True

--- a/tests/test_output_path_validation.py
+++ b/tests/test_output_path_validation.py
@@ -1,4 +1,5 @@
 """Tests for output path validation (#57)."""
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_output_path_validation.py
+++ b/tests/test_output_path_validation.py
@@ -1,0 +1,149 @@
+"""Tests for output path validation (#57)."""
+from pathlib import Path
+
+import pytest
+
+from voicecli.api import _validate_output_path
+
+
+class TestValidateOutputPath:
+    def test_valid_path_inside_base(self, tmp_path):
+        """Valid path inside base works."""
+        base = tmp_path / "base"
+        base.mkdir()
+        out = base / "test.wav"
+        result = _validate_output_path(out, allowed_base=base)
+        assert result == out.resolve()
+        assert result.parent.exists()
+
+    def test_path_escaping_base_raises(self, tmp_path):
+        """Path with .. escaping base raises ValueError."""
+        base = tmp_path / "base"
+        base.mkdir()
+        evil = base / ".." / "escape.wav"
+        with pytest.raises(ValueError, match="escapes"):
+            _validate_output_path(evil, allowed_base=base)
+
+    def test_absolute_path_outside_base_raises(self, tmp_path):
+        """Absolute path outside base raises ValueError."""
+        base = tmp_path / "base"
+        base.mkdir()
+        outside = tmp_path / "outside" / "test.wav"
+        with pytest.raises(ValueError, match="escapes"):
+            _validate_output_path(outside, allowed_base=base)
+
+    def test_absolute_path_outside_base_with_bypass(self, tmp_path):
+        """Bypass allows absolute path outside base."""
+        base = tmp_path / "base"
+        base.mkdir()
+        outside = tmp_path / "outside" / "test.wav"
+        result = _validate_output_path(outside, allowed_base=base, cli_bypass=True)
+        assert result == outside.resolve()
+
+    def test_relative_path_inside_base_works(self, tmp_path):
+        """Relative path staying inside base works."""
+        base = tmp_path / "base"
+        base.mkdir()
+        out = base / "subdir" / "test.wav"
+        result = _validate_output_path(out, allowed_base=base)
+        assert result.parent.exists()
+
+    def test_symlink_escaping_base_raises(self, tmp_path):
+        """Symlink pointing outside base is blocked."""
+        base = tmp_path / "base"
+        base.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        link = base / "link.wav"
+        link.symlink_to(outside / "evil.wav")
+        with pytest.raises(ValueError, match="escapes"):
+            _validate_output_path(link, allowed_base=base)
+
+    def test_nested_nonexistent_dir_created(self, tmp_path):
+        """Nested non-existent directory inside base is auto-created."""
+        base = tmp_path / "base"
+        base.mkdir()
+        out = base / "a" / "b" / "c" / "test.wav"
+        result = _validate_output_path(out, allowed_base=base)
+        assert result.parent.exists()
+
+
+class TestGenerateOutputValidation:
+    """Integration tests for generate() output validation."""
+
+    def test_generate_rejects_escape_path(self, tmp_path):
+        """generate() rejects path escaping base."""
+        from unittest.mock import MagicMock, patch
+
+        from voicecli.api import generate
+
+        base = tmp_path / "base"
+        base.mkdir()
+        evil = base / ".." / "escape.wav"
+
+        with (
+            patch("voicecli.config.load_defaults", return_value={}),
+            patch("voicecli.engine.get_engine", side_effect=Exception("should not reach")),
+            pytest.raises(ValueError, match="escapes"),
+        ):
+            generate("test", output=evil)
+
+    def test_generate_bypass_with_cli_flag(self, tmp_path):
+        """generate() allows outside path with _cli_bypass=True."""
+        from unittest.mock import MagicMock, patch
+
+        from voicecli.api import generate
+
+        outside = tmp_path / "outside" / "test.wav"
+        mock_engine = MagicMock()
+        mock_engine.generate.return_value = outside
+
+        with (
+            patch("voicecli.config.load_defaults", return_value={}),
+            patch("voicecli.engine.get_engine", return_value=mock_engine),
+        ):
+            # Should NOT raise - bypass active
+            # Use chatterbox engine to avoid daemon path
+            generate("test", output=outside, _cli_bypass=True, engine="chatterbox")
+
+
+class TestCloneOutputValidation:
+    """Integration tests for clone() output validation."""
+
+    def test_clone_rejects_escape_path(self, tmp_path):
+        """clone() rejects path escaping base."""
+        from unittest.mock import patch
+
+        from voicecli.api import clone
+
+        base = tmp_path / "base"
+        base.mkdir()
+        evil = base / ".." / "escape.wav"
+        ref = tmp_path / "ref.wav"
+        ref.write_bytes(b"fake audio")
+
+        with (
+            patch("voicecli.config.load_defaults", return_value={}),
+            patch("voicecli.engine.get_engine", side_effect=Exception("should not reach")),
+            pytest.raises(ValueError, match="escapes"),
+        ):
+            clone("test", ref=ref, output=evil)
+
+
+class TestCLIBypass:
+    """Tests for CLI bypass functionality."""
+
+    @pytest.mark.skip(reason="Requires CLI _cli_bypass integration (V4-T16)")
+    def test_cli_output_flag_bypasses_validation(self, tmp_path, monkeypatch):
+        """CLI --output flag should bypass validation for outside paths."""
+        import subprocess
+
+        outside = tmp_path / "outside" / "test.wav"
+        # This would fail without bypass
+        result = subprocess.run(
+            ["uv", "run", "voicecli", "generate", "test", "--output", str(outside)],
+            capture_output=True,
+            text=True,
+        )
+        # Should NOT contain "escapes" error
+        assert "escapes" not in result.stderr


### PR DESCRIPTION
## Summary
- Add `_validate_output_path()` helper in `api.py` that validates all output paths stay within an allowed base (default: `~/.voicecli/TTS/voices_out`), creates parent dirs, and supports a `_cli_bypass` flag for explicit CLI `--output` overrides.
- Wire validator into `generate()`, `clone()`, `transcribe()` and NATS TTS adapter; remove duplicated `mkdir` calls from 5 engines.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #57: refactor(api): centralize output_path validation (OWASP-adjacent) | OPEN |
| Spec | [57-centralize-output-path-validation-spec.mdx](artifacts/specs/57-centralize-output-path-validation-spec.mdx) | Present |
| Implementation | 1 commit on `feat/57-centralize-output-path-validation` | Complete |
| Verification | Lint ✅ Tests ✅ (new `tests/test_output_path_validation.py`) | Passed |

## Test Plan
- [ ] `uv run pytest tests/test_output_path_validation.py` — path traversal, parent creation, bypass flag
- [ ] `uv run pytest tests/test_api.py` — existing API behavior unchanged
- [ ] `voicecli generate "hello" --output /tmp/out.wav` — CLI `--output` still writes outside default base (bypass path)
- [ ] `voicecli generate script.md` with frontmatter `output_path: ../../../etc/passwd` — validator rejects traversal

Closes #57

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`