### PR TITLE
refactor(api): wire SynthesisPort — replace daemon direct coupling (ADR-059 V3/MP3)

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -11,6 +11,7 @@ type = layers
 layers =
     voicecli.cli | voicecli.nats | voicecli.tg | voicecli.listen | voicecli.overlay
     voicecli.api
+    voicecli.adapters
     voicecli.engine | voicecli.transcribe | voicecli.daemon | voicecli.stt_daemon | voicecli.model_registry
     voicecli.config | voicecli.paths | voicecli.utils | voicecli.env | voicecli.models | voicecli.samples | voicecli.translate | voicecli.markdown | voicecli.stt_modes
 ignore_imports =

--- a/.importlinter
+++ b/.importlinter
@@ -34,3 +34,13 @@ ignore_imports =
     voicecli.stt_daemon -> voicecli.transcribe
     # Transitional: voicecli.model_registry imports voicecli.engine to manage engine instances — needs decoupling via ports layer (ADR-059)
     voicecli.model_registry -> voicecli.engine
+
+[importlinter:contract:api-no-direct-infra]
+name = api must not import daemon or model_registry directly
+type = forbidden
+source_modules =
+    voicecli.api
+forbidden_modules =
+    voicecli.daemon
+    voicecli.model_registry
+allow_indirect_imports = True

--- a/src/voicecli/adapters/__init__.py
+++ b/src/voicecli/adapters/__init__.py
@@ -1,0 +1,1 @@
+# voicecli.adapters — infrastructure adapters for ports

--- a/src/voicecli/adapters/synthesis.py
+++ b/src/voicecli/adapters/synthesis.py
@@ -139,7 +139,7 @@ class DaemonSynthesisAdapter:
 
         # Fallback to local engine
         eng = get_engine(engine)
-        if kwargs.get("fast") and engine in QWEN_ENGINES:
+        if kwargs.pop("fast", False) and engine in QWEN_ENGINES:
             eng._small = True
         return eng.generate(
             text,
@@ -198,7 +198,7 @@ class DaemonSynthesisAdapter:
 
         # Fallback to local engine
         eng = get_engine(engine)
-        if kwargs.get("fast") and engine in QWEN_ENGINES:
+        if kwargs.pop("fast", False) and engine in QWEN_ENGINES:
             eng._small = True
         return eng.clone(
             text,
@@ -245,7 +245,7 @@ class LocalSynthesisAdapter:
         from voicecli.engine import QWEN_ENGINES
 
         eng = self._registry.get(engine)
-        if kwargs.get("fast") and engine in QWEN_ENGINES:
+        if kwargs.pop("fast", False) and engine in QWEN_ENGINES:
             eng._small = True
         return eng.generate(
             text,
@@ -281,7 +281,7 @@ class LocalSynthesisAdapter:
         from voicecli.engine import QWEN_ENGINES
 
         eng = self._registry.get(engine)
-        if kwargs.get("fast") and engine in QWEN_ENGINES:
+        if kwargs.pop("fast", False) and engine in QWEN_ENGINES:
             eng._small = True
         return eng.clone(
             text,

--- a/src/voicecli/adapters/synthesis.py
+++ b/src/voicecli/adapters/synthesis.py
@@ -1,0 +1,298 @@
+"""Infrastructure adapters for SynthesisPort.
+
+Provides two concrete implementations:
+- DaemonSynthesisAdapter: routes requests through the voicecli daemon socket.
+- LocalSynthesisAdapter: calls engines directly via ModelRegistry.
+
+All imports of heavy dependencies (voicecli.daemon, voicecli.engine, torch) are
+deferred to method bodies — never at class or module level.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+_DAEMON_WAIT_SECS = 60.0
+_DAEMON_POLL_INTERVAL = 2.0
+
+
+class DaemonSynthesisAdapter:
+    """SynthesisPort implementation that dispatches through the daemon socket."""
+
+    # ── availability ─────────────────────────────────────────────────────────
+
+    def is_available(self) -> bool:
+        """Return True if the daemon socket path exists."""
+        from voicecli.daemon import SOCKET_PATH
+
+        return SOCKET_PATH.exists()
+
+    # ── internal helpers ──────────────────────────────────────────────────────
+
+    def _wait_for_socket(self, timeout: float = _DAEMON_WAIT_SECS) -> bool:
+        """Block until daemon socket appears or timeout expires."""
+        from voicecli.daemon import SOCKET_PATH
+
+        if SOCKET_PATH.exists():
+            return True
+        print(
+            f"[voicecli] daemon socket not found — waiting up to {timeout:.0f}s...",
+            flush=True,
+        )
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            time.sleep(_DAEMON_POLL_INTERVAL)
+            if SOCKET_PATH.exists():
+                return True
+        return False
+
+    def _try_socket(self, request: dict) -> Path | None:
+        """Send request to daemon. Returns WAV path on success, None on failure."""
+        from voicecli.daemon import SOCKET_PATH, daemon_request
+
+        if not SOCKET_PATH.exists():
+            return None
+        try:
+            resp = daemon_request(request, timeout=300)
+            if resp.get("status") == "ok":
+                return Path(resp["path"])
+            log.error("daemon error: %s", resp.get("message", "unknown error"))
+        except Exception:
+            log.exception("daemon request failed")
+        return None
+
+    def _chunk_fn(self, engine_name: str):
+        """Return a daemon_fn closure for chunked generation/cloning."""
+
+        def daemon_fn(method: str, text: str, voice, chunk_path: Path, **kwargs) -> bool:
+            req: dict = {
+                "action": method,
+                "engine": engine_name,
+                "text": text,
+                "voice": voice,
+                "output_path": str(chunk_path.resolve()),
+                "language": kwargs.get("language"),
+                "instruct": kwargs.get("instruct"),
+                "exaggeration": kwargs.get("exaggeration"),
+                "cfg_weight": kwargs.get("cfg_weight"),
+                "segment_gap": kwargs.get("segment_gap"),
+                "crossfade": kwargs.get("crossfade"),
+                "segments": [],
+            }
+            if method == "clone":
+                ref = kwargs.get("ref_audio")
+                req["ref_audio"] = str(ref.resolve()) if ref else None
+                req["ref_text"] = kwargs.get("ref_text")
+            if not self._wait_for_socket():
+                return False
+            if self._try_socket(req) is None:
+                return False
+            return True
+
+        return daemon_fn
+
+    # ── SynthesisPort interface ───────────────────────────────────────────────
+
+    def generate(
+        self,
+        engine: str,
+        text: str,
+        voice: str | None,
+        output_path: Path,
+        *,
+        language: str | None = None,
+        instruct: str | None = None,
+        exaggeration: float | None = None,
+        cfg_weight: float | None = None,
+        segment_gap: int | None = None,
+        crossfade: int | None = None,
+        segments: list | None = None,
+        **kwargs,
+    ) -> Path | None:
+        """Generate speech via the daemon socket, fallback to local engine on miss."""
+        from voicecli.engine import QWEN_ENGINES, get_engine
+
+        # Try socket first for Qwen engines
+        if engine in QWEN_ENGINES and self._wait_for_socket():
+            result = self._try_socket(
+                {
+                    "action": "generate",
+                    "engine": engine,
+                    "text": text,
+                    "voice": voice,
+                    "output_path": str(output_path.resolve()),
+                    "language": language,
+                    "instruct": instruct,
+                    "exaggeration": exaggeration,
+                    "cfg_weight": cfg_weight,
+                    "segment_gap": segment_gap,
+                    "crossfade": crossfade,
+                    "segments": segments or [],
+                }
+            )
+            if result is not None:
+                return result
+
+        # Fallback to local engine
+        eng = get_engine(engine)
+        if kwargs.get("fast") and engine in QWEN_ENGINES:
+            eng._small = True
+        return eng.generate(
+            text,
+            voice,
+            output_path,
+            language=language,
+            instruct=instruct,
+            exaggeration=exaggeration,
+            cfg_weight=cfg_weight,
+            segment_gap=segment_gap,
+            crossfade=crossfade,
+            segments=segments,
+            **kwargs,
+        )
+
+    def clone(
+        self,
+        engine: str,
+        text: str,
+        ref_audio: Path,
+        output_path: Path,
+        *,
+        ref_text: str | None = None,
+        language: str | None = None,
+        exaggeration: float | None = None,
+        cfg_weight: float | None = None,
+        segment_gap: int | None = None,
+        crossfade: int | None = None,
+        segments: list | None = None,
+        **kwargs,
+    ) -> Path | None:
+        """Clone voice via the daemon socket, fallback to local engine on miss."""
+        from voicecli.engine import QWEN_ENGINES, get_engine
+
+        # Try socket first for Qwen engines
+        if engine in QWEN_ENGINES and self._wait_for_socket():
+            result = self._try_socket(
+                {
+                    "action": "clone",
+                    "engine": engine,
+                    "text": text,
+                    "voice": None,
+                    "ref_audio": str(ref_audio.resolve()),
+                    "ref_text": ref_text,
+                    "output_path": str(output_path.resolve()),
+                    "language": language,
+                    "exaggeration": exaggeration,
+                    "cfg_weight": cfg_weight,
+                    "segment_gap": segment_gap,
+                    "crossfade": crossfade,
+                    "segments": segments or [],
+                }
+            )
+            if result is not None:
+                return result
+
+        # Fallback to local engine
+        eng = get_engine(engine)
+        if kwargs.get("fast") and engine in QWEN_ENGINES:
+            eng._small = True
+        return eng.clone(
+            text,
+            ref_audio,
+            output_path,
+            ref_text=ref_text,
+            language=language,
+            exaggeration=exaggeration,
+            cfg_weight=cfg_weight,
+            segment_gap=segment_gap,
+            crossfade=crossfade,
+            segments=segments,
+            **kwargs,
+        )
+
+
+class LocalSynthesisAdapter:
+    """SynthesisPort implementation that calls engines directly via ModelRegistry."""
+
+    def __init__(self, registry) -> None:
+        self._registry = registry
+
+    def is_available(self) -> bool:
+        """Always available — local engines need no external socket."""
+        return True
+
+    def generate(
+        self,
+        engine: str,
+        text: str,
+        voice: str | None,
+        output_path: Path,
+        *,
+        language: str | None = None,
+        instruct: str | None = None,
+        exaggeration: float | None = None,
+        cfg_weight: float | None = None,
+        segment_gap: int | None = None,
+        crossfade: int | None = None,
+        segments: list | None = None,
+        **kwargs,
+    ) -> Path | None:
+        """Generate speech using a registry-cached local engine."""
+        from voicecli.engine import QWEN_ENGINES
+
+        eng = self._registry.get(engine)
+        if kwargs.get("fast") and engine in QWEN_ENGINES:
+            eng._small = True
+        return eng.generate(
+            text,
+            voice,
+            output_path,
+            language=language,
+            instruct=instruct,
+            exaggeration=exaggeration,
+            cfg_weight=cfg_weight,
+            segment_gap=segment_gap,
+            crossfade=crossfade,
+            segments=segments,
+            **kwargs,
+        )
+
+    def clone(
+        self,
+        engine: str,
+        text: str,
+        ref_audio: Path,
+        output_path: Path,
+        *,
+        ref_text: str | None = None,
+        language: str | None = None,
+        exaggeration: float | None = None,
+        cfg_weight: float | None = None,
+        segment_gap: int | None = None,
+        crossfade: int | None = None,
+        segments: list | None = None,
+        **kwargs,
+    ) -> Path | None:
+        """Clone voice using a registry-cached local engine."""
+        from voicecli.engine import QWEN_ENGINES
+
+        eng = self._registry.get(engine)
+        if kwargs.get("fast") and engine in QWEN_ENGINES:
+            eng._small = True
+        return eng.clone(
+            text,
+            ref_audio,
+            output_path,
+            ref_text=ref_text,
+            language=language,
+            exaggeration=exaggeration,
+            cfg_weight=cfg_weight,
+            segment_gap=segment_gap,
+            crossfade=crossfade,
+            segments=segments,
+            **kwargs,
+        )

--- a/src/voicecli/api.py
+++ b/src/voicecli/api.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import asyncio
-import dataclasses
 import logging
 import math
-import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from voicecli.ports.synthesis import SynthesisPort
 
 from voicecli.utils import OUTPUT_DIR, STT_OUTPUT_DIR, _Unrestricted
 
@@ -383,84 +385,6 @@ def _resolve_ref(ref: Path | str | None) -> Path:
     return active
 
 
-# ── Daemon helpers ───────────────────────────────────────────────────────────
-# TODO: ADR-059 wire SynthesisPort — replace direct daemon.py / model_registry
-#       coupling below with a SynthesisPort implementation injected at call
-#       sites (generate, clone). See voicecli.ports.synthesis.SynthesisPort.
-
-_DAEMON_WAIT_SECS = 60.0
-_DAEMON_POLL_INTERVAL = 2.0
-
-
-def _wait_for_daemon_socket(timeout: float = _DAEMON_WAIT_SECS) -> bool:
-    """Block until the daemon socket appears (or timeout expires).
-
-    Prints a single warning on the first poll so the caller knows why it waits.
-    Returns True if the socket is available, False if the timeout elapsed.
-    """
-    from voicecli.daemon import SOCKET_PATH
-
-    if SOCKET_PATH.exists():
-        return True
-    print(
-        f"[voicecli] daemon socket not found — waiting up to {timeout:.0f}s...",
-        flush=True,
-    )
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        time.sleep(_DAEMON_POLL_INTERVAL)
-        if SOCKET_PATH.exists():
-            return True
-    return False
-
-
-def _try_daemon(request: dict) -> Path | None:
-    """Send request to daemon. Returns WAV path on success, None on failure."""
-    from voicecli.daemon import SOCKET_PATH, daemon_request
-
-    if not SOCKET_PATH.exists():
-        return None
-    try:
-        resp = daemon_request(request, timeout=300)
-        if resp.get("status") == "ok":
-            return Path(resp["path"])
-        log.error("daemon error: %s", resp.get("message", "unknown error"))
-    except Exception:
-        log.exception("daemon request failed")
-    return None
-
-
-def _make_chunk_daemon_fn(engine_name: str):
-    """Return a daemon_fn for chunked generation/cloning."""
-
-    def daemon_fn(method: str, text: str, voice, chunk_path: Path, **kwargs) -> bool:
-        req: dict = {
-            "action": method,
-            "engine": engine_name,
-            "text": text,
-            "voice": voice,
-            "output_path": str(chunk_path.resolve()),
-            "language": kwargs.get("language"),
-            "instruct": kwargs.get("instruct"),
-            "exaggeration": kwargs.get("exaggeration"),
-            "cfg_weight": kwargs.get("cfg_weight"),
-            "segment_gap": kwargs.get("segment_gap"),
-            "crossfade": kwargs.get("crossfade"),
-            "segments": [],
-        }
-        if method == "clone":
-            ref = kwargs.get("ref_audio")
-            req["ref_audio"] = str(ref.resolve()) if ref else None
-            req["ref_text"] = kwargs.get("ref_text")
-        if not _wait_for_daemon_socket():
-            return False
-        if _try_daemon(req) is None:
-            return False
-        return True
-
-    return daemon_fn
-
-
 # ── Chunked output helpers ──────────────────────────────────────────────────
 
 
@@ -471,7 +395,7 @@ def _emit_chunk(
     voice,
     out: Path,
     index: int,
-    total: int,
+    _total: int,
     *,
     mp3: bool = False,
     daemon_fn=None,
@@ -682,7 +606,7 @@ def generate(
     crossfade: int | None = None,
     plain: bool = False,
     allowed_base: Path | _Unrestricted = OUTPUT_DIR,
-    _skip_daemon: bool = False,
+    _synthesis: "SynthesisPort | None" = None,
     **kwargs,
 ) -> TTSResult:
     """Generate speech from text or a markdown file using a built-in voice.
@@ -704,6 +628,8 @@ def generate(
         allowed_base: Base directory ``output`` must stay within
             (default: ``OUTPUT_DIR``). Pass ``UNRESTRICTED`` when the caller
             has already vetted the path (CLI ``--output``, server scratch dir).
+        _synthesis: SynthesisPort implementation to use. If None, defaults to
+            DaemonSynthesisAdapter (daemon socket with local engine fallback).
         **kwargs: Additional engine-specific parameters.
 
     Returns:
@@ -726,8 +652,14 @@ def generate(
         extra_kwargs=kwargs,
     )
 
-    from voicecli.engine import QWEN_ENGINES, get_engine
+    from voicecli.engine import QWEN_ENGINES
     from voicecli.utils import build_output_prefix, default_output_path
+
+    if _synthesis is None:
+        from voicecli.adapters.synthesis import DaemonSynthesisAdapter  # type: ignore[import-not-found]
+
+        _synthesis = DaemonSynthesisAdapter()
+    assert _synthesis is not None
 
     config_path = Path(config) if config is not None else None
 
@@ -770,22 +702,17 @@ def generate(
         # default_output_path writes inside OUTPUT_DIR by construction
         out = default_output_path(prefix)
 
-    # Use model_registry for NATS satellite mode (_skip_daemon), else get_engine
-    if _skip_daemon:
-        from voicecli.model_registry import model_registry
-
-        eng = model_registry.get(r_engine)
-    else:
-        eng = get_engine(r_engine)
-    if r_fast and r_engine in QWEN_ENGINES:
-        eng._small = True
-
     if r_chunked:
+        chunk_fn = getattr(_synthesis, "_chunk_fn", None)
         daemon_fn = (
-            _make_chunk_daemon_fn(r_engine)
-            if r_engine in QWEN_ENGINES and not _skip_daemon
-            else None
+            chunk_fn(r_engine) if r_engine in QWEN_ENGINES and chunk_fn is not None else None
         )
+        # _emit_chunk needs a local engine fallback; provide a thin shim via the adapter
+        from voicecli.engine import get_engine
+
+        eng = get_engine(r_engine)
+        if r_fast and r_engine in QWEN_ENGINES:
+            eng._small = True
         chunk_paths = _generate_chunked(
             eng,
             r_text,
@@ -800,41 +727,27 @@ def generate(
         )
         return TTSResult(wav_path=out.with_suffix(".done"), chunk_paths=chunk_paths)
 
-    if r_engine in QWEN_ENGINES and not _skip_daemon and _wait_for_daemon_socket():
-        daemon_result = _try_daemon(
-            {
-                "action": "generate",
-                "engine": r_engine,
-                "text": r_text,
-                "voice": r_voice,
-                "output_path": str(out.resolve()),
-                "language": r_language,
-                "instruct": extra.get("instruct"),
-                "exaggeration": extra.get("exaggeration"),
-                "cfg_weight": extra.get("cfg_weight"),
-                "segment_gap": extra.get("segment_gap"),
-                "crossfade": extra.get("crossfade"),
-                "segments": [dataclasses.asdict(s) for s in (extra.get("segments") or [])],
-            }
-        )
-        if daemon_result:
-            out = daemon_result
-            mp3_path = None
-            if r_mp3:
-                from voicecli.utils import wav_to_mp3
+    result = _synthesis.generate(
+        r_engine,
+        r_text,
+        r_voice,
+        out,
+        language=r_language,
+        fast=r_fast,
+        **extra,
+    )
+    if result is not None:
+        out = result
+        mp3_path = None
+        if r_mp3:
+            from voicecli.utils import wav_to_mp3
 
-                mp3_path = wav_to_mp3(out)
-            return TTSResult(wav_path=out, mp3_path=mp3_path)
+            mp3_path = wav_to_mp3(out)
+        return TTSResult(wav_path=out, mp3_path=mp3_path)
 
-    out = eng.generate(r_text, r_voice, out, language=r_language, **extra)
-
-    mp3_path = None
-    if r_mp3:
-        from voicecli.utils import wav_to_mp3
-
-        mp3_path = wav_to_mp3(out)
-
-    return TTSResult(wav_path=out, mp3_path=mp3_path)
+    # Adapter returned None — should not happen (adapter handles its own fallback),
+    # but guard defensively.
+    raise RuntimeError(f"Synthesis failed for engine '{r_engine}': adapter returned None")
 
 
 def clone(
@@ -854,7 +767,7 @@ def clone(
     crossfade: int | None = None,
     plain: bool = False,
     allowed_base: Path | _Unrestricted = OUTPUT_DIR,
-    _skip_daemon: bool = False,
+    _synthesis: "SynthesisPort | None" = None,
     **kwargs,
 ) -> TTSResult:
     """Clone a voice from reference audio and synthesize text.
@@ -877,6 +790,8 @@ def clone(
         allowed_base: Base directory ``output`` must stay within
             (default: ``OUTPUT_DIR``). Pass ``UNRESTRICTED`` when the caller
             has already vetted the path.
+        _synthesis: SynthesisPort implementation to use. If None, defaults to
+            DaemonSynthesisAdapter (daemon socket with local engine fallback).
         **kwargs: Additional engine-specific parameters.
 
     Returns:
@@ -900,8 +815,14 @@ def clone(
     )
     _check_str("ref_text", ref_text)
 
-    from voicecli.engine import QWEN_ENGINES, get_engine
+    from voicecli.engine import QWEN_ENGINES
     from voicecli.utils import build_output_prefix, default_output_path
+
+    if _synthesis is None:
+        from voicecli.adapters.synthesis import DaemonSynthesisAdapter  # type: ignore[import-not-found]
+
+        _synthesis = DaemonSynthesisAdapter()
+    assert _synthesis is not None
 
     ref_path = _resolve_ref(ref)
     config_path = Path(config) if config is not None else None
@@ -943,22 +864,17 @@ def clone(
         # default_output_path writes inside OUTPUT_DIR by construction
         out = default_output_path(prefix)
 
-    # Use model_registry for NATS satellite mode (_skip_daemon), else get_engine
-    if _skip_daemon:
-        from voicecli.model_registry import model_registry
-
-        eng = model_registry.get(r_engine)
-    else:
-        eng = get_engine(r_engine)
-    if r_fast and r_engine in QWEN_ENGINES:
-        eng._small = True
-
     if r_chunked:
+        chunk_fn = getattr(_synthesis, "_chunk_fn", None)
         daemon_fn = (
-            _make_chunk_daemon_fn(r_engine)
-            if r_engine in QWEN_ENGINES and not _skip_daemon
-            else None
+            chunk_fn(r_engine) if r_engine in QWEN_ENGINES and chunk_fn is not None else None
         )
+        # _emit_chunk needs a local engine fallback; provide a thin shim via the adapter
+        from voicecli.engine import get_engine
+
+        eng = get_engine(r_engine)
+        if r_fast and r_engine in QWEN_ENGINES:
+            eng._small = True
         chunk_paths = _clone_chunked(
             eng,
             r_text,
@@ -974,43 +890,28 @@ def clone(
         )
         return TTSResult(wav_path=out.with_suffix(".done"), chunk_paths=chunk_paths)
 
-    if r_engine in QWEN_ENGINES and not _skip_daemon and _wait_for_daemon_socket():
-        daemon_result = _try_daemon(
-            {
-                "action": "clone",
-                "engine": r_engine,
-                "text": r_text,
-                "voice": None,
-                "ref_audio": str(ref_path.resolve()),
-                "ref_text": ref_text,
-                "output_path": str(out.resolve()),
-                "language": r_language,
-                "instruct": extra.get("instruct"),
-                "exaggeration": extra.get("exaggeration"),
-                "cfg_weight": extra.get("cfg_weight"),
-                "segment_gap": extra.get("segment_gap"),
-                "crossfade": extra.get("crossfade"),
-                "segments": [dataclasses.asdict(s) for s in (extra.get("segments") or [])],
-            }
-        )
-        if daemon_result:
-            out = daemon_result
-            mp3_path = None
-            if r_mp3:
-                from voicecli.utils import wav_to_mp3
+    result = _synthesis.clone(
+        r_engine,
+        r_text,
+        ref_path,
+        out,
+        ref_text=ref_text,
+        language=r_language,
+        fast=r_fast,
+        **extra,
+    )
+    if result is not None:
+        out = result
+        mp3_path = None
+        if r_mp3:
+            from voicecli.utils import wav_to_mp3
 
-                mp3_path = wav_to_mp3(out)
-            return TTSResult(wav_path=out, mp3_path=mp3_path)
+            mp3_path = wav_to_mp3(out)
+        return TTSResult(wav_path=out, mp3_path=mp3_path)
 
-    out = eng.clone(r_text, ref_path, out, ref_text=ref_text, language=r_language, **extra)
-
-    mp3_path = None
-    if r_mp3:
-        from voicecli.utils import wav_to_mp3
-
-        mp3_path = wav_to_mp3(out)
-
-    return TTSResult(wav_path=out, mp3_path=mp3_path)
+    # Adapter returned None — should not happen (adapter handles its own fallback),
+    # but guard defensively.
+    raise RuntimeError(f"Clone failed for engine '{r_engine}': adapter returned None")
 
 
 def transcribe(

--- a/src/voicecli/nats/tts_adapter.py
+++ b/src/voicecli/nats/tts_adapter.py
@@ -210,6 +210,8 @@ class TtsNatsAdapter(NatsAdapterBase):
             loop = asyncio.get_running_loop()
 
             def _synthesize(language: str | None) -> None:
+                from voicecli.adapters.synthesis import LocalSynthesisAdapter
+                from voicecli.model_registry import model_registry
                 from voicecli.utils import UNRESTRICTED
 
                 kw = dict(optional_kwargs)
@@ -220,7 +222,7 @@ class TtsNatsAdapter(NatsAdapterBase):
                     engine=engine,
                     output=out_path,
                     allowed_base=UNRESTRICTED,
-                    _skip_daemon=True,
+                    _synthesis=LocalSynthesisAdapter(model_registry),
                     **kw,
                     **named_kwargs,
                 )

--- a/tests/test_local_synthesis_adapter.py
+++ b/tests/test_local_synthesis_adapter.py
@@ -1,0 +1,120 @@
+"""Unit tests for LocalSynthesisAdapter."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_registry():
+    registry = MagicMock()
+    engine = MagicMock()
+    engine.generate.return_value = Path("/tmp/out.wav")
+    engine.clone.return_value = Path("/tmp/out.wav")
+    registry.get.return_value = engine
+    return registry, engine
+
+
+class TestLocalSynthesisAdapterIsAvailable:
+    def test_always_true(self):
+        from voicecli.adapters.synthesis import LocalSynthesisAdapter
+
+        registry = MagicMock()
+        adapter = LocalSynthesisAdapter(registry)
+        assert adapter.is_available() is True
+
+
+class TestLocalSynthesisAdapterGenerate:
+    def test_delegates_to_registry_engine(self, mock_registry):
+        from voicecli.adapters.synthesis import LocalSynthesisAdapter
+
+        registry, engine = mock_registry
+        adapter = LocalSynthesisAdapter(registry)
+        out = Path("/tmp/out.wav")
+
+        result = adapter.generate("chatterbox", "hello", "Ryan", out)
+
+        registry.get.assert_called_once_with("chatterbox")
+        engine.generate.assert_called_once()
+        assert result == out
+
+    def test_fast_sets_small_for_qwen(self, mock_registry):
+        from voicecli.adapters.synthesis import LocalSynthesisAdapter
+
+        registry, engine = mock_registry
+        adapter = LocalSynthesisAdapter(registry)
+        out = Path("/tmp/out.wav")
+
+        with patch("voicecli.engine.QWEN_ENGINES", {"qwen"}):
+            adapter.generate("qwen", "hello", None, out, fast=True)
+
+        assert engine._small is True
+
+    def test_fast_not_forwarded_to_engine(self, mock_registry):
+        from voicecli.adapters.synthesis import LocalSynthesisAdapter
+
+        registry, engine = mock_registry
+        adapter = LocalSynthesisAdapter(registry)
+        out = Path("/tmp/out.wav")
+
+        with patch("voicecli.engine.QWEN_ENGINES", {"qwen"}):
+            adapter.generate("qwen", "hello", None, out, fast=True)
+
+        call_kwargs = engine.generate.call_args[1]
+        assert "fast" not in call_kwargs
+
+    def test_fast_ignored_for_non_qwen(self, mock_registry):
+        from voicecli.adapters.synthesis import LocalSynthesisAdapter
+
+        registry, engine = mock_registry
+        adapter = LocalSynthesisAdapter(registry)
+        out = Path("/tmp/out.wav")
+
+        with patch("voicecli.engine.QWEN_ENGINES", {"qwen"}):
+            adapter.generate("chatterbox", "hello", None, out, fast=True)
+
+        assert not hasattr(engine, "_small") or engine._small is not True
+
+
+class TestLocalSynthesisAdapterClone:
+    def test_delegates_to_registry_engine(self, mock_registry):
+        from voicecli.adapters.synthesis import LocalSynthesisAdapter
+
+        registry, engine = mock_registry
+        adapter = LocalSynthesisAdapter(registry)
+        ref = Path("/tmp/ref.wav")
+        out = Path("/tmp/out.wav")
+
+        result = adapter.clone("chatterbox", "hello", ref, out)
+
+        registry.get.assert_called_once_with("chatterbox")
+        engine.clone.assert_called_once()
+        assert result == out
+
+    def test_fast_sets_small_for_qwen(self, mock_registry):
+        from voicecli.adapters.synthesis import LocalSynthesisAdapter
+
+        registry, engine = mock_registry
+        adapter = LocalSynthesisAdapter(registry)
+        ref = Path("/tmp/ref.wav")
+        out = Path("/tmp/out.wav")
+
+        with patch("voicecli.engine.QWEN_ENGINES", {"qwen"}):
+            adapter.clone("qwen", "hello", ref, out, fast=True)
+
+        assert engine._small is True
+
+    def test_fast_not_forwarded_to_engine(self, mock_registry):
+        from voicecli.adapters.synthesis import LocalSynthesisAdapter
+
+        registry, engine = mock_registry
+        adapter = LocalSynthesisAdapter(registry)
+        ref = Path("/tmp/ref.wav")
+        out = Path("/tmp/out.wav")
+
+        with patch("voicecli.engine.QWEN_ENGINES", {"qwen"}):
+            adapter.clone("qwen", "hello", ref, out, fast=True)
+
+        call_kwargs = engine.clone.call_args[1]
+        assert "fast" not in call_kwargs

--- a/tests/test_voice_priority.py
+++ b/tests/test_voice_priority.py
@@ -41,24 +41,30 @@ def md_without_voice(tmp_path):
 
 @pytest.fixture
 def _mock_daemon():
-    """Mock daemon and engine so Qwen generate goes through the daemon path.
+    """Mock DaemonSynthesisAdapter so Qwen generate goes through the socket path.
 
-    Returns a mock for _try_daemon whose call args contain the voice field.
+    Returns a mock for _try_socket whose call args contain the voice field.
     """
     engine = MagicMock()
     engine.generate.return_value = Path("/tmp/fake.wav")
     mock_try = MagicMock(return_value=Path("/tmp/fake.wav"))
     with (
         patch("voicecli.engine.get_engine", return_value=engine),
-        patch("voicecli.api._wait_for_daemon_socket", return_value=True),
-        patch("voicecli.api._try_daemon", mock_try),
+        patch(
+            "voicecli.adapters.synthesis.DaemonSynthesisAdapter._wait_for_socket",
+            return_value=True,
+        ),
+        patch(
+            "voicecli.adapters.synthesis.DaemonSynthesisAdapter._try_socket",
+            mock_try,
+        ),
     ):
         yield mock_try
 
 
-def _called_voice(mock_try_daemon):
-    """Extract voice from the daemon request dict passed to _try_daemon."""
-    return mock_try_daemon.call_args[0][0]["voice"]
+def _called_voice(mock_try_socket):
+    """Extract voice from the daemon request dict passed to _try_socket."""
+    return mock_try_socket.call_args[0][0]["voice"]
 
 
 class TestVoicePriority:


### PR DESCRIPTION
## Summary

- Extract `_wait_for_daemon_socket`, `_try_daemon`, `_make_chunk_daemon_fn` from `api.py` into `DaemonSynthesisAdapter` (new `voicecli.adapters.synthesis` module)
- Replace `_skip_daemon: bool = False` with `_synthesis: SynthesisPort | None = None` in `generate()` and `clone()` — lazy-constructs `DaemonSynthesisAdapter()` when `None`
- Add `LocalSynthesisAdapter` for NATS satellite mode; update `nats/tts_adapter.py` to inject it instead of `_skip_daemon=True`
- Add forbidden importlinter contract: `voicecli.api` ¬→ `voicecli.daemon` / `voicecli.model_registry`

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #128: refactor(api): wire SynthesisPort in api.py — replace daemon direct coupling (ADR-059 V3/MP3) | Open |
| Analysis | — | Absent (F-lite, frame sufficient) |
| Spec | [128-wire-synthesis-port-api-spec.mdx](artifacts/specs/128-wire-synthesis-port-api-spec.mdx) | Present |
| Implementation | 3 commits on `feat/128-wire-synthesis-port-api` | Complete |
| Verification | Lint ✅ Typecheck ⚠️ (pre-existing torch/roxabi stubs missing in dev env) Tests ✅ (0 new — tests deferred per spec) | Passed |

## Test Plan

- [ ] `voicecli generate "hello"` with daemon running → routes via socket (check daemon log)
- [ ] `voicecli generate "hello"` with daemon stopped → falls back to `get_engine()` directly
- [ ] `voicecli clone "hello"` both paths above
- [ ] `uv run lint-imports` → both contracts pass
- [ ] `isinstance(DaemonSynthesisAdapter(), SynthesisPort)` → `True`
- [ ] `isinstance(LocalSynthesisAdapter(model_registry), SynthesisPort)` → `True`

Closes #128

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`