### PR TITLE
fix(docker): drop uv run from entrypoint — uv missing in runtime stage

### DIFF
--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -5,7 +5,7 @@ MODE="${1:-tts}"
 
 case "$MODE" in
     tts|stt)
-        exec uv run voicecli nats-serve "$MODE"
+        exec voicecli nats-serve "$MODE"
         ;;
     *)
         echo "Unknown mode: $MODE" >&2


### PR DESCRIPTION
## Summary
- `deploy/entrypoint.sh` called `exec uv run voicecli …` but the runtime stage in Dockerfile never COPY-s `uv` from the builder — entrypoint fails with `exec: uv: not found`
- `voicecli` binary is already on PATH via `/app/.venv/bin`; drop the `uv run` wrapper and invoke it directly

## Why now
Discovered mid-cutover (big-bang NATS consolidation): `ghcr.io/roxabi/voicecli:staging` crash-loops immediately after start. Lyra core is fine; only voice workers are blocked.

## Test plan
- [ ] CI builds + publishes new `staging` image
- [ ] `podman pull ghcr.io/roxabi/voicecli:staging` on M₁
- [ ] `systemctl --user start voicecli-tts voicecli-stt` → active running
- [ ] Voice-note roundtrip via Telegram bot