### PR TITLE
fix(e2e): make engine registry robust to missing torch

### DIFF
--- a/src/voicecli/engine.py
+++ b/src/voicecli/engine.py
@@ -86,6 +86,11 @@ QWEN_ENGINES = frozenset({"qwen", "qwen-fast"})
 
 def get_engine(name: str) -> TTSEngine:
     engines = _get_registry()
+    if not engines:
+        raise ValueError(
+            "No engines available. Install torch for real engines, "
+            "or set VOICECLI_ENABLE_MOCK_ENGINE=1 for mock engine."
+        )
     if name not in engines:
         raise ValueError(f"Unknown engine '{name}'. Available: {list(engines.keys())}")
     return engines[name]()

--- a/src/voicecli/engine.py
+++ b/src/voicecli/engine.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import contextlib
+import logging
 import re
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from pathlib import Path
+
+log = logging.getLogger(__name__)
 
 _CUDA_PATTERNS = re.compile(
     r"CUDA|cuDNN|NCCL|out of memory|CUBLAS|CUSOLVER|GPU|"
@@ -123,8 +126,8 @@ def _get_registry() -> dict[str, type[TTSEngine]]:
                 "voxtral": VoxtralEngine,
             }
         )
-    except ImportError:
-        pass  # torch not installed — real engines unavailable
+    except ImportError as e:
+        log.debug("Skipping real engines: %s", e)
 
     if coerce_bool_env("VOICECLI_ENABLE_MOCK_ENGINE"):
         from voicecli.engines.mock import MockEngine

--- a/src/voicecli/engine.py
+++ b/src/voicecli/engine.py
@@ -98,21 +98,34 @@ def _get_registry() -> dict[str, type[TTSEngine]]:
     MockEngine is gated by ``VOICECLI_ENABLE_MOCK_ENGINE`` — unset in prod,
     set to "1" in the e2e docker-compose files so the NATS satellite can
     answer round-trip requests without loading a real model.
+
+    Real engine imports are wrapped in try/except to handle missing torch.
+    If ImportError occurs (torch not installed), real engines are skipped.
     """
-    from voicecli.engines.chatterbox import ChatterboxEngine
-    from voicecli.engines.chatterbox_turbo import ChatterboxTurboEngine
-    from voicecli.engines.qwen import QwenEngine
-    from voicecli.engines.qwen_fast import QwenFastEngine
-    from voicecli.engines.voxtral import VoxtralEngine
     from voicecli.env import coerce_bool_env
 
-    registry: dict[str, type[TTSEngine]] = {
-        "qwen": QwenEngine,
-        "qwen-fast": QwenFastEngine,
-        "chatterbox": ChatterboxEngine,
-        "chatterbox-turbo": ChatterboxTurboEngine,
-        "voxtral": VoxtralEngine,
-    }
+    registry: dict[str, type[TTSEngine]] = {}
+
+    # Try to load real engines — skip if torch unavailable
+    try:
+        from voicecli.engines.chatterbox import ChatterboxEngine
+        from voicecli.engines.chatterbox_turbo import ChatterboxTurboEngine
+        from voicecli.engines.qwen import QwenEngine
+        from voicecli.engines.qwen_fast import QwenFastEngine
+        from voicecli.engines.voxtral import VoxtralEngine
+
+        registry.update(
+            {
+                "qwen": QwenEngine,
+                "qwen-fast": QwenFastEngine,
+                "chatterbox": ChatterboxEngine,
+                "chatterbox-turbo": ChatterboxTurboEngine,
+                "voxtral": VoxtralEngine,
+            }
+        )
+    except ImportError:
+        pass  # torch not installed — real engines unavailable
+
     if coerce_bool_env("VOICECLI_ENABLE_MOCK_ENGINE"):
         from voicecli.engines.mock import MockEngine
 

--- a/tests/e2e/docker-compose.nats.yml
+++ b/tests/e2e/docker-compose.nats.yml
@@ -21,7 +21,7 @@ services:
         && uv sync --extra nats --frozen
         --no-install-package torch
         --no-install-package torchaudio -q
-        && uv run voicecli nats-serve tts --engine mock
+        && uv run --no-sync voicecli nats-serve tts --engine mock
     environment:
       VOICECLI_ENABLE_MOCK_ENGINE: "1"
       NATS_URL: "nats://nats:4222"
@@ -45,7 +45,7 @@ services:
         && uv sync --extra nats --frozen
         --no-install-package torch
         --no-install-package torchaudio -q
-        && uv run voicecli nats-serve stt --model mock
+        && uv run --no-sync voicecli nats-serve stt --model mock
     environment:
       VOICECLI_ENABLE_MOCK_ENGINE: "1"
       NATS_URL: "nats://nats:4222"


### PR DESCRIPTION
## Summary
- Wrap real engine imports in try/except to handle missing torch gracefully
- Mock engine remains gated by `VOICECLI_ENABLE_MOCK_ENGINE` env var
- Fix docker-compose to use `--no-sync` flag preventing `uv run` from reinstalling torch

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #85: test_nats_roundtrip fails with engine_unavailable | OPEN |
| Frame | [85-e2e-engine-unavailable-frame.mdx](artifacts/frames/85-e2e-engine-unavailable-frame.mdx) | Approved |
| Spec | [85-e2e-engine-unavailable-spec.mdx](artifacts/specs/85-e2e-engine-unavailable-spec.mdx) | Approved |
| Implementation | 1 commit on `feat/85-e2e-engine-unavailable` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (e2e passes) | Passed |

## Test Plan
- [x] `VOICECLI_ENABLE_MOCK_ENGINE=1 uv run python -c "import sys; sys.modules['torch']=None; from voicecli.engine import _get_registry; print(list(_get_registry().keys()))"` → `['mock']`
- [x] `pytest tests/e2e/ -v` → passes

Closes #85

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`