### PR TITLE
fix(docker): drop --extra voxtral — heavy optional engine not used by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /app
 
 # Layer-cache: install deps before copying source
 COPY pyproject.toml uv.lock ./
-RUN uv sync --frozen --no-dev --extra voxtral --extra nats
+RUN uv sync --frozen --no-dev --extra nats
 
 # Copy source into venv location (no rebuild of deps)
 COPY src/ ./src/


### PR DESCRIPTION
## Summary
- Drop `--extra voxtral` from Dockerfile uv sync
- Default nats-serve engine is `qwen-fast`; voxtral is optional and adds torch+HQQ (~10min CI build)
- Engine code path preserved; `engine=voxtral` will raise ImportError at runtime if invoked

## Why now
CI image build for #113 was running ~15-20min due to voxtral deps. Cancelled and reshipping slimmer.

## Test plan
- [ ] CI builds + publishes new `staging` image faster
- [ ] `podman pull ghcr.io/roxabi/voicecli:staging` on M₁
- [ ] voicecli-tts + voicecli-stt start + register with NATS
- [ ] Voice-note roundtrip via Telegram