### PR TITLE
fix(nats): validate NATS_URL scheme before connecting

### DIFF
--- a/docs/NATS-SERVE.md
+++ b/docs/NATS-SERVE.md
@@ -43,7 +43,7 @@ export them in the shell environment before running `voicecli nats-serve`.
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `NATS_URL` | — (required) | NATS server URL, e.g. `nats://127.0.0.1:4222` |
+| `NATS_URL` | — (required) | NATS server URL, e.g. `nats://127.0.0.1:4222`. Accepted schemes: `nats://` (unencrypted, dev only — logs a warning) and `tls://`. WebSocket schemes (`ws://`, `wss://`) are intentionally rejected; use a NATS server with a TCP listener instead. |
 | `NATS_NKEY_SEED_PATH` | — (required for nkey auth) | Path to the NKey seed file. **File permissions must be `0600`** — the satellite refuses to start if the file is world- or group-readable. |
 | `NATS_CA_CERT` | — (optional) | Path to a PEM CA certificate for TLS verification |
 | `VOICECLI_ENGINE` | from `voicecli.toml` | TTS engine override (`qwen`, `qwen-fast`, `chatterbox`, etc.) |

--- a/src/voicecli/cli_nats.py
+++ b/src/voicecli/cli_nats.py
@@ -1,11 +1,27 @@
 """NATS serve sub-app — TTS and STT satellite CLI commands."""
 
+import re
 from pathlib import Path
 from typing import Annotated, Optional
 
 import typer
 
 nats_app = typer.Typer(help="NATS subscriber satellites for hub-driven voice.")
+
+_VALID_NATS_SCHEME = re.compile(r"^(nats|tls)://")
+
+
+def _check_nats_url(nats_url: str, log: object) -> None:
+    """Validate NATS_URL scheme; exit 2 on invalid, warn on non-TLS."""
+    if not _VALID_NATS_SCHEME.match(nats_url):
+        log.error(  # type: ignore[attr-defined]
+            "NATS_URL scheme invalid: got %r — must start with nats:// or tls://", nats_url
+        )
+        raise typer.Exit(2)
+    if not nats_url.startswith("tls://"):
+        log.warning(  # type: ignore[attr-defined]
+            "NATS_URL uses non-TLS scheme %r — traffic is unencrypted", nats_url
+        )
 
 
 @nats_app.command("tts")
@@ -64,6 +80,7 @@ def nats_serve_tts(
     if not nats_url:
         log.error("NATS_URL env var is required")
         raise typer.Exit(2)
+    _check_nats_url(nats_url, log)
 
     adapter = TtsNatsAdapter(
         default_engine=resolved_engine,
@@ -126,6 +143,7 @@ def nats_serve_stt(
     if not nats_url:
         log.error("NATS_URL env var is required")
         raise typer.Exit(2)
+    _check_nats_url(nats_url, log)
 
     adapter = SttNatsAdapter(
         default_model=resolved_model,

--- a/src/voicecli/cli_nats.py
+++ b/src/voicecli/cli_nats.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 from pathlib import Path
+from urllib.parse import urlparse
 from typing import Annotated, Optional
 
 import typer
@@ -18,6 +19,9 @@ def _check_nats_url(nats_url: str, log: logging.Logger) -> None:
     m = _VALID_NATS_SCHEME.match(nats_url)
     if not m:
         log.error("NATS_URL scheme invalid: got %r — must start with nats:// or tls://", nats_url)
+        raise typer.Exit(2)
+    if not urlparse(nats_url).hostname:
+        log.error("NATS_URL has no host: got %r", nats_url)
         raise typer.Exit(2)
     if m.group(1) != "tls":
         log.warning("NATS_URL uses non-TLS scheme %r — traffic is unencrypted", nats_url)

--- a/src/voicecli/cli_nats.py
+++ b/src/voicecli/cli_nats.py
@@ -1,6 +1,7 @@
 """NATS serve sub-app — TTS and STT satellite CLI commands."""
 
 import logging
+import os
 import re
 from pathlib import Path
 from typing import Annotated, Optional
@@ -9,7 +10,7 @@ import typer
 
 nats_app = typer.Typer(help="NATS subscriber satellites for hub-driven voice.")
 
-_VALID_NATS_SCHEME = re.compile(r"^(nats|tls)://")
+_VALID_NATS_SCHEME = re.compile(r"(nats|tls)://")
 
 
 def _check_nats_url(nats_url: str, log: logging.Logger) -> None:
@@ -43,8 +44,6 @@ def nats_serve_tts(
 ) -> None:
     """Subscribe to lyra.voice.tts.request and reply with synthesized audio."""
     import asyncio
-    import logging
-    import os
 
     from voicecli.config import load_nats_config
     from voicecli.model_registry import model_registry
@@ -112,8 +111,6 @@ def nats_serve_stt(
 ) -> None:
     """Subscribe to lyra.voice.stt.request and reply with transcription."""
     import asyncio
-    import logging
-    import os
 
     from voicecli.nats.config import _probe_socket_daemon, _resolve_model
     from voicecli.nats.stt_adapter import SttNatsAdapter

--- a/src/voicecli/cli_nats.py
+++ b/src/voicecli/cli_nats.py
@@ -1,5 +1,6 @@
 """NATS serve sub-app — TTS and STT satellite CLI commands."""
 
+import logging
 import re
 from pathlib import Path
 from typing import Annotated, Optional
@@ -11,17 +12,14 @@ nats_app = typer.Typer(help="NATS subscriber satellites for hub-driven voice.")
 _VALID_NATS_SCHEME = re.compile(r"^(nats|tls)://")
 
 
-def _check_nats_url(nats_url: str, log: object) -> None:
+def _check_nats_url(nats_url: str, log: logging.Logger) -> None:
     """Validate NATS_URL scheme; exit 2 on invalid, warn on non-TLS."""
-    if not _VALID_NATS_SCHEME.match(nats_url):
-        log.error(  # type: ignore[attr-defined]
-            "NATS_URL scheme invalid: got %r — must start with nats:// or tls://", nats_url
-        )
+    m = _VALID_NATS_SCHEME.match(nats_url)
+    if not m:
+        log.error("NATS_URL scheme invalid: got %r — must start with nats:// or tls://", nats_url)
         raise typer.Exit(2)
-    if not nats_url.startswith("tls://"):
-        log.warning(  # type: ignore[attr-defined]
-            "NATS_URL uses non-TLS scheme %r — traffic is unencrypted", nats_url
-        )
+    if m.group(1) != "tls":
+        log.warning("NATS_URL uses non-TLS scheme %r — traffic is unencrypted", nats_url)
 
 
 @nats_app.command("tts")

--- a/tests/nats/test_connect.py
+++ b/tests/nats/test_connect.py
@@ -221,11 +221,14 @@ class TestNatsUrlSchemeValidation:
 
         from voicecli.cli import app
 
+        # Arrange
         monkeypatch.setenv("NATS_URL", "ws://attacker.host:4222")
 
+        # Act
         with patch("voicecli.nats.config._probe_socket_daemon", return_value="absent"):
             result = CliRunner().invoke(app, ["nats-serve", "tts"])
 
+        # Assert
         assert result.exit_code == 2, result.output
 
     def test_stt_exits_2_on_invalid_scheme(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -236,11 +239,14 @@ class TestNatsUrlSchemeValidation:
 
         from voicecli.cli import app
 
+        # Arrange
         monkeypatch.setenv("NATS_URL", "ws://attacker.host:4222")
 
+        # Act
         with patch("voicecli.nats.config._probe_socket_daemon", return_value="absent"):
             result = CliRunner().invoke(app, ["nats-serve", "stt"])
 
+        # Assert
         assert result.exit_code == 2, result.output
 
     def test_tts_exits_2_on_http_scheme(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -251,11 +257,14 @@ class TestNatsUrlSchemeValidation:
 
         from voicecli.cli import app
 
+        # Arrange
         monkeypatch.setenv("NATS_URL", "http://localhost:4222")
 
+        # Act
         with patch("voicecli.nats.config._probe_socket_daemon", return_value="absent"):
             result = CliRunner().invoke(app, ["nats-serve", "tts"])
 
+        # Assert
         assert result.exit_code == 2, result.output
 
     def test_tts_warns_on_nats_scheme(
@@ -269,10 +278,12 @@ class TestNatsUrlSchemeValidation:
 
         from voicecli.cli import app
 
+        # Arrange
         monkeypatch.setenv("NATS_URL", "nats://localhost:4222")
 
+        # Act
         with (
-            caplog.at_level(logging.WARNING),
+            caplog.at_level(logging.WARNING, logger="voicecli.nats-serve.tts"),
             patch("voicecli.nats.config._probe_socket_daemon", return_value="absent"),
             patch(
                 "voicecli.nats.tts_adapter.TtsNatsAdapter.run",
@@ -281,6 +292,7 @@ class TestNatsUrlSchemeValidation:
         ):
             result = CliRunner().invoke(app, ["nats-serve", "tts"])
 
+        # Assert
         assert result.exit_code == 0, result.output
         assert mock_run.call_count == 1
         assert any("unencrypted" in r.message for r in caplog.records)
@@ -296,10 +308,12 @@ class TestNatsUrlSchemeValidation:
 
         from voicecli.cli import app
 
+        # Arrange
         monkeypatch.setenv("NATS_URL", "tls://localhost:4222")
 
+        # Act
         with (
-            caplog.at_level(logging.WARNING),
+            caplog.at_level(logging.WARNING, logger="voicecli.nats-serve.tts"),
             patch("voicecli.nats.config._probe_socket_daemon", return_value="absent"),
             patch(
                 "voicecli.nats.tts_adapter.TtsNatsAdapter.run",
@@ -308,6 +322,7 @@ class TestNatsUrlSchemeValidation:
         ):
             result = CliRunner().invoke(app, ["nats-serve", "tts"])
 
+        # Assert
         assert result.exit_code == 0, result.output
         assert mock_run.call_count == 1
         assert not any("unencrypted" in r.message for r in caplog.records)
@@ -323,10 +338,12 @@ class TestNatsUrlSchemeValidation:
 
         from voicecli.cli import app
 
+        # Arrange
         monkeypatch.setenv("NATS_URL", "nats://localhost:4222")
 
+        # Act
         with (
-            caplog.at_level(logging.WARNING),
+            caplog.at_level(logging.WARNING, logger="voicecli.nats-serve.stt"),
             patch("voicecli.nats.config._probe_socket_daemon", return_value="absent"),
             patch(
                 "voicecli.nats.stt_adapter.SttNatsAdapter.run",
@@ -335,6 +352,43 @@ class TestNatsUrlSchemeValidation:
         ):
             result = CliRunner().invoke(app, ["nats-serve", "stt"])
 
+        # Assert
         assert result.exit_code == 0, result.output
         assert mock_run.call_count == 1
         assert any("unencrypted" in r.message for r in caplog.records)
+
+    def test_tts_vram_guard_precedes_scheme_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """VRAM guard (exit 78) fires before scheme validation — invalid URL + live socket exits 78."""
+        from unittest.mock import patch
+
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        # Arrange
+        monkeypatch.setenv("NATS_URL", "ws://attacker.host:4222")
+
+        # Act
+        with patch("voicecli.nats.config._probe_socket_daemon", return_value="live"):
+            result = CliRunner().invoke(app, ["nats-serve", "tts"])
+
+        # Assert — VRAM guard wins; scheme check is never reached
+        assert result.exit_code == 78, result.output
+
+    def test_stt_vram_guard_precedes_scheme_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """VRAM guard (exit 78) fires before scheme validation on STT path."""
+        from unittest.mock import patch
+
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        # Arrange
+        monkeypatch.setenv("NATS_URL", "ws://attacker.host:4222")
+
+        # Act
+        with patch("voicecli.nats.config._probe_socket_daemon", return_value="live"):
+            result = CliRunner().invoke(app, ["nats-serve", "stt"])
+
+        # Assert — VRAM guard wins; scheme check is never reached
+        assert result.exit_code == 78, result.output

--- a/tests/nats/test_connect.py
+++ b/tests/nats/test_connect.py
@@ -392,3 +392,51 @@ class TestNatsUrlSchemeValidation:
 
         # Assert — VRAM guard wins; scheme check is never reached
         assert result.exit_code == 78, result.output
+
+    def test_stt_exits_2_on_http_scheme(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """nats-serve stt exits 2 for http:// scheme."""
+        from unittest.mock import patch
+
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        # Arrange
+        monkeypatch.setenv("NATS_URL", "http://localhost:4222")
+
+        # Act
+        with patch("voicecli.nats.config._probe_socket_daemon", return_value="absent"):
+            result = CliRunner().invoke(app, ["nats-serve", "stt"])
+
+        # Assert
+        assert result.exit_code == 2, result.output
+
+    def test_stt_no_warning_on_tls_scheme(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """nats-serve stt does not warn for tls:// scheme."""
+        import logging
+        from unittest.mock import AsyncMock, patch
+
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        # Arrange
+        monkeypatch.setenv("NATS_URL", "tls://localhost:4222")
+
+        # Act
+        with (
+            caplog.at_level(logging.WARNING, logger="voicecli.nats-serve.stt"),
+            patch("voicecli.nats.config._probe_socket_daemon", return_value="absent"),
+            patch(
+                "voicecli.nats.stt_adapter.SttNatsAdapter.run",
+                new_callable=AsyncMock,
+            ) as mock_run,
+        ):
+            result = CliRunner().invoke(app, ["nats-serve", "stt"])
+
+        # Assert
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_count == 1
+        assert not any("unencrypted" in r.message for r in caplog.records)

--- a/tests/nats/test_connect.py
+++ b/tests/nats/test_connect.py
@@ -208,3 +208,133 @@ class TestMissingNatsUrl:
             result = CliRunner().invoke(app, ["nats-serve", "stt"])
 
         assert result.exit_code == 2, result.output
+
+
+class TestNatsUrlSchemeValidation:
+    """Verify NATS_URL scheme guard: exit 2 on invalid scheme, warn on non-TLS."""
+
+    def test_tts_exits_2_on_invalid_scheme(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """nats-serve tts exits 2 when NATS_URL has an invalid scheme."""
+        from unittest.mock import patch
+
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        monkeypatch.setenv("NATS_URL", "ws://attacker.host:4222")
+
+        with patch("voicecli.nats.config._probe_socket_daemon", return_value="absent"):
+            result = CliRunner().invoke(app, ["nats-serve", "tts"])
+
+        assert result.exit_code == 2, result.output
+
+    def test_stt_exits_2_on_invalid_scheme(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """nats-serve stt exits 2 when NATS_URL has an invalid scheme."""
+        from unittest.mock import patch
+
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        monkeypatch.setenv("NATS_URL", "ws://attacker.host:4222")
+
+        with patch("voicecli.nats.config._probe_socket_daemon", return_value="absent"):
+            result = CliRunner().invoke(app, ["nats-serve", "stt"])
+
+        assert result.exit_code == 2, result.output
+
+    def test_tts_exits_2_on_http_scheme(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """nats-serve tts exits 2 for http:// scheme."""
+        from unittest.mock import patch
+
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        monkeypatch.setenv("NATS_URL", "http://localhost:4222")
+
+        with patch("voicecli.nats.config._probe_socket_daemon", return_value="absent"):
+            result = CliRunner().invoke(app, ["nats-serve", "tts"])
+
+        assert result.exit_code == 2, result.output
+
+    def test_tts_warns_on_nats_scheme(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """nats-serve tts emits unencrypted warning for nats:// and proceeds."""
+        import logging
+        from unittest.mock import AsyncMock, patch
+
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        monkeypatch.setenv("NATS_URL", "nats://localhost:4222")
+
+        with (
+            caplog.at_level(logging.WARNING),
+            patch("voicecli.nats.config._probe_socket_daemon", return_value="absent"),
+            patch(
+                "voicecli.nats.tts_adapter.TtsNatsAdapter.run",
+                new_callable=AsyncMock,
+            ) as mock_run,
+        ):
+            result = CliRunner().invoke(app, ["nats-serve", "tts"])
+
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_count == 1
+        assert any("unencrypted" in r.message for r in caplog.records)
+
+    def test_tts_no_warning_on_tls_scheme(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """nats-serve tts does not warn for tls:// scheme."""
+        import logging
+        from unittest.mock import AsyncMock, patch
+
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        monkeypatch.setenv("NATS_URL", "tls://localhost:4222")
+
+        with (
+            caplog.at_level(logging.WARNING),
+            patch("voicecli.nats.config._probe_socket_daemon", return_value="absent"),
+            patch(
+                "voicecli.nats.tts_adapter.TtsNatsAdapter.run",
+                new_callable=AsyncMock,
+            ) as mock_run,
+        ):
+            result = CliRunner().invoke(app, ["nats-serve", "tts"])
+
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_count == 1
+        assert not any("unencrypted" in r.message for r in caplog.records)
+
+    def test_stt_warns_on_nats_scheme(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """nats-serve stt emits unencrypted warning for nats:// and proceeds."""
+        import logging
+        from unittest.mock import AsyncMock, patch
+
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        monkeypatch.setenv("NATS_URL", "nats://localhost:4222")
+
+        with (
+            caplog.at_level(logging.WARNING),
+            patch("voicecli.nats.config._probe_socket_daemon", return_value="absent"),
+            patch(
+                "voicecli.nats.stt_adapter.SttNatsAdapter.run",
+                new_callable=AsyncMock,
+            ) as mock_run,
+        ):
+            result = CliRunner().invoke(app, ["nats-serve", "stt"])
+
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_count == 1
+        assert any("unencrypted" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- Reject invalid NATS_URL schemes (`ws://`, `http://`, etc.) at startup with exit 2 to prevent traffic redirection to attacker-controlled hosts
- Emit a `WARNING` when `nats://` (unencrypted) is used instead of `tls://`

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #135: fix(nats): validate NATS_URL scheme before connecting | Open |
| Implementation | 1 commit on `feat/135-fix-nats-validate-nats-url-scheme-before-connecting` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (7 new) | Passed |

## Test Plan
- [ ] `NATS_URL=ws://attacker.host voicecli nats-serve tts` → exits 2 with scheme error
- [ ] `NATS_URL=http://localhost voicecli nats-serve stt` → exits 2 with scheme error
- [ ] `NATS_URL=nats://localhost:4222 voicecli nats-serve tts` → starts, logs `unencrypted` warning
- [ ] `NATS_URL=tls://localhost:4222 voicecli nats-serve tts` → starts, no warning

Closes #135

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`