### PR TITLE
ci(auto-merge): use --merge for promote PRs (Convention A)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,6 +1,10 @@
 # Auto-merge PRs that have been reviewed and passed all required checks.
-# Adds the PR to GitHub's merge queue (squash) once the "reviewed" label is present.
+# Adds the PR to GitHub's merge queue once the "reviewed" label is present.
 # GitHub natively waits for all required status checks before merging.
+#
+# Merge strategy (Convention A):
+#   - Promote PRs (base=main, head=staging) → --merge (preserves history, no phantom conflicts)
+#   - All other PRs                          → --squash
 #
 # Also closes linked issues after merge, because GITHUB_TOKEN-initiated
 # auto-merges don't trigger GitHub's native "Closes #X" issue closure.
@@ -31,11 +35,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Enable auto-merge (squash)
-        run: gh pr merge "$PR_NUMBER" --auto --squash
+      - name: Enable auto-merge
+        run: |
+          if [[ "$BASE_REF" == "main" && "$HEAD_REF" == "staging" ]]; then
+            echo "Promote PR detected (base=main, head=staging) — using --merge (Convention A)"
+            gh pr merge "$PR_NUMBER" --auto --merge
+          else
+            echo "Standard PR — using --squash"
+            gh pr merge "$PR_NUMBER" --auto --squash
+          fi
         env:
           GH_TOKEN: ${{ secrets.PAT }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
 
   update-behind-prs:
     name: Update behind PRs


### PR DESCRIPTION
## Summary

Promote PRs (base=`main`, head=`staging`) must use **merge-commit**, not squash. Squashing promote PRs causes phantom file conflicts on the next cycle — main ends up with one condensed commit whose content overlaps staging's individual feature commits, and git's merge strategy can't reconcile them without manual intervention.

Today I hit this exact problem on #89 (the v0.2.0 promote): had to back-merge `main` into staging with `-s ours` to clear the phantom conflict, then manually `gh pr merge 89 --merge` because auto-merge would have squashed.

## Fix

Detect promote PRs via base/head ref check, route to `--merge`:

\`\`\`yaml
if [[ "\$BASE_REF" == "main" && "\$HEAD_REF" == "staging" ]]; then
  gh pr merge "\$PR_NUMBER" --auto --merge
else
  gh pr merge "\$PR_NUMBER" --auto --squash
fi
\`\`\`

All other PRs continue to use \`--squash\` (unchanged behavior).

## Test plan

- [x] Local validation: YAML syntax + env var expansion
- [ ] Next promote cycle: verify `reviewed` label on a staging→main PR triggers `--merge`, not squash
- [ ] Regression: verify a normal feature-branch PR still gets squashed

## Impact

Zero-impact on feature PRs. Eliminates manual intervention on every promote — future promote PRs will just work with the `reviewed` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)