### PR TITLE
feat(infra): migrate to shared roxabi-ml-base image + torch as extra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y portaudio19-dev libcairo2-dev libgirepository-2.0-dev gir1.2-gtk-3.0
       - name: Install dependencies
-        run: uv sync --dev --extra nats
+        # --extra all pulls torch/transformers/faster_whisper so pyright resolves
+        # imports gated behind opt-in extras (post-#116 ml-base migration).
+        run: uv sync --dev --extra all
       - name: Lint
         run: uv run ruff check .
       - name: Format check
@@ -56,6 +58,11 @@ jobs:
             echo "::error::seed-shaped file committed under tests/e2e/"
             exit 1
           fi
+      - name: Build voicecli-mock image (PR-local)
+        # publish.yml only pushes to ghcr on staging push, so PR builds must
+        # build the mock image locally and tag it as the staging ref the
+        # compose file expects.
+        run: docker build -f Dockerfile.mock -t ghcr.io/roxabi/voicecli-mock:staging .
       - name: Run E2E tests
         run: pytest tests/e2e/ -v
       - name: Dump compose logs on failure

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,3 +12,10 @@ jobs:
     with:
       image_name: ghcr.io/roxabi/voicecli
       release_please_component: voicecli
+
+  publish-mock:
+    uses: Roxabi/.github/.github/workflows/publish-container.yml@v1
+    with:
+      image_name: ghcr.io/roxabi/voicecli-mock
+      dockerfile_path: Dockerfile.mock
+      release_please_component: voicecli

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,18 +20,39 @@ WORKDIR /app
 # (they live in /usr/local/lib/python3.12/dist-packages, not the venv).
 RUN uv venv --system-site-packages /app/.venv
 
+# Packages already present in ml-base's system site-packages — skip to avoid
+# duplicating ~5 GB of NVIDIA CUDA libs and triton in the venv.
+# Shell variable used (not ARG/ENV) so word-splitting works correctly in RUN.
+RUN UV_SKIP="--no-install-package torch \
+    --no-install-package torchaudio \
+    --no-install-package triton \
+    --no-install-package nvidia-cublas-cu12 \
+    --no-install-package nvidia-cuda-cupti-cu12 \
+    --no-install-package nvidia-cuda-nvrtc-cu12 \
+    --no-install-package nvidia-cuda-runtime-cu12 \
+    --no-install-package nvidia-cudnn-cu12 \
+    --no-install-package nvidia-cufft-cu12 \
+    --no-install-package nvidia-cufile-cu12 \
+    --no-install-package nvidia-curand-cu12 \
+    --no-install-package nvidia-cusolver-cu12 \
+    --no-install-package nvidia-cusparse-cu12 \
+    --no-install-package nvidia-cusparselt-cu12 \
+    --no-install-package nvidia-nccl-cu12 \
+    --no-install-package nvidia-nvjitlink-cu12 \
+    --no-install-package nvidia-nvtx-cu12 \
+    --no-install-package nvidia-nvshmem-cu12" && \
+    echo "$UV_SKIP" > /uv-skip-flags
+
 # Layer-cache: install deps without project first (deps don't change when src does).
 COPY pyproject.toml uv.lock README.md ./
 RUN uv sync --frozen --no-dev --no-install-project \
-        --no-install-package torch \
-        --no-install-package torchaudio \
+        $(cat /uv-skip-flags) \
         --extra tts --extra stt --extra nats
 
 # Now copy source and install the project itself.
 COPY src/ ./src/
 RUN uv sync --frozen --no-dev \
-        --no-install-package torch \
-        --no-install-package torchaudio \
+        $(cat /uv-skip-flags) \
         --extra tts --extra stt --extra nats
 
 COPY deploy/entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,13 @@
 # syntax=docker/dockerfile:1
 # ── build stage ──────────────────────────────────────────────────────────────
-FROM docker.io/nvidia/cuda:12.5.1-runtime-ubuntu24.04 AS builder
+ARG ML_BASE_TAG=cu128-py312-torch2.7.1
+FROM ghcr.io/roxabi/ml-base:${ML_BASE_TAG} AS builder
 
 ENV UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1
 
-# uv from official OCI artifact (digest-pinned via manifest, no curl|tar)
-COPY --from=ghcr.io/astral-sh/uv:0.11.7 /uv /uvx /usr/local/bin/
-
-# Build deps: Python + audio build deps + Cython compiler
+# Build deps: audio build deps only — ml-base already supplies python3.12 + uv + toolchain
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        python3-venv python3-dev \
-        gcc g++ \
         portaudio19-dev \
         git ca-certificates && \
     rm -rf /var/lib/apt/lists/*
@@ -20,7 +16,10 @@ WORKDIR /app
 
 # Layer-cache: install deps before copying source
 COPY pyproject.toml uv.lock ./
-RUN uv sync --frozen --no-dev --extra nats
+RUN uv sync --frozen --no-dev \
+        --no-install-package torch \
+        --no-install-package torchaudio \
+        --extra tts --extra stt --extra nats
 
 # Copy source into venv location (no rebuild of deps)
 COPY src/ ./src/
@@ -28,10 +27,11 @@ COPY deploy/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # ── runtime stage ─────────────────────────────────────────────────────────────
-FROM docker.io/nvidia/cuda:12.5.1-runtime-ubuntu24.04 AS runtime
+FROM docker.io/nvidia/cuda:12.8.1-cudnn9-runtime-ubuntu24.04 AS runtime
 
-# Runtime deps only: portaudio shared lib + TLS roots
+# Runtime deps: python3 (ubuntu24.04 default is 3.12) + portaudio shared lib + TLS roots
 RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 \
         libportaudio2 \
         ca-certificates && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,32 +6,45 @@ FROM ghcr.io/roxabi/ml-base:${ML_BASE_TAG} AS builder
 ENV UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1
 
-# Build deps: audio build deps only — ml-base already supplies python3.12 + uv + toolchain
+# Build deps: ml-base supplies python3.12 + uv + torch but no C toolchain.
+# pyaudio + nkeys + sox build wheels from source → need gcc + python headers.
 RUN apt-get update && apt-get install -y --no-install-recommends \
+        gcc g++ python3-dev \
         portaudio19-dev \
         git ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
-# Layer-cache: install deps before copying source
-COPY pyproject.toml uv.lock ./
+# Use system-site-packages so the venv inherits torch + flash-attn from ml-base
+# (they live in /usr/local/lib/python3.12/dist-packages, not the venv).
+RUN uv venv --system-site-packages /app/.venv
+
+# Layer-cache: install deps without project first (deps don't change when src does).
+COPY pyproject.toml uv.lock README.md ./
+RUN uv sync --frozen --no-dev --no-install-project \
+        --no-install-package torch \
+        --no-install-package torchaudio \
+        --extra tts --extra stt --extra nats
+
+# Now copy source and install the project itself.
+COPY src/ ./src/
 RUN uv sync --frozen --no-dev \
         --no-install-package torch \
         --no-install-package torchaudio \
         --extra tts --extra stt --extra nats
 
-# Copy source into venv location (no rebuild of deps)
-COPY src/ ./src/
 COPY deploy/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # ── runtime stage ─────────────────────────────────────────────────────────────
-FROM docker.io/nvidia/cuda:12.8.1-cudnn9-runtime-ubuntu24.04 AS runtime
+# Use ml-base as runtime base — it ships torch + flash-attn + python that the
+# venv inherits via --system-site-packages. Multi-stage still buys us no leak
+# of gcc/g++/python3-dev/portaudio19-dev/git into prod (those are builder-only).
+FROM ghcr.io/roxabi/ml-base:${ML_BASE_TAG} AS runtime
 
-# Runtime deps: python3 (ubuntu24.04 default is 3.12) + portaudio shared lib + TLS roots
+# Runtime deps: portaudio shared lib for pyaudio + TLS roots.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        python3 \
         libportaudio2 \
         ca-certificates && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.mock
+++ b/Dockerfile.mock
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+# Slim mock SUT for E2E. No torch, no ML libs — only NATS deps + mock engine.
+FROM python:3.12-slim AS builder
+
+ENV UV_LINK_MODE=copy UV_COMPILE_BYTECODE=1
+COPY --from=ghcr.io/astral-sh/uv:0.11.7 /uv /uvx /usr/local/bin/
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        gcc python3-dev portaudio19-dev git ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY pyproject.toml uv.lock ./
+COPY src/ ./src/
+RUN uv sync --frozen --no-dev --extra nats
+
+FROM python:3.12-slim AS runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libsndfile1 libportaudio2 ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -r -g 1501 voicecli && \
+    useradd -r -u 1501 -g voicecli -m -d /home/voicecli -s /bin/bash voicecli
+
+COPY --from=builder --chown=voicecli:voicecli /app /app
+ENV PATH="/app/.venv/bin:$PATH" VIRTUAL_ENV="/app/.venv" \
+    VOICECLI_ENABLE_MOCK_ENGINE=1 PYTHONDONTWRITEBYTECODE=1
+WORKDIR /app
+USER voicecli
+
+ENTRYPOINT ["voicecli"]

--- a/README.md
+++ b/README.md
@@ -36,10 +36,30 @@ flowchart LR
 
 ## Install
 
+> **Breaking change in v0.3:** `uv sync` alone no longer installs any engine. Choose an extra
+> that matches your use case — torch and ML libraries are now opt-in.
+
 ```bash
 git clone <repo-url> && cd voiceCLI
-uv sync
+
+# Full install — TTS + STT + NATS satellite
+uv sync --extra all
+
+# TTS only (Qwen3, Chatterbox, torch)
+uv sync --extra tts
+
+# STT only (Faster Whisper, torch)
+uv sync --extra stt
+
+# Mock E2E / NATS satellite only (no heavy ML deps)
+uv sync --extra nats
 ```
+
+**Docker users:** torch and torchaudio are preinstalled in the base image
+(`ghcr.io/roxabi/ml-base`), so the container build skips them. For editable
+installs outside Docker, `uv` resolves torch automatically from the
+`pytorch-cu128` index already declared in `pyproject.toml` — no extra index
+configuration needed.
 
 ## Quick Start
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,6 +3,27 @@ title: Configuration
 description: voicecli.toml reference and configuration resolution
 ---
 
+## Install Profiles
+
+ML libraries (torch, torchaudio) are optional extras — choose the profile that
+matches your use case. `uv sync` with no extras installs only the CLI core.
+
+| Profile | Command | What is installed |
+|---------|---------|-------------------|
+| **TTS dev** | `uv sync --extra tts` | Qwen3-TTS, faster-qwen3-tts, Chatterbox, torch, torchaudio |
+| **STT dev** | `uv sync --extra stt` | Faster Whisper, torch, torchaudio |
+| **Mock E2E / NATS satellite** | `uv sync --extra nats` | roxabi-nats, nats-py, nkeys, nvidia-ml-py (no torch) |
+| **Full** | `uv sync --extra all` | Everything above combined (`tts + stt + nats`) |
+| **Voxtral** | `uv sync --extra voxtral` | voxtral-tts (int4), scipy |
+| **Hotkey** | `uv sync --extra hotkey` | pynput |
+| **Overlay** | `uv sync --extra overlay` | PyGObject, pycairo |
+
+**Docker image:** the `ghcr.io/roxabi/ml-base` base image ships torch and
+torchaudio prebuilt for CUDA 12.8. The Dockerfile installs voicecli with
+`--no-install-package torch torchaudio` so the pre-built wheels are used
+instead of pulling from PyPI. Editable installs outside Docker resolve torch
+via the `pytorch-cu128` index already declared in `pyproject.toml`.
+
 ## Config File
 
 voiceCLI uses `voicecli.toml` (gitignored). Copy from `voicecli.example.toml` and customize.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,8 @@ description = "Unified CLI for voice generation — Qwen3-TTS & Chatterbox backe
 requires-python = ">=3.12,<3.13"
 dependencies = [
     "typer>=0.12",
-    "qwen-tts",
-    "faster-qwen3-tts",
-    "chatterbox-tts",
     "soundfile",
     "lameenc>=1.7",
-    "faster-whisper>=1.2",
-    "torch>=2.7",
-    "torchaudio>=2.7",
     "pyaudio>=0.2.14",
 ]
 
@@ -66,6 +60,19 @@ pythonpath = ["src"]
 testpaths = ["tests"]
 
 [project.optional-dependencies]
+tts = [
+    "qwen-tts",
+    "faster-qwen3-tts",
+    "chatterbox-tts",
+    "torch>=2.7",
+    "torchaudio>=2.7",
+]
+stt = [
+    "faster-whisper>=1.2",
+    "torch>=2.7",
+    "torchaudio>=2.7",
+]
+all = ["voicecli[tts,stt,nats]"]
 voxtral = ["voxtral-tts[int4]", "scipy"]
 hotkey = ["pynput>=1.7"]
 overlay = ["PyGObject>=3.42", "pycairo>=1.25"]

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -76,6 +76,9 @@ def compose_stack(nkey_seed: tuple[Path, str], nats_conf: Path):
         "REPO_ROOT": str(REPO_ROOT),
         "SEED_PATH": str(seed_path),
         "NATS_CONF_PATH": str(nats_conf),
+        # Pass host uid/gid so containers can read the 0o600 seed bind-mount.
+        "HOST_UID": str(os.getuid()),
+        "HOST_GID": str(os.getgid()),
     }
 
     up = subprocess.run(

--- a/tests/e2e/docker-compose.nats.yml
+++ b/tests/e2e/docker-compose.nats.yml
@@ -8,7 +8,7 @@ services:
       - ${NATS_CONF_PATH}:/etc/nats/nats-server.conf:ro
 
   voicecli-tts:
-    image: ghcr.io/roxabi/voicecli:staging
+    image: ghcr.io/roxabi/voicecli-mock:staging
     depends_on: [nats]
     environment:
       VOICECLI_ENABLE_MOCK_ENGINE: "1"
@@ -19,7 +19,7 @@ services:
     entrypoint: ["voicecli", "nats-serve", "tts", "--engine", "mock"]
 
   voicecli-stt:
-    image: ghcr.io/roxabi/voicecli:staging
+    image: ghcr.io/roxabi/voicecli-mock:staging
     depends_on: [nats]
     environment:
       VOICECLI_ENABLE_MOCK_ENGINE: "1"

--- a/tests/e2e/docker-compose.nats.yml
+++ b/tests/e2e/docker-compose.nats.yml
@@ -9,6 +9,9 @@ services:
 
   voicecli-tts:
     image: ghcr.io/roxabi/voicecli-mock:staging
+    # Run as host uid so the bind-mounted nkey seed (0o600 on host) is readable.
+    # roxabi_nats enforces 0o600/0o400, so chmod 0o644 is rejected.
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"
     depends_on: [nats]
     environment:
       VOICECLI_ENABLE_MOCK_ENGINE: "1"
@@ -20,6 +23,7 @@ services:
 
   voicecli-stt:
     image: ghcr.io/roxabi/voicecli-mock:staging
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"
     depends_on: [nats]
     environment:
       VOICECLI_ENABLE_MOCK_ENGINE: "1"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -87,7 +87,7 @@ def test_clone_no_ref_no_active_raises_valueerror():
         clone("Hello")
 
 
-def test_invalid_engine_raises_valueerror():
+def test_invalid_engine_raises_valueerror(mock_engine):
     """generate() with an invalid engine name should raise ValueError."""
     from voicecli.api import generate
 
@@ -129,7 +129,7 @@ def test_path_params_accept_str_and_path(tmp_path):
         assert isinstance(result, TTSResult)
 
 
-def test_list_engines_returns_strings():
+def test_list_engines_returns_strings(mock_engine):
     """list_engines() should return a list of engine key strings."""
     from voicecli.api import list_engines
 
@@ -137,10 +137,10 @@ def test_list_engines_returns_strings():
     assert isinstance(engines, list)
     assert len(engines) > 0
     assert all(isinstance(e, str) for e in engines)
-    assert "qwen" in engines
+    assert "mock" in engines
 
 
-def test_list_voices_invalid_raises_valueerror():
+def test_list_voices_invalid_raises_valueerror(mock_engine):
     """list_voices() with an invalid engine should raise ValueError."""
     from voicecli.api import list_voices
 

--- a/tests/test_mock_engine_gate.py
+++ b/tests/test_mock_engine_gate.py
@@ -27,7 +27,11 @@ def test_registry_excludes_mock_when_env_unset(monkeypatch):
     monkeypatch.delenv("VOICECLI_ENABLE_MOCK_ENGINE", raising=False)
     assert "mock" not in available_engines()
 
-    with pytest.raises(ValueError, match="Unknown engine 'mock'"):
+    # Without the gate, get_engine("mock") raises ValueError. Exact wording
+    # depends on whether torch is installed: real engines registered →
+    # "Unknown engine 'mock'"; torch absent (slim install) → "No engines
+    # available". Both confirm the gate excludes mock.
+    with pytest.raises(ValueError, match=r"(Unknown engine 'mock'|No engines available)"):
         get_engine("mock")
 
 

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -21,6 +21,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytest.importorskip("torch", reason="torch is opt-in via [stt]/[tts]/[all] extras")
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_vram_lifecycle.py
+++ b/tests/test_vram_lifecycle.py
@@ -13,6 +13,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytest.importorskip("torch", reason="torch is opt-in via [stt]/[tts]/[all] extras")
+
 
 class TestVramCleanup:
     def test_calls_gc_collect(self):

--- a/uv.lock
+++ b/uv.lock
@@ -123,7 +123,7 @@ name = "certifi"
 version = "2022.12.7"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18" },
+    { url = "https://download.pytorch.org/whl/certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18", upload-time = "2023-10-03T17:33:19Z" },
 ]
 
 [[package]]
@@ -163,7 +163,7 @@ name = "charset-normalizer"
 version = "2.1.1"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/charset_normalizer-2.1.1-py3-none-any.whl", hash = "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f" },
+    { url = "https://download.pytorch.org/whl/charset_normalizer-2.1.1-py3-none-any.whl", hash = "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f", upload-time = "2023-10-03T17:33:19Z" },
 ]
 
 [[package]]
@@ -206,7 +206,7 @@ name = "colorama"
 version = "0.4.6"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6" },
+    { url = "https://download.pytorch.org/whl/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", upload-time = "2023-10-05T23:50:34Z" },
 ]
 
 [[package]]
@@ -247,8 +247,8 @@ dependencies = [
     { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu128/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:694ba35023846625ef471257e6b5a4bc8af690f961d197d77d34b1d1db393f56" },
-    { url = "https://download.pytorch.org/whl/cu128/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fda147a344e8eaeca0c6ff113d2851ffca8f7dfc0a6c932374ee5c47caa649c8" },
+    { url = "https://download.pytorch.org/whl/cu128/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:694ba35023846625ef471257e6b5a4bc8af690f961d197d77d34b1d1db393f56", upload-time = "2026-01-26T17:23:49Z" },
+    { url = "https://download.pytorch.org/whl/cu128/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fda147a344e8eaeca0c6ff113d2851ffca8f7dfc0a6c932374ee5c47caa649c8", upload-time = "2026-01-26T17:23:50Z" },
 ]
 
 [[package]]
@@ -256,7 +256,7 @@ name = "cuda-pathfinder"
 version = "1.2.2"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/cuda_pathfinder-1.2.2-py3-none-any.whl" },
+    { url = "https://download.pytorch.org/whl/cuda_pathfinder-1.2.2-py3-none-any.whl", upload-time = "2026-01-20T19:36:05Z" },
 ]
 
 [[package]]
@@ -618,7 +618,7 @@ name = "idna"
 version = "3.4"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2" },
+    { url = "https://download.pytorch.org/whl/idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2", upload-time = "2023-10-06T21:35:40Z" },
 ]
 
 [[package]]
@@ -644,7 +644,7 @@ dependencies = [
     { name = "zipp" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/importlib_metadata-7.1.0-py3-none-any.whl" },
+    { url = "https://download.pytorch.org/whl/importlib_metadata-7.1.0-py3-none-any.whl", upload-time = "2025-08-05T21:34:24Z" },
 ]
 
 [[package]]
@@ -673,7 +673,7 @@ dependencies = [
     { name = "markupsafe" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/jinja2-3.1.6-py3-none-any.whl" },
+    { url = "https://download.pytorch.org/whl/jinja2-3.1.6-py3-none-any.whl", upload-time = "2025-10-14T18:38:59Z" },
 ]
 
 [[package]]
@@ -763,12 +763,12 @@ name = "markupsafe"
 version = "3.0.2"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl" },
-    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl" },
-    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl" },
-    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl" },
-    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl" },
-    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl" },
+    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", upload-time = "2026-02-19T22:23:09Z" },
+    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", upload-time = "2026-02-19T22:23:09Z" },
+    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", upload-time = "2026-02-19T22:23:09Z" },
+    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", upload-time = "2026-02-19T22:23:11Z" },
+    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", upload-time = "2026-02-19T22:23:11Z" },
+    { url = "https://download.pytorch.org/whl/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", upload-time = "2026-02-19T22:23:11Z" },
 ]
 
 [[package]]
@@ -1118,7 +1118,7 @@ name = "packaging"
 version = "24.1"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124" },
+    { url = "https://download.pytorch.org/whl/packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124", upload-time = "2024-10-29T23:48:01Z" },
 ]
 
 [[package]]
@@ -1630,7 +1630,7 @@ dependencies = [
     { name = "urllib3" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349" },
+    { url = "https://download.pytorch.org/whl/requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349", upload-time = "2023-10-06T21:36:51Z" },
 ]
 
 [[package]]
@@ -1805,7 +1805,7 @@ name = "setuptools"
 version = "70.2.0"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/setuptools-70.2.0-py3-none-any.whl", hash = "sha256:b8b8060bb426838fbe942479c90296ce976249451118ef566a5a0b7d8b78fb05" },
+    { url = "https://download.pytorch.org/whl/setuptools-70.2.0-py3-none-any.whl", hash = "sha256:b8b8060bb426838fbe942479c90296ce976249451118ef566a5a0b7d8b78fb05", upload-time = "2025-01-30T19:44:58Z" },
 ]
 
 [[package]]
@@ -1999,9 +1999,9 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6f09cdf2415516be028ae82e6b985bcfc3eac37bc52ab401142689f6224516ca" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:628e89bd5110ced7debee2a57c69959725b7fbc64eab81a39dd70e46c7e28ba5" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:fbde8f6a9ec8c76979a0d14df21c10b9e5cab6f0d106a73ca73e2179bc597cae" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6f09cdf2415516be028ae82e6b985bcfc3eac37bc52ab401142689f6224516ca", upload-time = "2026-01-21T15:22:03Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:628e89bd5110ced7debee2a57c69959725b7fbc64eab81a39dd70e46c7e28ba5", upload-time = "2026-01-21T15:22:11Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:fbde8f6a9ec8c76979a0d14df21c10b9e5cab6f0d106a73ca73e2179bc597cae", upload-time = "2026-01-21T15:22:17Z" },
 ]
 
 [[package]]
@@ -2009,7 +2009,7 @@ name = "torchao"
 version = "0.16.0+cu128"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu128/torchao-0.16.0%2Bcu128-cp310-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eda63ff11519c563d2f664b11e52cd7dcd0d7ff34c88cdfdef330e409d3f253f" },
+    { url = "https://download.pytorch.org/whl/cu128/torchao-0.16.0%2Bcu128-cp310-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eda63ff11519c563d2f664b11e52cd7dcd0d7ff34c88cdfdef330e409d3f253f", upload-time = "2026-02-10T18:44:08Z" },
 ]
 
 [[package]]
@@ -2020,9 +2020,9 @@ dependencies = [
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:08b56d10d1cd8536d40e18caceedc5567a30f5eb24381cde1dfa620724187c92" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d26b91a173cee6db9abff68b48d64236950ffc5628d06448ecdd7ac56841e10a" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.10.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:9a890dfbc7a3301f5ce7930f3ce452841f0c34e51686609628e99ed52c5cc775" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:08b56d10d1cd8536d40e18caceedc5567a30f5eb24381cde1dfa620724187c92", upload-time = "2026-01-21T15:05:48Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d26b91a173cee6db9abff68b48d64236950ffc5628d06448ecdd7ac56841e10a", upload-time = "2026-01-21T15:05:48Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.10.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:9a890dfbc7a3301f5ce7930f3ce452841f0c34e51686609628e99ed52c5cc775", upload-time = "2026-01-21T15:05:48Z" },
 ]
 
 [[package]]
@@ -2033,7 +2033,7 @@ dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/tqdm-4.66.5-py3-none-any.whl", hash = "sha256:90279a3770753eafc9194a0364852159802111925aa30eb3f9d85b0e805ac7cd" },
+    { url = "https://download.pytorch.org/whl/tqdm-4.66.5-py3-none-any.whl", hash = "sha256:90279a3770753eafc9194a0364852159802111925aa30eb3f9d85b0e805ac7cd", upload-time = "2024-10-30T00:09:55Z" },
 ]
 
 [[package]]
@@ -2062,8 +2062,8 @@ name = "triton"
 version = "3.6.0"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e42d084864d12b8784736fe51a0cd05f6cc56775b25c8102c9d80c421f4e298" },
-    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f5928e6d44c34a97bbe164cceddc0ef2007121c89ebcfba5415cf452de7ee9f" },
+    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e42d084864d12b8784736fe51a0cd05f6cc56775b25c8102c9d80c421f4e298", upload-time = "2026-01-22T23:13:34Z" },
+    { url = "https://download-r2.pytorch.org/whl/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f5928e6d44c34a97bbe164cceddc0ef2007121c89ebcfba5415cf452de7ee9f", upload-time = "2026-01-22T23:13:42Z" },
 ]
 
 [[package]]
@@ -2115,7 +2115,7 @@ name = "urllib3"
 version = "1.26.13"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/urllib3-1.26.13-py2.py3-none-any.whl", hash = "sha256:47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc" },
+    { url = "https://download.pytorch.org/whl/urllib3-1.26.13-py2.py3-none-any.whl", hash = "sha256:47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc", upload-time = "2023-10-06T21:48:51Z" },
 ]
 
 [[package]]
@@ -2150,19 +2150,25 @@ name = "voicecli"
 version = "0.2.0"
 source = { editable = "." }
 dependencies = [
-    { name = "chatterbox-tts" },
-    { name = "faster-qwen3-tts" },
-    { name = "faster-whisper" },
     { name = "lameenc" },
     { name = "pyaudio" },
-    { name = "qwen-tts" },
     { name = "soundfile" },
-    { name = "torch" },
-    { name = "torchaudio" },
     { name = "typer" },
 ]
 
 [package.optional-dependencies]
+all = [
+    { name = "chatterbox-tts" },
+    { name = "faster-qwen3-tts" },
+    { name = "faster-whisper" },
+    { name = "nats-py" },
+    { name = "nkeys" },
+    { name = "nvidia-ml-py" },
+    { name = "qwen-tts" },
+    { name = "roxabi-nats" },
+    { name = "torch" },
+    { name = "torchaudio" },
+]
 hotkey = [
     { name = "pynput" },
 ]
@@ -2175,6 +2181,18 @@ nats = [
 overlay = [
     { name = "pycairo" },
     { name = "pygobject" },
+]
+stt = [
+    { name = "faster-whisper" },
+    { name = "torch" },
+    { name = "torchaudio" },
+]
+tts = [
+    { name = "chatterbox-tts" },
+    { name = "faster-qwen3-tts" },
+    { name = "qwen-tts" },
+    { name = "torch" },
+    { name = "torchaudio" },
 ]
 voxtral = [
     { name = "scipy" },
@@ -2193,9 +2211,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "chatterbox-tts" },
-    { name = "faster-qwen3-tts" },
-    { name = "faster-whisper", specifier = ">=1.2" },
+    { name = "chatterbox-tts", marker = "extra == 'tts'" },
+    { name = "faster-qwen3-tts", marker = "extra == 'tts'" },
+    { name = "faster-whisper", marker = "extra == 'stt'", specifier = ">=1.2" },
     { name = "lameenc", specifier = ">=1.7" },
     { name = "nats-py", marker = "extra == 'nats'", specifier = ">=2.6,<3" },
     { name = "nkeys", marker = "extra == 'nats'", specifier = ">=0.1" },
@@ -2204,16 +2222,19 @@ requires-dist = [
     { name = "pycairo", marker = "extra == 'overlay'", specifier = ">=1.25" },
     { name = "pygobject", marker = "extra == 'overlay'", specifier = ">=3.42" },
     { name = "pynput", marker = "extra == 'hotkey'", specifier = ">=1.7" },
-    { name = "qwen-tts" },
+    { name = "qwen-tts", marker = "extra == 'tts'" },
     { name = "roxabi-nats", marker = "extra == 'nats'", git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-nats&tag=roxabi-nats%2Fv0.2.1" },
     { name = "scipy", marker = "extra == 'voxtral'" },
     { name = "soundfile" },
-    { name = "torch", specifier = ">=2.7" },
-    { name = "torchaudio", specifier = ">=2.7" },
+    { name = "torch", marker = "extra == 'stt'", specifier = ">=2.7" },
+    { name = "torch", marker = "extra == 'tts'", specifier = ">=2.7" },
+    { name = "torchaudio", marker = "extra == 'stt'", specifier = ">=2.7" },
+    { name = "torchaudio", marker = "extra == 'tts'", specifier = ">=2.7" },
     { name = "typer", specifier = ">=0.12" },
+    { name = "voicecli", extras = ["tts", "stt", "nats"], marker = "extra == 'all'" },
     { name = "voxtral-tts", extras = ["int4"], marker = "extra == 'voxtral'", git = "https://github.com/Roxabi/voxtral-tts.git?branch=main" },
 ]
-provides-extras = ["voxtral", "hotkey", "overlay", "nats"]
+provides-extras = ["tts", "stt", "all", "voxtral", "hotkey", "overlay", "nats"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2276,5 +2297,5 @@ name = "zipp"
 version = "3.19.2"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 wheels = [
-    { url = "https://download.pytorch.org/whl/zipp-3.19.2-py3-none-any.whl" },
+    { url = "https://download.pytorch.org/whl/zipp-3.19.2-py3-none-any.whl", upload-time = "2025-08-05T22:17:38Z" },
 ]


### PR DESCRIPTION
## Summary
- Consume `ghcr.io/roxabi/ml-base:cu128-py312-torch2.7.1` as Dockerfile builder base (CUDA 12.5→12.8, +cuDNN 9, +flash-attn from base).
- Split torch + heavy ML libs out of core deps into `[tts]`/`[stt]`/`[all]` extras → enables slim mock SUT.
- New `Dockerfile.mock` (242 MB, `python:3.12-slim`) replaces 7 GB voicecli:staging pull in compose for E2E speedup.
- `publish.yml` now builds + pushes both `voicecli` and `voicecli-mock` images.
- Exclude 16 nvidia-*/triton packages from venv — already present in ml-base system site-packages. Image: 19.7 GB → 13.5 GB (−6.2 GB).

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #116: infra: shared roxabi-ml-base image + voiceCLI migration | OPEN |
| Spec | [116-ml-base-migration-spec.mdx](artifacts/specs/116-ml-base-migration-spec.mdx) | Approved |
| Plan | [116-ml-base-migration-plan.mdx](artifacts/plans/116-ml-base-migration-plan.mdx) | F-lite, 19 tasks |
| Implementation | 6 commits on `feat/116-ml-base-migration` | T1–T6, T8, T9, T11, T17–T19 (11/19) |
| Verification | Lint ✅ · Pytest 405 ✅ / 3 skipped (torch-gated) · Image size 13.5 GB ✅ | Local QG green |

## Blocked by

- [ ] Roxabi/voiceCLI#117 — `roxabi-ml-base` repo bootstrap + GHCR publish.

Until #117 publishes the base image, the following remain pending:
- T7 (Phase B smoke on M₂ — qwen-fast generate)
- T10 (Phase C E2E green vs `voicecli-mock:local`)
- T12 (CI green on this PR — both images build)
- T13 (Phase D ctranslate2/whisper smoke on M₁ Ampere — cuDNN 9 ABI guard)
- T14–T16 (Quadlet swap + NATS drain doc)

## Image size

| Before | After | Delta |
|--------|-------|-------|
| 19.7 GB | 13.5 GB | −6.2 GB |

Root cause: uv resolves torch's transitive deps (nvidia-cublas, cudnn, triton, etc.) even when torch is skipped via `--no-install-package`. All 16 packages are already in ml-base's system site-packages and visible via `--system-site-packages` venv. Added explicit `--no-install-package` for each.

**Note:** 8 GB spec target is not achievable — ml-base alone is 12.7 GB. Real floor is ~13.5 GB. Further savings require splitting TTS/STT into separate images or trimming ml-base itself.

## BREAKING CHANGE

`uv sync` alone no longer installs engines. Use `--extra all` (full), `--extra tts` (TTS-only), `--extra stt` (STT-only), or `--extra nats` (mock SUT).

## Test Plan
- [ ] CI pulls ml-base once #117 ships → Docker build green
- [ ] E2E job pulls `voicecli-mock:staging` (<300 MB) instead of 7 GB image; total wall-clock <60 s
- [ ] M₂ smoke: `voicecli generate ... -e qwen-fast` produces wav from new image
- [ ] M₁ smoke: ctranslate2/whisper inference green on sm_86 + cuDNN 9

Closes #116

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`