### PR TITLE
fix(docker): fully qualify base images to docker.io/* (unblock M₁ build)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.4-runtime-ubuntu24.04
+FROM docker.io/nvidia/cuda:12.4-runtime-ubuntu24.04
 
 # Install uv with pinned version (avoid curl | sh supply chain risk)
 ENV UV_VERSION=0.6.17


### PR DESCRIPTION
## Summary

- Qualify `FROM nvidia/cuda:12.4-runtime-ubuntu24.04` → `FROM docker.io/nvidia/cuda:12.4-runtime-ubuntu24.04`
- Eliminates short-name resolution at `podman build` time on hosts without `unqualified-search-registries` configured

## Context

M₁ (`roxabituwer`) runs Podman 5.x on Ubuntu 26.04 LTS. That platform ships `/etc/containers/registries.conf` without an `unqualified-search-registries` list, so any bare `FROM <name>:<tag>` either fails or blocks on an interactive prompt. This was blocking the big-bang NATS consolidation cutover build (ADR-055, pre-window Task 5).

## Test plan

- [ ] `podman build -t localhost/voicecli:latest .` succeeds on M₁ (no unqualified-search-registries in /etc/containers/registries.conf)
- [ ] CI passes (existing tests unaffected — Dockerfile change only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)