### PR TITLE
fix(docker): correct nvidia/cuda base tag — 12.4 ubuntu24 never existed on Docker Hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/nvidia/cuda:12.4-runtime-ubuntu24.04
+FROM docker.io/nvidia/cuda:12.5.1-runtime-ubuntu24.04
 
 # Install uv with pinned version (avoid curl | sh supply chain risk)
 ENV UV_VERSION=0.6.17


### PR DESCRIPTION
## Summary

- The tag `nvidia/cuda:12.4-runtime-ubuntu24.04` does not exist on Docker Hub; ubuntu24.04 variants begin at `12.5.1`
- Update base image to `docker.io/nvidia/cuda:12.5.1-runtime-ubuntu24.04` (earliest available ubuntu24 tag for CUDA 12.x)

## Context

Discovered during big-bang NATS consolidation pre-window Task 5 on M₁. After PR #108 (qualified registry prefix) the build still failed:
```
manifest unknown: manifest unknown
```
M₁ driver: CUDA 13.0 (RTX 3080, Ampere, compute 8.6) — `12.5.1` runtime is fully backward-compatible.

## Test plan

- [ ] `podman build -t localhost/voicecli:latest .` succeeds on M₁
- [ ] `podman run --rm --device nvidia.com/gpu=all localhost/voicecli:latest nvidia-smi` shows GPU
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)