### PR TITLE
fix(nkeys): relocate NATS seed paths to ~/.voicecli/nkeys/ (ADR-055 D4)

### DIFF
--- a/deploy/quadlet/voicecli-stt.container
+++ b/deploy/quadlet/voicecli-stt.container
@@ -5,7 +5,7 @@ Description=voiceCLI STT NATS worker
 Image=ghcr.io/roxabi/voicecli:0.5.0
 Volume=voicecli-models:/home/appuser/.cache/huggingface
 Volume=voicecli-models:/home/appuser/.cache/voicecli
-Secret=voicecli-stt.seed,type=mount,target=/home/appuser/.config/voicecli/nkeys/seed.seed,mode=0400
+Secret=voicecli-nats-stt,type=mount,target=/home/appuser/.config/voicecli/nkeys/seed.seed,mode=0400
 Device=nvidia.com/gpu=all
 Environment=NATS_URL=nats://nats.internal:4222
 HealthCmd=bash -c "nvidia-smi && pgrep -f 'voicecli nats-serve' || exit 1"

--- a/deploy/quadlet/voicecli-tts.container
+++ b/deploy/quadlet/voicecli-tts.container
@@ -5,7 +5,7 @@ Description=voiceCLI TTS NATS worker
 Image=ghcr.io/roxabi/voicecli:0.5.0
 Volume=voicecli-models:/home/appuser/.cache/huggingface
 Volume=voicecli-models:/home/appuser/.cache/voicecli
-Secret=voicecli-tts.seed,type=mount,target=/home/appuser/.config/voicecli/nkeys/seed.seed,mode=0400
+Secret=voicecli-nats-tts,type=mount,target=/home/appuser/.config/voicecli/nkeys/seed.seed,mode=0400
 Device=nvidia.com/gpu=all
 Environment=NATS_URL=nats://nats.internal:4222
 HealthCmd=bash -c "nvidia-smi && pgrep -f 'voicecli nats-serve' || exit 1"

--- a/docs/NATS-SERVE.md
+++ b/docs/NATS-SERVE.md
@@ -135,7 +135,7 @@ command=voicecli nats-serve tts
 ; VOICECLI_ALLOW_COEXIST is intentionally absent — do NOT set it on co-located GPU
 ; hosts (e.g. RTX 3080 10 GB). Setting it bypasses the VRAM-sequencing guard and
 ; will cause CUDA OOM under concurrent synthesis. See VRAM sequencing section above.
-environment=NATS_URL="nats://nats.internal:4222",NATS_NKEY_SEED_PATH="/home/lyra/.lyra/nkeys/voicecli-tts.seed",LYRA_TTS_ENGINE="qwen-fast"
+environment=NATS_URL="nats://nats.internal:4222",NATS_NKEY_SEED_PATH="/home/lyra/.voicecli/nkeys/voice-tts.seed",LYRA_TTS_ENGINE="qwen-fast"
 autorestart=unexpected
 exitcodes=0,3,78
 stopsignal=TERM
@@ -168,7 +168,7 @@ For the STT satellite stanza, see [STT — Required supervisord stanza](#stt--re
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | Process exits 78 immediately on startup | Live socket daemon (`tts-serve` / `stt-serve`) detected | Stop the socket daemon via supervisorctl, then restart; or pass `--allow-coexist` if coexistence is intentional |
-| `PermissionError` referencing the seed file path | NKey seed file is not `0600` | `chmod 600 /path/to/voicecli-tts.seed` |
+| `PermissionError` referencing the seed file path | NKey seed file is not `0600` | `chmod 600 ~/.voicecli/nkeys/voice-tts.seed` |
 | Replies never arrive at the hub / requests time out | Wrong `NATS_URL`, network partition, or mismatched queue group name | Verify `NATS_URL` is reachable from the satellite host; queue group names are `tts-workers` (TTS) and `stt-workers` (STT) |
 | Heartbeats stop arriving during a synthesis | Concurrency contract violated (bug) | Report it — the spec guarantees heartbeats continue independently of in-flight synthesis |
 | Hub logs `payload_too_large` | Reply WAV exceeds NATS server `max_payload` | Increase `max_payload` in the NATS server config, or shorten the synthesis text |
@@ -372,7 +372,7 @@ Same rules as TTS (`autorestart=unexpected`, `exitcodes=0,3,78`) — see
 command=voicecli nats-serve stt
 ; VOICECLI_ALLOW_COEXIST is intentionally absent — do NOT set it on co-located GPU
 ; hosts. Bypasses the VRAM-sequencing guard and risks OOM. See VRAM sequencing above.
-environment=NATS_URL="nats://nats.internal:4222",NATS_NKEY_SEED_PATH="/home/lyra/.lyra/nkeys/voicecli-stt.seed",VOICECLI_MODEL="large-v3-turbo",VOICECLI_MAX_CONCURRENT="1"
+environment=NATS_URL="nats://nats.internal:4222",NATS_NKEY_SEED_PATH="/home/lyra/.voicecli/nkeys/voice-stt.seed",VOICECLI_MODEL="large-v3-turbo",VOICECLI_MAX_CONCURRENT="1"
 autorestart=unexpected
 exitcodes=0,3,78
 stopsignal=TERM
@@ -487,18 +487,19 @@ of containerized NATS satellites without manual podman commands.
 2. Create the NKey seed secrets (one per satellite):
 
    ```bash
-   printf 'SU...' > ~/.local/share/voicecli/nkeys/voicecli-tts.seed
-   chmod 600 ~/.local/share/voicecli/nkeys/voicecli-tts.seed
+   mkdir -p ~/.voicecli/nkeys && chmod 700 ~/.voicecli/nkeys
+   printf 'SU...' > ~/.voicecli/nkeys/voice-tts.seed
+   chmod 600 ~/.voicecli/nkeys/voice-tts.seed
 
-   printf 'SU...' > ~/.local/share/voicecli/nkeys/voicecli-stt.seed
-   chmod 600 ~/.local/share/voicecli/nkeys/voicecli-stt.seed
+   printf 'SU...' > ~/.voicecli/nkeys/voice-stt.seed
+   chmod 600 ~/.voicecli/nkeys/voice-stt.seed
    ```
 
 3. Register secrets with Podman (required for Quadlet `Secret=` directive):
 
    ```bash
-   podman secret create voicecli-tts.seed ~/.local/share/voicecli/nkeys/voicecli-tts.seed
-   podman secret create voicecli-stt.seed ~/.local/share/voicecli/nkeys/voicecli-stt.seed
+   podman secret create voicecli-nats-tts ~/.voicecli/nkeys/voice-tts.seed
+   podman secret create voicecli-nats-stt ~/.voicecli/nkeys/voice-stt.seed
    ```
 
 4. Reload systemd and start the service(s):

--- a/supervisor/conf.d/voicecli_stt.conf
+++ b/supervisor/conf.d/voicecli_stt.conf
@@ -1,7 +1,7 @@
 [program:voicecli_stt]
 command=%(ENV_HOME)s/projects/voiceCLI/supervisor/scripts/run_voicecli.sh stt
 directory=%(ENV_HOME)s/projects/voiceCLI
-environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/voiceCLI/.venv/bin:/usr/local/bin:/usr/bin:/bin",NATS_URL="tls://127.0.0.1:4222",NATS_NKEY_SEED_PATH="%(ENV_HOME)s/.lyra/nkeys/voice-stt.seed",NATS_CA_CERT="/etc/nats/certs/ca.crt"
+environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/voiceCLI/.venv/bin:/usr/local/bin:/usr/bin:/bin",NATS_URL="tls://127.0.0.1:4222",NATS_NKEY_SEED_PATH="%(ENV_HOME)s/.voicecli/nkeys/voice-stt.seed",NATS_CA_CERT="/etc/nats/certs/ca.crt"
 autostart=false
 autorestart=unexpected
 exitcodes=0,3,78,79

--- a/supervisor/conf.d/voicecli_tts.conf
+++ b/supervisor/conf.d/voicecli_tts.conf
@@ -1,7 +1,7 @@
 [program:voicecli_tts]
 command=%(ENV_HOME)s/projects/voiceCLI/supervisor/scripts/run_voicecli.sh tts
 directory=%(ENV_HOME)s/projects/voiceCLI
-environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/voiceCLI/.venv/bin:/usr/local/bin:/usr/bin:/bin",NATS_URL="tls://127.0.0.1:4222",NATS_NKEY_SEED_PATH="%(ENV_HOME)s/.lyra/nkeys/voice-tts.seed",NATS_CA_CERT="/etc/nats/certs/ca.crt"
+environment=HOME="%(ENV_HOME)s",PATH="%(ENV_HOME)s/.local/bin:%(ENV_HOME)s/projects/voiceCLI/.venv/bin:/usr/local/bin:/usr/bin:/bin",NATS_URL="tls://127.0.0.1:4222",NATS_NKEY_SEED_PATH="%(ENV_HOME)s/.voicecli/nkeys/voice-tts.seed",NATS_CA_CERT="/etc/nats/certs/ca.crt"
 autostart=false
 autorestart=unexpected
 exitcodes=0,3,78,79


### PR DESCRIPTION
## Summary

Move voiceCLI NATS nkey seeds out of \`~/.lyra/nkeys/\` (Phase 1 artifact — placed there when voiceCLI ran under Lyra's supervisord conf) to \`~/.voicecli/nkeys/\` per ADR-055 D4. First concrete step of voiceCLI Phase 2 Quadlet migration — unblocks #728.

## What changed

| File | Change |
|---|---|
| \`supervisor/conf.d/voicecli_tts.conf\` | \`NATS_NKEY_SEED_PATH\`: \`~/.lyra/nkeys/voice-tts.seed\` → \`~/.voicecli/nkeys/voice-tts.seed\` |
| \`supervisor/conf.d/voicecli_stt.conf\` | same for stt |
| \`docs/NATS-SERVE.md\` | normalize all seed-path examples to \`~/.voicecli/nkeys/voice-{tts,stt}.seed\`; update Quadlet provisioning to ADR-055 podman-secret naming (\`voicecli-nats-{tts,stt}\`) |
| \`deploy/quadlet/voicecli-tts.container\` | \`Secret=voicecli-tts.seed\` → \`Secret=voicecli-nats-tts\` (match D4 convention) |
| \`deploy/quadlet/voicecli-stt.container\` | \`Secret=voicecli-stt.seed\` → \`Secret=voicecli-nats-stt\` |

**Filename note:** seed files remain \`voice-{tts,stt}.seed\` (short identity). ADR-055 D1's \`voicecli-\` prefix applies to container images, not seed identities. D4's migration script explicitly preserves \`voice-*\` filenames.

## Lyra auth.conf — no change required

NATS \`auth.conf\` authorizes clients by their **derived public nkey**, not by seed file path. The Lyra-side \`deploy/nats/auth.conf\` entries for \`voice-tts\` / \`voice-stt\` already identify these clients by pubkey and remain valid after this migration — the seeds are the same cryptographic material, only relocated on disk.

Phase 4 (ADR-055 D2) consolidates all NATS-using projects onto one merged auth.conf. Until then, Lyra's auth.conf carries voiceCLI's pubkeys unchanged.

## Operator runbook — M₁ + M₂ migration (you run this, not Claude)

### Pre-flight

**Do both machines.** If you run voiceCLI locally on M₂, migrate it too before merging this PR locally — seeds currently live at \`~/.lyra/nkeys/voice-{tts,stt}.seed\` on M₂ as well.

\`\`\`bash
# 1. Stop voiceCLI so no process is mid-auth during the move (M₁)
supervisorctl -c ~/projects/supervisord.conf stop voicecli_tts voicecli_stt

# 2. Confirm source state — seeds must exist at the old path
if ! ls ~/.lyra/nkeys/voice-*.seed >/dev/null 2>&1; then
    echo "Seeds not at ~/.lyra/nkeys/ — may already be migrated. Check ~/.voicecli/nkeys/ before proceeding."
    exit 0
fi

# 3. Confirm no stale copies already exist at destination (idempotency guard)
if ls ~/.voicecli/nkeys/voice-*.seed 2>/dev/null; then
    echo "WARN: seeds already exist at ~/.voicecli/nkeys/ — investigate before overwriting."
    exit 1
fi
\`\`\`

### Migrate

\`\`\`bash
mkdir -p ~/.voicecli/nkeys/
chmod 700 ~/.voicecli/nkeys/

mv ~/.lyra/nkeys/voice-tts.seed ~/.voicecli/nkeys/voice-tts.seed
mv ~/.lyra/nkeys/voice-stt.seed ~/.voicecli/nkeys/voice-stt.seed

chmod 600 ~/.voicecli/nkeys/voice-*.seed

# Verify permissions and contents present
stat -c '%a %n' ~/.voicecli/nkeys/voice-*.seed
# Expected: "600 /home/mickael/.voicecli/nkeys/voice-tts.seed" etc.
\`\`\`

### No auth.conf edits needed

The NATS server does not reference seed file paths — it authorizes by pubkey. No edit to \`/etc/nats/auth.conf\` or Lyra's \`deploy/nats/auth.conf\` is required. Skip any instinct to \`grep\` NATS configs for the old path — you will find nothing, and that is correct.

### Verify (before restarting workers)

Test that the **migrated seed file** authenticates correctly — not the operator's own NATS CLI context:

\`\`\`bash
# Pass the seed explicitly via --nkey to prove the migrated file works
nats sub 'voice.>' \\
  --nkey ~/.voicecli/nkeys/voice-tts.seed \\
  --count 1 \\
  --timeout 5s \\
  -s tls://127.0.0.1:4222
# Expected: subscription established, no auth errors in NATS journal.

# Repeat with the stt seed
nats sub 'voice.>' \\
  --nkey ~/.voicecli/nkeys/voice-stt.seed \\
  --count 1 \\
  --timeout 5s \\
  -s tls://127.0.0.1:4222
\`\`\`

If NATS logs show auth failures, **stop** — do not restart workers. Run rollback below.

### Restart workers (after merging this PR + \`git pull\` on M₁)

\`\`\`bash
supervisorctl -c ~/projects/supervisord.conf start voicecli_tts voicecli_stt
supervisorctl -c ~/projects/supervisord.conf status voicecli_tts voicecli_stt
\`\`\`

Both should reach RUNNING within \`startsecs\` (10s TTS, 15s STT) with no PermissionError in stderr logs.

### Rollback (if verify fails)

\`\`\`bash
supervisorctl -c ~/projects/supervisord.conf stop voicecli_tts voicecli_stt

mv ~/.voicecli/nkeys/voice-tts.seed ~/.lyra/nkeys/
mv ~/.voicecli/nkeys/voice-stt.seed ~/.lyra/nkeys/

# Revert the supervisor conf (git stash or checkout the pre-merge version)
git -C ~/projects/voiceCLI checkout HEAD~1 -- supervisor/conf.d/voicecli_tts.conf supervisor/conf.d/voicecli_stt.conf

supervisorctl -c ~/projects/supervisord.conf reread
supervisorctl -c ~/projects/supervisord.conf update voicecli_tts voicecli_stt
supervisorctl -c ~/projects/supervisord.conf start voicecli_tts voicecli_stt
\`\`\`

No NATS reload needed for rollback either — same reason (pubkey unchanged).

**Do not regen nkeys** — same seeds, different path.

## Test Plan

- [ ] \`stat -c '%a' ~/.voicecli/nkeys/voice-*.seed\` returns \`600\` for both files
- [ ] \`nats sub 'voice.>' --nkey ~/.voicecli/nkeys/voice-tts.seed --count 1 --timeout 5s\` succeeds
- [ ] Both supervisor services reach RUNNING after restart; \`supervisorctl tail voicecli_tts stderr\` shows no PermissionError
- [ ] \`/var/log/nats/\` (or journald: \`journalctl -u nats -n 100\`) shows no auth-refused entries post-reload

## References

- ADR-055 \`lyra/docs/architecture/adr/055-quadlet-ecosystem-conventions.mdx\` — D4 env file + nkey convention, D2 cross-bus authorization
- ADR-055 Implementation issue #1 — this PR
- Precursor to #728 (voiceCLI Quadlet epic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)