### PR TITLE
fix(docker): install python3 in runtime stage — venv symlinks require it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,9 @@ RUN chmod +x /entrypoint.sh
 # ── runtime stage ─────────────────────────────────────────────────────────────
 FROM docker.io/nvidia/cuda:12.5.1-runtime-ubuntu24.04 AS runtime
 
-# Runtime deps only: portaudio shared lib + TLS roots
+# Runtime deps only: python (venv binaries symlink to /usr/bin/python3) + portaudio shared lib + TLS roots
 RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 \
         libportaudio2 \
         ca-certificates && \
     rm -rf /var/lib/apt/lists/*

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ HUB_SERVICES   := tts stt
 QUADLET_DIR        ?= $(HOME)/.config/containers/systemd
 VOICECLI_NKEYS_DIR ?= $(HOME)/.voicecli/nkeys
 
-.PHONY: register tts stt install lint test quadlet-install quadlet-secrets-install
+DOCKER_IMAGE ?= localhost/voicecli:test
+
+.PHONY: register tts stt install lint test quadlet-install quadlet-secrets-install docker-build docker-smoke
 
 register:
 	@echo "Registering voiceCLI with supervisor hub..."
@@ -58,3 +60,15 @@ quadlet-secrets-install:  ## (re)create Podman secrets from $(VOICECLI_NKEYS_DIR
 	 podman secret create --replace voicecli-nats-stt  "$(VOICECLI_NKEYS_DIR)/voice-stt.seed"; \
 	 podman secret create --replace voicecli-nats-tts  "$(VOICECLI_NKEYS_DIR)/voice-tts.seed"
 	@echo "Podman secrets installed. Verify: podman secret ls"
+
+docker-build:  ## build runtime image locally as $(DOCKER_IMAGE)
+	podman build -t "$(DOCKER_IMAGE)" .
+
+docker-smoke: docker-build  ## local CI-equivalent smoke: exec, venv python, entrypoint wiring
+	@echo "── 1/3: voicecli --version ──"
+	@podman run --rm --entrypoint= "$(DOCKER_IMAGE)" voicecli --version
+	@echo "── 2/3: venv python resolves ──"
+	@podman run --rm --entrypoint=/bin/sh "$(DOCKER_IMAGE)" -c 'head -1 /app/.venv/bin/voicecli && /app/.venv/bin/python --version'
+	@echo "── 3/3: nats-serve --help (entrypoint codepath, no NATS needed) ──"
+	@podman run --rm --entrypoint= "$(DOCKER_IMAGE)" voicecli nats-serve --help | head -5
+	@echo "✓ smoke passed"


### PR DESCRIPTION
## Summary
- `/app/.venv/bin/python → /usr/bin/python3`; runtime stage only installed libportaudio2 + ca-certificates
- Container started fine but entrypoint hit `cannot execute: required file not found` when launching `voicecli`
- Add `python3` to runtime apt install

## Why now
Discovered mid-cutover. 3rd Dockerfile bug uncovered post-#113/#114 — image builds, starts, but crashes on exec.

## Test plan
- [ ] CI builds new image
- [ ] `podman run … ghcr.io/roxabi/voicecli:staging voicecli --version` succeeds
- [ ] voicecli-tts/stt services active
- [ ] Voice-note roundtrip