### PR TITLE
fix(docker): fix uv tarball extraction path (strip-components + explicit member)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV UV_VERSION=0.6.17
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-venv git curl ca-certificates && \
     curl -fsSL "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz" | \
-    tar -xzf - -C /usr/local/bin uv && \
+    tar -xzf - --strip-components=1 -C /usr/local/bin uv-x86_64-unknown-linux-gnu/uv && \
     rm -rf /var/lib/apt/lists/* && \
     chmod +x /usr/local/bin/uv
 


### PR DESCRIPTION
## Summary

- The uv release tarball layout is `uv-x86_64-unknown-linux-gnu/uv` — no bare `uv` at the top level
- `tar -xzf - -C /usr/local/bin uv` fails with `tar: uv: Not found in archive`
- Fix: use `--strip-components=1` and explicit member `uv-x86_64-unknown-linux-gnu/uv`

## Context

Discovered during big-bang NATS consolidation pre-window Task 5 on M₁ after PRs #108 (qualified registry) and #109 (correct CUDA tag) landed. The CUDA base image now pulls correctly; this is the remaining blocker for `podman build`.

## Test plan

- [ ] `podman build -t localhost/voicecli:latest .` succeeds on M₁ (full build completes)
- [ ] `podman run --rm localhost/voicecli:latest uv --version` shows `0.6.17`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)