### PR TITLE
fix(api): use registry-cached engine in chunked synthesis path

### DIFF
--- a/src/voicecli/api.py
+++ b/src/voicecli/api.py
@@ -707,10 +707,13 @@ def generate(
         daemon_fn = (
             chunk_fn(r_engine) if r_engine in QWEN_ENGINES and chunk_fn is not None else None
         )
-        # _emit_chunk needs a local engine fallback; provide a thin shim via the adapter
-        from voicecli.engine import get_engine
+        registry = getattr(_synthesis, "_registry", None)
+        if registry is not None:
+            eng = registry.get(r_engine)
+        else:
+            from voicecli.engine import get_engine
 
-        eng = get_engine(r_engine)
+            eng = get_engine(r_engine)
         if r_fast and r_engine in QWEN_ENGINES:
             eng._small = True
         chunk_paths = _generate_chunked(
@@ -869,10 +872,13 @@ def clone(
         daemon_fn = (
             chunk_fn(r_engine) if r_engine in QWEN_ENGINES and chunk_fn is not None else None
         )
-        # _emit_chunk needs a local engine fallback; provide a thin shim via the adapter
-        from voicecli.engine import get_engine
+        registry = getattr(_synthesis, "_registry", None)
+        if registry is not None:
+            eng = registry.get(r_engine)
+        else:
+            from voicecli.engine import get_engine
 
-        eng = get_engine(r_engine)
+            eng = get_engine(r_engine)
         if r_fast and r_engine in QWEN_ENGINES:
             eng._small = True
         chunk_paths = _clone_chunked(


### PR DESCRIPTION
## Summary

- In `generate()` and `clone()`, the chunked path was calling `get_engine(r_engine)` which creates a **fresh engine instance** on every synthesis request
- On the 1st call: model loads into VRAM (~5 GB), engine object falls out of scope at end of synthesis
- On the 2nd call: new engine instance, `_model=None`, VRAM check sees ~2.5 GB free (old tensors still resident), needs 5 GB → fails with `RuntimeError: CUDA error in qwen-fast: not enough VRAM`
- Fix: when `_synthesis` provides a `_registry` (`LocalSynthesisAdapter` does), use `registry.get(r_engine)` which returns the cached, already-loaded engine instance

## Test plan

- [ ] Send 2+ TTS requests back-to-back in prod; both should succeed
- [ ] 1st request: model loads (cold), ~6s; 2nd request: model already warm, faster
- [ ] `model_registry.loaded_engines()` shows `["qwen-fast"]` after 1st request

🤖 Generated with [Claude Code](https://claude.com/claude-code)