### PR TITLE
fix(samples): add error handling to samples_record command

### DIFF
--- a/src/voicecli/cli_samples.py
+++ b/src/voicecli/cli_samples.py
@@ -44,7 +44,11 @@ def samples_record(
     """Record audio from microphone and save as a sample."""
     from voicecli.samples import record_sample
 
-    dest = record_sample(name, duration=duration)
+    try:
+        dest = record_sample(name, duration=duration)
+    except (RuntimeError, OSError) as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
     typer.echo(f"Recorded {dest}")
 
 

--- a/src/voicecli/cli_samples.py
+++ b/src/voicecli/cli_samples.py
@@ -114,6 +114,9 @@ def samples_from_url(
             wav_name = dest.name
             set_active(wav_name)
             typer.echo(f"Active sample set to: {wav_name}")
-    except (RuntimeError, ValueError) as e:
+    except ValueError as e:
+        typer.echo(f"Invalid argument: {e}", err=True)
+        raise typer.Exit(1)
+    except RuntimeError as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)

--- a/src/voicecli/samples.py
+++ b/src/voicecli/samples.py
@@ -137,6 +137,7 @@ def _check_tool(name: str) -> None:
         hints = {
             "yt-dlp": "Install with: uv tool install yt-dlp",
             "ffmpeg": "Install with: sudo apt install ffmpeg",
+            "parecord": "Install with: sudo apt install pulseaudio-utils",
         }
         hint = hints.get(name, f"Please install {name}")
         raise RuntimeError(f"'{name}' not found on PATH. {hint}")
@@ -236,6 +237,7 @@ def record_sample(name: str, duration: float = 10.0, samplerate: int = 24000) ->
     """Record from microphone via PulseAudio (parecord) and save as WAV."""
     import subprocess
 
+    _check_tool("parecord")
     ensure_dir()
     if not name.endswith(".wav"):
         name = f"{name}.wav"
@@ -244,8 +246,9 @@ def record_sample(name: str, duration: float = 10.0, samplerate: int = 24000) ->
     _chime("start")
     print(f"Recording for {duration}s...")
 
+    result = None
     try:
-        subprocess.run(
+        result = subprocess.run(
             [
                 "parecord",
                 "--channels=1",
@@ -258,6 +261,11 @@ def record_sample(name: str, duration: float = 10.0, samplerate: int = 24000) ->
         )
     except subprocess.TimeoutExpired:
         pass  # expected — this is how we stop after the set duration
+
+    if result is not None and result.returncode != 0:
+        raise RuntimeError(f"parecord failed (exit {result.returncode})")
+    if not dest.exists() or dest.stat().st_size == 0:
+        raise RuntimeError("parecord produced no output — check microphone and PulseAudio")
 
     _chime("stop")
     print(f"Saved recording to {dest}")

--- a/src/voicecli/samples.py
+++ b/src/voicecli/samples.py
@@ -237,6 +237,9 @@ def record_sample(name: str, duration: float = 10.0, samplerate: int = 24000) ->
     """Record from microphone via PulseAudio (parecord) and save as WAV."""
     import subprocess
 
+    if duration <= 0:
+        raise ValueError(f"duration must be positive, got {duration}")
+
     _check_tool("parecord")
     ensure_dir()
     if not name.endswith(".wav"):
@@ -260,7 +263,9 @@ def record_sample(name: str, duration: float = 10.0, samplerate: int = 24000) ->
             timeout=duration,
         )
     except subprocess.TimeoutExpired:
-        pass  # expected — this is how we stop after the set duration
+        # subprocess.run() already called process.kill() + communicate() before
+        # re-raising — process is dead by the time we reach this block.
+        pass
 
     if result is not None and result.returncode != 0:
         raise RuntimeError(f"parecord failed (exit {result.returncode})")

--- a/tests/test_samples_record.py
+++ b/tests/test_samples_record.py
@@ -1,0 +1,189 @@
+"""Tests for samples record command and record_sample()."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from voicecli.samples import _check_tool, record_sample
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def samples_env(tmp_path, monkeypatch):
+    """Temporary samples dir with patched SAMPLES_DIR."""
+    samples_dir = tmp_path / "samples"
+    samples_dir.mkdir()
+    monkeypatch.setattr("voicecli.samples.SAMPLES_DIR", samples_dir)
+    return samples_dir
+
+
+@pytest.fixture()
+def mock_chime(monkeypatch):
+    monkeypatch.setattr("voicecli.samples._chime", lambda *_: None)
+
+
+# ── _check_tool — parecord hint ───────────────────────────────────────────────
+
+
+class TestCheckToolParecord:
+    def test_not_found_parecord(self):
+        with patch("voicecli.samples.shutil.which", return_value=None):
+            with pytest.raises(RuntimeError, match="parecord.*not found"):
+                _check_tool("parecord")
+
+    def test_not_found_parecord_hint(self):
+        with patch("voicecli.samples.shutil.which", return_value=None):
+            with pytest.raises(RuntimeError, match="pulseaudio-utils"):
+                _check_tool("parecord")
+
+
+# ── record_sample unit tests ─────────────────────────────────────────────────
+
+
+class TestRecordSample:
+    @patch("voicecli.samples.shutil.which", return_value="/usr/bin/parecord")
+    def test_happy_path_timeout_is_normal_stop(self, _mock_which, samples_env, mock_chime):
+        # Arrange — parecord times out (normal), dest was written during recording
+        def fake_run(cmd, *, timeout):
+            dest = Path(cmd[-1])
+            dest.write_bytes(b"fake wav data")
+            raise subprocess.TimeoutExpired(cmd, timeout)
+
+        with patch("voicecli.samples.subprocess.run", side_effect=fake_run):
+            # Act
+            result = record_sample("myrecording", duration=5.0)
+
+        # Assert
+        assert result == samples_env / "myrecording.wav"
+        assert result.exists()
+
+    @patch("voicecli.samples.shutil.which", return_value="/usr/bin/parecord")
+    def test_happy_path_appends_wav_extension(self, _mock_which, samples_env, mock_chime):
+        def fake_run(cmd, *, timeout):
+            Path(cmd[-1]).write_bytes(b"data")
+            raise subprocess.TimeoutExpired(cmd, timeout)
+
+        with patch("voicecli.samples.subprocess.run", side_effect=fake_run):
+            result = record_sample("noext", duration=2.0)
+
+        assert result.name == "noext.wav"
+
+    @patch("voicecli.samples.shutil.which", return_value=None)
+    def test_missing_parecord_raises(self, _mock_which):
+        with pytest.raises(RuntimeError, match="parecord.*not found"):
+            record_sample("test")
+
+    @patch("voicecli.samples.shutil.which", return_value="/usr/bin/parecord")
+    def test_nonzero_returncode_raises(self, _mock_which, samples_env, mock_chime):
+        # Arrange — parecord exits non-zero (PulseAudio not running etc.)
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        dest = samples_env / "test.wav"
+        dest.write_bytes(b"partial")  # file exists so we reach returncode check
+
+        with patch("voicecli.samples.subprocess.run", return_value=mock_result):
+            with pytest.raises(RuntimeError, match="parecord failed \\(exit 1\\)"):
+                record_sample("test", duration=2.0)
+
+    @patch("voicecli.samples.shutil.which", return_value="/usr/bin/parecord")
+    def test_dest_missing_after_timeout_raises(self, _mock_which, samples_env, mock_chime):
+        # Arrange — timeout but dest never written
+        def fake_run(cmd, *, timeout):
+            raise subprocess.TimeoutExpired(cmd, timeout)  # no file written
+
+        with patch("voicecli.samples.subprocess.run", side_effect=fake_run):
+            with pytest.raises(RuntimeError, match="parecord produced no output"):
+                record_sample("test", duration=2.0)
+
+    @patch("voicecli.samples.shutil.which", return_value="/usr/bin/parecord")
+    def test_zero_byte_dest_raises(self, _mock_which, samples_env, mock_chime):
+        # Arrange — timeout, dest is zero bytes (empty file written)
+        def fake_run(cmd, *, timeout):
+            Path(cmd[-1]).touch()  # zero-byte file
+            raise subprocess.TimeoutExpired(cmd, timeout)
+
+        with patch("voicecli.samples.subprocess.run", side_effect=fake_run):
+            with pytest.raises(RuntimeError, match="parecord produced no output"):
+                record_sample("test", duration=2.0)
+
+    def test_negative_duration_raises(self):
+        with pytest.raises(ValueError, match="duration must be positive"):
+            record_sample("test", duration=-1.0)
+
+    def test_zero_duration_raises(self):
+        with pytest.raises(ValueError, match="duration must be positive"):
+            record_sample("test", duration=0)
+
+
+# ── CLI command tests ────────────────────────────────────────────────────────
+
+
+class TestSamplesRecordCommand:
+    def test_happy_path(self):
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        runner = CliRunner()
+        fake_dest = Path("TTS/samples/mymic.wav")
+
+        with patch("voicecli.samples.record_sample", return_value=fake_dest):
+            result = runner.invoke(app, ["samples", "record", "mymic"])
+
+        assert result.exit_code == 0
+        assert "Recorded" in result.output
+
+    def test_runtime_error_exits_1(self):
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        runner = CliRunner()
+
+        with patch(
+            "voicecli.samples.record_sample",
+            side_effect=RuntimeError("parecord not found on PATH"),
+        ):
+            result = runner.invoke(app, ["samples", "record", "mymic"])
+
+        assert result.exit_code == 1
+
+    def test_os_error_exits_1(self):
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        runner = CliRunner()
+
+        with patch(
+            "voicecli.samples.record_sample",
+            side_effect=OSError("device busy"),
+        ):
+            result = runner.invoke(app, ["samples", "record", "mymic"])
+
+        assert result.exit_code == 1
+
+
+# ── from-url ValueError prefix (new in this PR) ───────────────────────────────
+
+
+class TestFromUrlValueErrorPrefix:
+    def test_value_error_uses_invalid_argument_prefix(self):
+        from typer.testing import CliRunner
+
+        from voicecli.cli import app
+
+        runner = CliRunner()
+
+        with patch(
+            "voicecli.samples.from_url",
+            side_effect=ValueError("Only http/https URLs are supported"),
+        ):
+            result = runner.invoke(app, ["samples", "from-url", "file:///etc/passwd", "evil"])
+
+        assert result.exit_code == 1
+        assert "Invalid argument:" in result.output


### PR DESCRIPTION
## Summary
- Wrap `record_sample()` call in `try/except (RuntimeError, OSError)` matching the pattern used by all sibling commands (`add`, `use`, `remove`, `from-url`)
- Produces a clean `Error: <msg>` on stderr + exit code 1 instead of a raw traceback when `parecord` fails

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #134: fix(samples): add error handling to samples_record command | Open |
| Implementation | 1 commit on `feat/134-fix-samples-error-handling` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ | Passed |

## Test Plan
- [ ] Run `voicecli samples record test` with no microphone/PulseAudio available — should print `Error: ...` to stderr and exit 1
- [ ] Run `voicecli samples record test` with a working mic — should record and print the output path

Closes #134

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`