### PR TITLE
chore(116): drain-and-swap docs + post-merge review fixes

### DIFF
--- a/artifacts/analyses/116-image-size-investigation.md
+++ b/artifacts/analyses/116-image-size-investigation.md
@@ -1,0 +1,208 @@
+# voiceCLI Image Size Investigation (#116)
+
+**Date:** 2026-04-26
+**Image:** `localhost/voicecli:local`
+**Measured size:** 19.7 GB
+**Spec target:** 8 GB
+**Delta:** +11.7 GB over target
+
+---
+
+## 1. Layer breakdown
+
+```
+podman history localhost/voicecli:local
+```
+
+| Layer | Size | Source |
+|---|---|---|
+| ml-base base layers (cuda + cudnn + torch + flash-attn) | 12.7 GB | `ghcr.io/roxabi/ml-base:cu128-py312-torch2.7.1` |
+| `COPY --from=builder /app /app` | **6.98 GB** | our venv + src |
+| `apt-get install libportaudio2 ca-certificates` | 6.19 MB | runtime apt |
+| `groupadd voicecli` + entrypoint copy | ~30 KB | — |
+| **Total** | **19.7 GB** | |
+
+→ Bloat lives in `/app`, copied wholesale from builder.
+
+---
+
+## 2. `/app` breakdown
+
+```
+podman run --rm --entrypoint sh localhost/voicecli:local -c 'du -sh /app/.venv /app/src'
+```
+
+| Path | Size |
+|---|---|
+| `/app/.venv` | **6.6 GB** |
+| `/app/src` | 1.1 MB |
+
+→ Bloat is exclusively in the venv.
+
+---
+
+## 3. Top venv site-packages
+
+```
+du -sh /app/.venv/lib/python3.12/site-packages/* | sort -h | tail -20
+```
+
+| Package | Size | In ml-base? | Verdict |
+|---|---|:---:|---|
+| `nvidia/*` | **4.3 GB** | ✅ | **DUPLICATED** |
+| `triton` | **641 MB** | ✅ | **DUPLICATED** |
+| `pkuseg` | 184 MB | ❌ | legit (Qwen ZH tokenizer) |
+| `llvmlite` | 162 MB | ❌ | legit (numba) |
+| `transformers` | 115 MB | ❌ | legit |
+| `scipy` | 114 MB | ❌ | legit |
+| `cuda` (cuda-python) | 106 MB | ❌ | legit |
+| `av.libs` | 82 MB | ❌ | legit |
+| `onnx` | 78 MB | ❌ | legit |
+| `ctranslate2.libs` | 75 MB | ❌ | legit |
+| `sympy` | 74 MB | ❌ | legit |
+| `pandas` | 73 MB | ❌ | legit |
+| `ctranslate2` | 60 MB | ❌ | legit |
+| `gradio` | 57 MB | ❌ | review (UI dep — needed?) |
+| `onnxruntime` | 53 MB | ❌ | legit |
+| `sklearn` | 47 MB | ❌ | legit |
+| `numpy` | 43 MB | ❌ | legit |
+| `av`, `perth`, `numba` | ~30 MB ea | ❌ | legit |
+
+**Duplicated total: ~5 GB.**
+
+---
+
+## 4. nvidia/* breakdown
+
+```
+du -sh /app/.venv/lib/python3.12/site-packages/nvidia/*
+```
+
+| Sub-pkg | Size | In ml-base? |
+|---|---|:---:|
+| `cudnn` | 1005 MB | ✅ |
+| `cublas` | 830 MB | ✅ |
+| `cusparselt` | 432 MB | ❌ (not present in ml-base) |
+| `nccl` | 410 MB | ✅ |
+| `cusolver` | 387 MB | ✅ |
+| `cusparse` | 371 MB | ✅ |
+| `cufft` | 269 MB | ✅ |
+| `cuda_nvrtc` | 212 MB | ✅ |
+| `nvshmem` | 195 MB | ❌ (not present in ml-base) |
+| `curand` | 133 MB | ✅ |
+| `nvjitlink` | 90 MB | ✅ |
+| `cuda_cupti` | 41 MB | ✅ |
+| `cuda_runtime` | 5 MB | ✅ |
+| `cufile` | 3.2 MB | ✅ |
+| `nvtx` | 0.4 MB | ✅ |
+
+ml-base has 14/16. Missing: `cusparselt` (432 MB), `nvshmem` (195 MB) — pulled by torch 2.7.1 metadata but **ml-base's torch 2.7.1 install works without them** (verified: `import torch` succeeds in ml-base alone). These are optional accelerator libs.
+
+---
+
+## 5. Root cause
+
+`uv sync --frozen --no-install-package torch --no-install-package torchaudio` excludes torch + torchaudio themselves from install, but **does NOT propagate the exclusion to their transitive deps**. The torch wheel's metadata declares `nvidia-cudnn-cu12`, `nvidia-cublas-cu12`, etc. as deps — uv resolves and installs them as standalone packages even though torch is skipped.
+
+Same for `triton` (a torch dep).
+
+The `--system-site-packages` venv flag makes the venv *able to see* ml-base's torch at `/usr/local/lib/python3.12/dist-packages/`, but uv's resolver doesn't know that and installs the wheels anyway.
+
+---
+
+## 6. Verification
+
+ml-base alone has working torch + flash-attn:
+
+```
+podman run --rm ghcr.io/roxabi/ml-base:cu128-py312-torch2.7.1 \
+  python -c "import torch, flash_attn; print(torch.__version__)"
+# 2.7.1+cu128
+```
+
+ml-base's nvidia/triton at:
+```
+/usr/local/lib/python3.12/dist-packages/nvidia/{cublas,cudnn,...}
+/usr/local/lib/python3.12/dist-packages/triton/
+```
+
+→ Already on `sys.path` for any venv created with `--system-site-packages`.
+
+---
+
+## 7. Proposed fix
+
+Add to both `uv sync` invocations in `Dockerfile`:
+
+```dockerfile
+--no-install-package triton \
+--no-install-package nvidia-cublas-cu12 \
+--no-install-package nvidia-cuda-cupti-cu12 \
+--no-install-package nvidia-cuda-nvrtc-cu12 \
+--no-install-package nvidia-cuda-runtime-cu12 \
+--no-install-package nvidia-cudnn-cu12 \
+--no-install-package nvidia-cufft-cu12 \
+--no-install-package nvidia-cufile-cu12 \
+--no-install-package nvidia-curand-cu12 \
+--no-install-package nvidia-cusolver-cu12 \
+--no-install-package nvidia-cusparse-cu12 \
+--no-install-package nvidia-cusparselt-cu12 \
+--no-install-package nvidia-nccl-cu12 \
+--no-install-package nvidia-nvjitlink-cu12 \
+--no-install-package nvidia-nvtx-cu12 \
+--no-install-package nvidia-nvshmem-cu12
+```
+
+**Expected outcome:** 19.7 GB → ~14.7 GB (−5 GB).
+
+**Risk:** Low. ml-base's torch already works without `cusparselt`/`nvshmem`. All other nvidia-* libs are present in ml-base at the system site-packages path, which the venv inherits via `--system-site-packages`.
+
+---
+
+## 8. Why we still won't hit 8 GB
+
+| Component | Size | Avoidable? |
+|---|---|---|
+| ml-base | 12.7 GB | No (cuda + cudnn + torch + flash-attn baseline) |
+| Legit extras (transformers, scipy, pandas, ctranslate2, onnx, gradio, etc.) | ~1.3 GB | Partially (review `gradio` dep) |
+| Project src + entrypoint | ~1 MB | No |
+| **Floor** | **~14 GB** | |
+
+The 8 GB spec target was likely set assuming a thinner base or a different install profile (e.g. STT-only without TTS extras). To approach 8 GB we would need:
+- Mode-specific images (TTS-only ≠ STT-only ≠ all-extras)
+- Or strip extras and install at runtime (defeats container immutability)
+- Or trim ml-base itself (drop flash-attn? cuDNN?)
+
+---
+
+## 9. Side investigation prompts
+
+If running this independently, the key checks are:
+
+1. **Confirm the bloat:**
+   ```
+   podman history localhost/voicecli:local --format "{{.Size}}\t{{.CreatedBy}}" | head
+   ```
+2. **Confirm `nvidia/*` duplication:**
+   ```
+   podman run --rm --entrypoint sh localhost/voicecli:local -c \
+     'du -sh /app/.venv/lib/python3.12/site-packages/nvidia/*'
+   ```
+3. **Confirm ml-base provides them:**
+   ```
+   podman run --rm --entrypoint sh ghcr.io/roxabi/ml-base:cu128-py312-torch2.7.1 -c \
+     'ls /usr/local/lib/python3.12/dist-packages/nvidia/'
+   ```
+4. **Test the fix:** patch Dockerfile per §7, rebuild, re-measure. Verify:
+   ```
+   podman run --rm voicecli:local python -c \
+     "import torch; print(torch.cuda.is_available()); import flash_attn"
+   ```
+
+---
+
+## 10. Open questions
+
+- Is `gradio` (57 MB) actually used by voiceCLI runtime, or only by chatterbox dev tools?
+- Could we add `nvidia-cusparselt-cu12` + `nvidia-nvshmem-cu12` to ml-base instead of accepting them in voicecli's venv? (~627 MB savings if they're shared across consumers)
+- Does uv have a `--no-install-deps-of` or `--inherit-system-package` flag we could use instead of enumerating 16 packages? (worth checking uv 0.11+ changelog)

--- a/deploy/quadlet/voicecli-stt.container
+++ b/deploy/quadlet/voicecli-stt.container
@@ -26,6 +26,9 @@ DropCapability=all
 [Service]
 Restart=on-failure
 RestartSec=10
+# Exits 3 (drain timeout) and 78 (VRAM-sequencing guard) are intentional —
+# do not restart-loop on them. Mirrors supervisord's `exitcodes=0,3,78`.
+RestartForceExitStatus=3 78
 
 [Install]
 WantedBy=default.target

--- a/deploy/quadlet/voicecli-tts.container
+++ b/deploy/quadlet/voicecli-tts.container
@@ -25,6 +25,9 @@ DropCapability=all
 [Service]
 Restart=on-failure
 RestartSec=10
+# Exits 3 (drain timeout) and 78 (VRAM-sequencing guard) are intentional —
+# do not restart-loop on them. Mirrors supervisord's `exitcodes=0,3,78`.
+RestartForceExitStatus=3 78
 
 [Install]
 WantedBy=default.target

--- a/docs/NATS-SERVE.md
+++ b/docs/NATS-SERVE.md
@@ -548,8 +548,9 @@ restart throttling.
 
 ### Image registry
 
-The Quadlet units reference `ghcr.io/roxabi/voicecli:latest`. For production,
-pin to a specific digest:
+The Quadlet units reference `ghcr.io/roxabi/voicecli:staging` — the rolling tag
+that `publish.yml` pushes on every staging branch update. For production, pin
+to a specific digest:
 
 ```ini
 Image=ghcr.io/roxabi/voicecli@sha256:<digest>
@@ -558,6 +559,72 @@ Image=ghcr.io/roxabi/voicecli@sha256:<digest>
 Build and push from the repo root:
 
 ```bash
-podman build -t ghcr.io/roxabi/voicecli:latest .
-podman push ghcr.io/roxabi/voicecli:latest
+podman build -t ghcr.io/roxabi/voicecli:staging .
+podman push ghcr.io/roxabi/voicecli:staging
 ```
+
+### Drain-and-swap upgrade protocol
+
+The voiceCLI workers hold GPU VRAM and may be mid-synthesis when a new image
+lands. A blind `systemctl restart` interrupts in-flight requests and leaves
+NATS clients without responders. Use the drain-and-swap sequence below to roll
+out a new `:staging` image with zero dropped requests and a one-command
+rollback path.
+
+**Pre-swap — tag the running image as `:staging-prev`:**
+
+```bash
+# Capture the digest currently in use so we can roll back atomically.
+CURRENT=$(podman inspect voicecli-tts --format '{{.ImageDigest}}')
+podman tag "ghcr.io/roxabi/voicecli@${CURRENT}" ghcr.io/roxabi/voicecli:staging-prev
+```
+
+**Drain — let in-flight work finish before pulling:**
+
+```bash
+# Sends SIGTERM → satellite stops accepting new NATS requests, waits up to
+# VOICECLI_DRAIN_TIMEOUT (default 30 s) for in-flight synthesis to complete,
+# then exits with code 0 (clean) or 3 (timeout exceeded). Quadlet's
+# Restart=on-failure does NOT fire on code 0, so the unit stays stopped.
+systemctl --user stop voicecli-tts.service
+systemctl --user stop voicecli-stt.service
+```
+
+Tail logs to confirm a clean drain:
+
+```bash
+journalctl --user -u voicecli-tts.service -n 50 | grep -E 'drain|exit'
+# Expect: "drained N in-flight requests, exiting cleanly" → exit 0
+```
+
+**Swap — pull the new image and reload Quadlet:**
+
+```bash
+podman pull ghcr.io/roxabi/voicecli:staging
+# Quadlet generates systemd units from .container files at daemon-reload time;
+# re-run after pulling so the new image digest is picked up.
+systemctl --user daemon-reload
+systemctl --user start voicecli-tts.service voicecli-stt.service
+```
+
+**Verify — health + a smoke request:**
+
+```bash
+systemctl --user status voicecli-tts.service voicecli-stt.service
+# Quick NATS round-trip from the host (requires nats-py + a user nkey):
+nats req voicecli.tts.qwen.generate '{"text":"smoke","voice":"Cherry"}' --timeout 30s
+```
+
+**Rollback — if the new image regresses:**
+
+```bash
+systemctl --user stop voicecli-tts.service voicecli-stt.service
+# Repoint the rolling tag back to the previous digest.
+podman tag ghcr.io/roxabi/voicecli:staging-prev ghcr.io/roxabi/voicecli:staging
+systemctl --user daemon-reload
+systemctl --user start voicecli-tts.service voicecli-stt.service
+```
+
+The `:staging-prev` tag survives `podman pull :staging` (only the rolling tag
+is overwritten), so a rollback is always one `podman tag` away until the next
+swap re-tags `:staging-prev`.

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -81,8 +81,10 @@ def compose_stack(nkey_seed: tuple[Path, str], nats_conf: Path):
         "HOST_GID": str(os.getgid()),
     }
 
+    # -p e2e: pin project name so CI teardown (`docker compose -p e2e ...`)
+    # targets the same stack the fixture brought up.
     up = subprocess.run(
-        ["docker", "compose", "-f", str(COMPOSE_FILE), "up", "-d"],
+        ["docker", "compose", "-p", "e2e", "-f", str(COMPOSE_FILE), "up", "-d"],
         env=env,
         capture_output=True,
         text=True,
@@ -95,7 +97,7 @@ def compose_stack(nkey_seed: tuple[Path, str], nats_conf: Path):
         yield env
     finally:
         subprocess.run(
-            ["docker", "compose", "-f", str(COMPOSE_FILE), "down", "-v"],
+            ["docker", "compose", "-p", "e2e", "-f", str(COMPOSE_FILE), "down", "-v"],
             env=env,
             capture_output=True,
             text=True,


### PR DESCRIPTION
## Summary

Follow-ups to #118 (ml-base migration) — these two commits were pushed after auto-merge fired and didn't make the original PR.

- **`docs(nats-serve)`** — drain-and-swap upgrade protocol section in `docs/NATS-SERVE.md` (closes T14/T15/T16: pre-swap `:staging-prev` tag, SIGTERM drain, podman pull + daemon-reload, smoke verify, one-tag rollback). Also commits the standalone image-size investigation (`artifacts/analyses/116-image-size-investigation.md`).
- **`fix(quadlet,e2e)`** — addresses two medium-confidence findings from the #118 code review:
  - `RestartForceExitStatus=3 78` on both Quadlet units (matches supervisord `exitcodes=0,3,78`; prevents restart-loop on intentional drain-timeout / VRAM-guard exits)
  - `-p e2e` on `docker compose up`/`down` in `tests/e2e/conftest.py` (pins project name to match CI teardown)

## Test Plan
- [x] Lint + typecheck + 387 unit tests green locally
- [ ] CI green on this PR (re-runs full ci + e2e jobs)
- [ ] Verify Quadlet syntax: `systemd-analyze verify deploy/quadlet/voicecli-tts.container` (post-merge on M₁)

Refs #116