### PR TITLE
feat(deploy): add container form factor for Quadlet deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Git
+.git/
+.gitignore
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+.venv/
+venv/
+*.egg-info/
+.eggs/
+dist/
+build/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Project
+.env*
+!.env.example
+artifacts/
+tests/
+*.md
+!README.md
+
+# Build
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,3 +136,17 @@ make -C ~/projects stt start
 | **allow-coexist** | Large-VRAM dev boxes (RTX 5070 Ti 16GB, …) only | `--allow-coexist` ∨ `VOICECLI_ALLOW_COEXIST=1` |
 
 ¬allow-coexist on RTX 3080 (10GB) prod — OOMs under concurrent synthesis. Full guard + exit codes: [`docs/NATS-SERVE.md#vram-sequencing`](docs/NATS-SERVE.md#vram-sequencing).
+
+### Container deployment (Quadlet)
+
+Production hosts can run voiceCLI as a Podman container managed by systemd via Quadlet. Unit files in `deploy/quadlet/` define TTS and STT NATS satellites with GPU passthrough.
+
+| File | Purpose |
+|---|---|
+| `Dockerfile` | Multi-stage build for CUDA 12.4 + uv + extras |
+| `deploy/entrypoint.sh` | Mode selector (`tts` \| `stt`) → `nats-serve` |
+| `deploy/quadlet/voicecli-tts.container` | TTS satellite systemd unit |
+| `deploy/quadlet/voicecli-stt.container` | STT satellite systemd unit |
+| `deploy/quadlet/voicecli-models.volume` | Shared HuggingFace cache volume |
+
+Full Quadlet setup: [`docs/NATS-SERVE.md#quadlet-deployment-podman--systemd`](docs/NATS-SERVE.md#quadlet-deployment-podman--systemd).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,34 @@
 FROM nvidia/cuda:12.4-runtime-ubuntu24.04
 
-# Python 3.12 + uv + git (for git-based deps)
-RUN apt-get update && apt-get install -y --no-install-recommends python3-venv git curl ca-certificates && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    rm -rf /var/lib/apt/lists/*
+# Install uv with pinned version (avoid curl | sh supply chain risk)
+ENV UV_VERSION=0.6.17
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3-venv git curl ca-certificates && \
+    curl -fsSL "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz" | \
+    tar -xzf - -C /usr/local/bin uv && \
+    rm -rf /var/lib/apt/lists/* && \
+    chmod +x /usr/local/bin/uv
 
-ENV PATH="/root/.local/bin:$PATH"
-
-# Create non-root user
-RUN useradd -r -m -d /app appuser
+# Create non-root user with home directory
+RUN useradd -r -m -d /home/appuser -s /bin/bash appuser
 
 WORKDIR /app
 
 # Copy dependency files first for layer caching
-COPY pyproject.toml uv.lock ./
+COPY --chown=appuser:appuser pyproject.toml uv.lock ./
 RUN uv sync --frozen --extra voxtral --extra nats
 
 # Copy source and set ownership
 COPY --chown=appuser:appuser . .
 
-# Entrypoint receives mode as argument
-COPY deploy/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh && chown appuser:appuser /entrypoint.sh
+# Entrypoint
+COPY --chown=appuser:appuser deploy/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 USER appuser
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["tts"]
 
-# Health check — GPU visibility
-HEALTHCHECK CMD nvidia-smi || exit 1
+# Health check — GPU visibility + process check
+HEALTHCHECK CMD nvidia-smi && pgrep -f "voicecli nats-serve" || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM nvidia/cuda:12.4-devel-ubuntu24.04
+
+# Python 3.12 + uv + git (for git-based deps)
+RUN apt-get update && apt-get install -y python3-venv git curl && \
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+
+ENV PATH="/root/.local/bin:$PATH"
+
+WORKDIR /app
+COPY . .
+RUN uv sync --frozen --extra voxtral --extra nats
+
+# Entrypoint receives mode as argument
+COPY deploy/entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["tts"]
+
+# Health check — GPU visibility
+HEALTHCHECK CMD nvidia-smi || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,30 @@
-FROM nvidia/cuda:12.4-devel-ubuntu24.04
+FROM nvidia/cuda:12.4-runtime-ubuntu24.04
 
 # Python 3.12 + uv + git (for git-based deps)
-RUN apt-get update && apt-get install -y python3-venv git curl && \
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+RUN apt-get update && apt-get install -y --no-install-recommends python3-venv git curl ca-certificates && \
+    curl -LsSf https://astral.sh/uv/install.sh | sh && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/root/.local/bin:$PATH"
 
+# Create non-root user
+RUN useradd -r -m -d /app appuser
+
 WORKDIR /app
-COPY . .
+
+# Copy dependency files first for layer caching
+COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --extra voxtral --extra nats
+
+# Copy source and set ownership
+COPY --chown=appuser:appuser . .
 
 # Entrypoint receives mode as argument
 COPY deploy/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh && chown appuser:appuser /entrypoint.sh
+
+USER appuser
+
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["tts"]
 

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+MODE="${1:-tts}"
+
+case "$MODE" in
+    tts|stt)
+        exec uv run voicecli nats-serve "$MODE"
+        ;;
+    *)
+        echo "Unknown mode: $MODE" >&2
+        exit 1
+        ;;
+esac

--- a/deploy/quadlet/voicecli-models.volume
+++ b/deploy/quadlet/voicecli-models.volume
@@ -1,0 +1,2 @@
+[Volume]
+VolumeName=voicecli-models

--- a/deploy/quadlet/voicecli-stt.container
+++ b/deploy/quadlet/voicecli-stt.container
@@ -2,14 +2,16 @@
 Description=voiceCLI STT NATS worker
 
 [Container]
-Image=ghcr.io/roxabi/voicecli:latest
-Volume=voicecli-models:/root/.cache/huggingface
-Volume=voicecli-models:/root/.cache/voicecli
-Secret=voicecli-stt.seed,type=mount,target=/root/.config/voicecli/nkeys/seed.seed
+Image=ghcr.io/roxabi/voicecli:0.5.0
+Volume=voicecli-models:/home/appuser/.cache/huggingface
+Volume=voicecli-models:/home/appuser/.cache/voicecli
+Secret=voicecli-stt.seed,type=mount,target=/home/appuser/.config/voicecli/nkeys/seed.seed,mode=0400
 Device=nvidia.com/gpu=all
 Environment=NATS_URL=nats://nats.internal:4222
-HealthCmd=nvidia-smi
+HealthCmd=bash -c "nvidia-smi && pgrep -f 'voicecli nats-serve' || exit 1"
 HealthInterval=30s
+NoNewPrivileges=true
+DropCapability=CAP_SYS_ADMIN CAP_NET_ADMIN CAP_SYS_PTRACE
 
 [Service]
 Restart=on-failure

--- a/deploy/quadlet/voicecli-stt.container
+++ b/deploy/quadlet/voicecli-stt.container
@@ -1,0 +1,19 @@
+[Unit]
+Description=voiceCLI STT NATS worker
+
+[Container]
+Image=ghcr.io/roxabi/voicecli:latest
+Volume=voicecli-models:/root/.cache/huggingface
+Volume=voicecli-models:/root/.cache/voicecli
+Secret=voicecli-stt.seed,type=mount,target=/root/.config/voicecli/nkeys/seed.seed
+Device=nvidia.com/gpu=all
+Environment=NATS_URL=nats://nats.internal:4222
+HealthCmd=nvidia-smi
+HealthInterval=30s
+
+[Service]
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=default.target

--- a/deploy/quadlet/voicecli-tts.container
+++ b/deploy/quadlet/voicecli-tts.container
@@ -1,0 +1,19 @@
+[Unit]
+Description=voiceCLI TTS NATS worker
+
+[Container]
+Image=ghcr.io/roxabi/voicecli:latest
+Volume=voicecli-models:/root/.cache/huggingface
+Volume=voicecli-models:/root/.cache/voicecli
+Secret=voicecli-tts.seed,type=mount,target=/root/.config/voicecli/nkeys/seed.seed
+Device=nvidia.com/gpu=all
+Environment=NATS_URL=nats://nats.internal:4222
+HealthCmd=nvidia-smi
+HealthInterval=30s
+
+[Service]
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=default.target

--- a/deploy/quadlet/voicecli-tts.container
+++ b/deploy/quadlet/voicecli-tts.container
@@ -2,14 +2,16 @@
 Description=voiceCLI TTS NATS worker
 
 [Container]
-Image=ghcr.io/roxabi/voicecli:latest
-Volume=voicecli-models:/root/.cache/huggingface
-Volume=voicecli-models:/root/.cache/voicecli
-Secret=voicecli-tts.seed,type=mount,target=/root/.config/voicecli/nkeys/seed.seed
+Image=ghcr.io/roxabi/voicecli:0.5.0
+Volume=voicecli-models:/home/appuser/.cache/huggingface
+Volume=voicecli-models:/home/appuser/.cache/voicecli
+Secret=voicecli-tts.seed,type=mount,target=/home/appuser/.config/voicecli/nkeys/seed.seed,mode=0400
 Device=nvidia.com/gpu=all
 Environment=NATS_URL=nats://nats.internal:4222
-HealthCmd=nvidia-smi
+HealthCmd=bash -c "nvidia-smi && pgrep -f 'voicecli nats-serve' || exit 1"
 HealthInterval=30s
+NoNewPrivileges=true
+DropCapability=CAP_SYS_ADMIN CAP_NET_ADMIN CAP_SYS_PTRACE
 
 [Service]
 Restart=on-failure

--- a/docs/NATS-SERVE.md
+++ b/docs/NATS-SERVE.md
@@ -457,3 +457,106 @@ the engine registry (and the STT transcribe short-circuit) when the
 unset, so `mock` is absent from `voicecli.engine.available_engines()` and any
 request carrying `engine: "mock"` is rejected with `engine_unavailable`. The
 `mock_engine` pytest fixture sets the var for the test scope.
+
+---
+
+## Quadlet deployment (Podman + systemd)
+
+For production hosts running Podman with systemd integration, voiceCLI provides
+Quadlet unit files in `deploy/quadlet/`. These enable native systemd management
+of containerized NATS satellites without manual podman commands.
+
+### Files
+
+| File | Purpose |
+|---|---|
+| `voicecli-tts.container` | TTS satellite as a systemd service |
+| `voicecli-stt.container` | STT satellite as a systemd service |
+| `voicecli-models.volume` | Shared volume for HuggingFace model cache |
+
+### Installation
+
+1. Copy Quadlet units to `~/.config/containers/systemd/` (user) or
+   `/etc/containers/systemd/` (root):
+
+   ```bash
+   mkdir -p ~/.config/containers/systemd
+   cp deploy/quadlet/*.container deploy/quadlet/*.volume ~/.config/containers/systemd/
+   ```
+
+2. Create the NKey seed secrets (one per satellite):
+
+   ```bash
+   printf 'SU...' > ~/.local/share/voicecli/nkeys/voicecli-tts.seed
+   chmod 600 ~/.local/share/voicecli/nkeys/voicecli-tts.seed
+
+   printf 'SU...' > ~/.local/share/voicecli/nkeys/voicecli-stt.seed
+   chmod 600 ~/.local/share/voicecli/nkeys/voicecli-stt.seed
+   ```
+
+3. Register secrets with Podman (required for Quadlet `Secret=` directive):
+
+   ```bash
+   podman secret create voicecli-tts.seed ~/.local/share/voicecli/nkeys/voicecli-tts.seed
+   podman secret create voicecli-stt.seed ~/.local/share/voicecli/nkeys/voicecli-stt.seed
+   ```
+
+4. Reload systemd and start the service(s):
+
+   ```bash
+   systemctl --user daemon-reload
+   systemctl --user start voicecli-tts
+   # or for STT:
+   systemctl --user start voicecli-stt
+   ```
+
+### Pre-seeding models
+
+On first run, each satellite downloads its model (~7 GB for TTS, ~2 GB for STT).
+To avoid a cold-start delay on production hosts, pre-seed the shared volume:
+
+```bash
+# Build the image locally first
+podman build -t voicecli:latest .
+
+# Run a one-shot container to populate the cache
+podman run --rm -v voicecli-models:/root/.cache/huggingface voicecli:latest uv run voicecli --help
+# The TTS/STT model will download on first synthesis/transcription
+```
+
+Alternatively, copy an existing cache from another host:
+
+```bash
+podman volume create voicecli-models
+podman run --rm -v voicecli-models:/data alpine tar xf - -C /data < cache.tar
+```
+
+### Resource considerations
+
+The TTS and STT satellites both require GPU access. On single-GPU hosts with
+limited VRAM (e.g. RTX 3080 10 GB), run only one satellite at a time or use
+`VOICECLI_MAX_CONCURRENT=1` on the STT satellite — see
+[STT — Required supervisord stanza](#stt--required-supervisord-stanza) for the
+supervisord equivalent.
+
+Quadlet does not directly support `exitcodes=` for restart policy tuning. The
+`Restart=on-failure` directive in the Quadlet files restarts on non-zero exits,
+which includes exit codes 3 (drain timeout) and 78 (VRAM guard). This is
+acceptable for containerized deployments where the orchestration layer handles
+restart throttling.
+
+### Image registry
+
+The Quadlet units reference `ghcr.io/roxabi/voicecli:latest`. For production,
+pin to a specific digest:
+
+```ini
+Image=ghcr.io/roxabi/voicecli@sha256:<digest>
+```
+
+Build and push from the repo root:
+
+```bash
+podman build -t ghcr.io/roxabi/voicecli:latest .
+podman push ghcr.io/roxabi/voicecli:latest
+```


### PR DESCRIPTION
## Summary

- Add Dockerfile with CUDA 12.4 base, uv sync, and GPU healthcheck for containerized voiceCLI workers
- Add Quadlet units (`voicecli-{tts,stt}.container`) for Podman systemd deployment with CDI GPU passthrough
- Add named volume unit (`voicecli-models.volume`) for persistent model cache
- Add entrypoint script for `nats-serve` mode selection (tts/stt)
- Update NATS-SERVE.md with Quadlet deployment section
- Update CLAUDE.md with container deployment notes

This establishes the containerization pattern for future Roxabi services (llmcli, imagecli).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #94: voiceCLI container form factor | OPEN |
| Frame | [94-container-form-factor-frame.mdx](../staging/artifacts/frames/94-container-form-factor-frame.mdx) | Approved |
| Spec | [94-container-form-factor-spec.mdx](../staging/artifacts/specs/94-container-form-factor-spec.mdx) | Approved |
| Plan | [94-container-form-factor-plan.mdx](../staging/artifacts/plans/94-container-form-factor-plan.mdx) | Complete |
| Implementation | 1 commit on `feat/94-container-form-factor` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (399 passed) | Passed |

## Test Plan

- [ ] `podman build -t voicecli:latest .` succeeds
- [ ] `podman run --rm --device nvidia.com/gpu=all voicecli:latest nvidia-smi` shows GPU
- [ ] Quadlet units valid syntax (copy to `~/.config/containers/systemd/`)
- [ ] `systemctl --user start voicecli-tts` starts container (requires NATS + GPU)

Closes #94

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/pr`