### PR TITLE
refactor(markdown): extract shared types into voicecli.markdown_types

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -14,6 +14,7 @@ layers =
     voicecli.adapters
     voicecli.engine | voicecli.transcribe | voicecli.daemon | voicecli.stt_daemon | voicecli.model_registry | voicecli.daemon_protocol
     voicecli.config | voicecli.paths | voicecli.utils | voicecli.env | voicecli.models | voicecli.samples | voicecli.translate | voicecli.markdown | voicecli.stt_modes | voicecli.clipboard | voicecli.history | voicecli.ui_sounds | voicecli.engine_caps | voicecli._markdown_directives
+    voicecli.markdown_types
 ignore_imports =
     # Transitional: voicecli.translate imports voicecli.markdown for MD rendering — same layer peer dependency
     voicecli.translate -> voicecli.markdown
@@ -51,7 +52,6 @@ ignore_imports =
     # ADR-059 V10: same config/utils layer peer dependencies
     voicecli.translate -> voicecli.engine_caps
     voicecli.markdown -> voicecli._markdown_directives
-    voicecli._markdown_directives -> voicecli.markdown
     voicecli.history -> voicecli.paths
 
 [importlinter:contract:api-no-direct-infra]

--- a/docs/architecture/index.mdx
+++ b/docs/architecture/index.mdx
@@ -19,7 +19,9 @@ voiceCLI/
 │   ├── __init__.py             # Public exports (generate, clone, transcribe, etc.)
 │   ├── cli.py                  # Typer app — CLI entry point
 │   ├── api.py                  # Orchestration — public library API
-│   ├── markdown.py             # Domain models (TTSDocument, Segment) + parsing
+│   ├── markdown.py             # Public markdown API (re-exports + parse_md_file)
+│   ├── markdown_types.py       # Shared primitives: TTSDocument, Segment, parse_frontmatter, strip_markdown
+│   ├── _markdown_directives.py # Internal directive parser (private — import via markdown.py)
 │   ├── translate.py            # Engine capability matrix + document translation
 │   ├── config.py               # TOML config loader (walk-up search)
 │   ├── engine.py               # Abstract TTSEngine base class + registry
@@ -58,7 +60,7 @@ graph BT
     API["api.py (generate, clone, transcribe)"]
   end
   subgraph Domain["Domain Layer"]
-    MD["markdown.py (TTSDocument, Segment)"]
+    MD["markdown.py + markdown_types.py (TTSDocument, Segment)"]
     TR["translate.py (ENGINE_CAPS)"]
     CFG["config.py (TOML loader)"]
     UTL["utils.py (language, audio, paths)"]
@@ -84,7 +86,7 @@ graph BT
 |-------|---------|----------------|
 | **Presentation** | `cli.py` | Parse CLI flags, invoke API, format output, handle `typer.Exit` |
 | **Application** | `api.py` | Orchestration: config resolution, input parsing, translation, engine dispatch, chunking |
-| **Domain** | `markdown.py`, `translate.py`, `config.py`, `utils.py`, `models.py`, `samples.py` | Data models, parsing, capability matrix, configuration, utilities — pure Python, no heavy deps |
+| **Domain** | `markdown.py` + `markdown_types.py` (+ private `_markdown_directives.py`), `translate.py`, `config.py`, `utils.py`, `models.py`, `samples.py` | Data models, parsing, capability matrix, configuration, utilities — pure Python, no heavy deps |
 | **Infrastructure** | `engine.py`, `engines/*.py`, `daemon.py`, `transcribe.py`, `listen.py` | Abstract engine base, concrete engine implementations, daemon, STT adapters |
 
 ### Dependency Direction

--- a/docs/architecture/patterns.mdx
+++ b/docs/architecture/patterns.mdx
@@ -293,12 +293,12 @@ def _try_daemon(request: dict) -> Path | None:
 
 ## Composition Pattern
 
-**File:** `markdown.py`
+**File:** `markdown_types.py` (re-exported via `markdown.py`)
 
 Instruct strings can be composed from structured parts or set as raw bypass.
 
 ```python
-# markdown.py — deterministic composition
+# markdown_types.py — deterministic composition
 def compose_instruct(accent, personality, speed, emotion):
     parts = [p for p in (accent, personality, speed, emotion) if p]
     return ". ".join(parts) if parts else None

--- a/src/voicecli/_markdown_directives.py
+++ b/src/voicecli/_markdown_directives.py
@@ -9,10 +9,10 @@ Private module — import via voicecli.markdown, not directly.
 import re
 from pathlib import Path
 
-from voicecli.markdown import (
-    TTSDocument,
-    Segment,
+from voicecli.markdown_types import (
     _INSTRUCT_PARTS,
+    Segment,
+    TTSDocument,
     compose_instruct,
     parse_frontmatter,
     strip_markdown,

--- a/src/voicecli/markdown.py
+++ b/src/voicecli/markdown.py
@@ -8,7 +8,6 @@ implementation. Existing call sites continue to import names from this module.
 from pathlib import Path
 
 from voicecli.markdown_types import (
-    _INSTRUCT_PARTS,
     Segment,
     TTSDocument,
     compose_instruct,
@@ -19,7 +18,6 @@ from voicecli.markdown_types import (
 __all__ = [
     "Segment",
     "TTSDocument",
-    "_INSTRUCT_PARTS",
     "compose_instruct",
     "parse_frontmatter",
     "strip_markdown",
@@ -34,20 +32,20 @@ def parse_md_file(path: Path) -> TTSDocument:
     # Deferred import keeps voicecli.markdown free of any back-reference at
     # module load time; voicecli._markdown_directives now depends only on
     # voicecli.markdown_types, so the historical cycle is gone.
-    from voicecli._markdown_directives import parse_md_file as _parse  # type: ignore[import-not-found]
+    from voicecli._markdown_directives import parse_md_file as _parse
 
     return _parse(path)
 
 
 def _parse_comment_kvs(content: str) -> dict[str, str]:
     """Re-export from _markdown_directives (used by tests and any external callers)."""
-    from voicecli._markdown_directives import _parse_comment_kvs as _fn  # type: ignore[import-not-found]
+    from voicecli._markdown_directives import _parse_comment_kvs as _fn
 
     return _fn(content)
 
 
 def _parse_segments(body: str, defaults: dict) -> list[Segment]:
     """Re-export from _markdown_directives (used by tests and any external callers)."""
-    from voicecli._markdown_directives import _parse_segments as _fn  # type: ignore[import-not-found]
+    from voicecli._markdown_directives import _parse_segments as _fn
 
     return _fn(body, defaults)

--- a/src/voicecli/markdown.py
+++ b/src/voicecli/markdown.py
@@ -1,135 +1,39 @@
-"""Parse markdown files with YAML frontmatter for TTS metadata."""
+"""Public markdown API for TTS scripts.
 
-import re
-from dataclasses import dataclass, field
+Re-exports the shared primitives from :mod:`voicecli.markdown_types` and
+delegates parsing to the internal :mod:`voicecli._markdown_directives`
+implementation. Existing call sites continue to import names from this module.
+"""
+
 from pathlib import Path
 
+from voicecli.markdown_types import (
+    _INSTRUCT_PARTS,
+    Segment,
+    TTSDocument,
+    compose_instruct,
+    parse_frontmatter,
+    strip_markdown,
+)
 
-_INSTRUCT_PARTS = ("accent", "personality", "speed", "emotion")
-
-
-def compose_instruct(
-    accent: str | None = None,
-    personality: str | None = None,
-    speed: str | None = None,
-    emotion: str | None = None,
-) -> str | None:
-    """Join non-None instruct parts into a single instruct string."""
-    parts = [p for p in (accent, personality, speed, emotion) if p]
-    return ". ".join(parts) if parts else None
-
-
-@dataclass
-class Segment:
-    """A text segment with per-section overrides."""
-
-    text: str
-    instruct: str | None = None
-    accent: str | None = None
-    personality: str | None = None
-    speed: str | None = None
-    emotion: str | None = None
-    exaggeration: float | None = None
-    cfg_weight: float | None = None
-    flow_steps: int | None = None
-    cfg_alpha: float | None = None
-    temperature: float | None = None
-    top_p: float | None = None
-    min_p: float | None = None
-    repetition_penalty: float | None = None
-    segment_gap: int | None = None
-    crossfade: int | None = None
-    language: str | None = None
-    voice: str | None = None
-
-
-@dataclass
-class TTSDocument:
-    text: str
-    language: str | None = None
-    voice: str | None = None
-    engine: str | None = None
-    instruct: str | None = None
-    accent: str | None = None
-    personality: str | None = None
-    speed: str | None = None
-    emotion: str | None = None
-    exaggeration: float | None = None
-    cfg_weight: float | None = None
-    flow_steps: int | None = None
-    cfg_alpha: float | None = None
-    temperature: float | None = None
-    top_p: float | None = None
-    min_p: float | None = None
-    repetition_penalty: float | None = None
-    segment_gap: int | None = None
-    crossfade: int | None = None
-    extra: dict = field(default_factory=dict)
-    segments: list[Segment] = field(default_factory=list)
-
-
-def parse_frontmatter(content: str) -> tuple[dict, str]:
-    """Split YAML frontmatter from body. Returns (metadata, body)."""
-    match = re.match(r"^---\s*\n(.*?)\n---\s*\n(.*)", content, re.DOTALL)
-    if not match:
-        return {}, content
-
-    yaml_block, body = match.group(1), match.group(2)
-
-    # Simple YAML parser — handles key: value lines (no nested structures needed)
-    metadata = {}
-    for line in yaml_block.splitlines():
-        line = line.strip()
-        if not line or line.startswith("#"):
-            continue
-        if ":" not in line:
-            continue
-        key, _, value = line.partition(":")
-        key = key.strip()
-        value = value.strip()
-        # Strip surrounding quotes
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
-            value = value[1:-1]
-        metadata[key] = value
-
-    return metadata, body
-
-
-def strip_markdown(text: str) -> str:
-    """Strip markdown formatting to plain text, preserving paralinguistic tags like [laugh]."""
-    # Remove headers (# ... )
-    text = re.sub(r"^#{1,6}\s+", "", text, flags=re.MULTILINE)
-    # Remove bold/italic markers
-    text = re.sub(r"\*{1,3}([^*]+)\*{1,3}", r"\1", text)
-    text = re.sub(r"_{1,3}([^_]+)_{1,3}", r"\1", text)
-    # Remove links [text](url) → text
-    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
-    # Remove inline code backticks
-    text = re.sub(r"`([^`]+)`", r"\1", text)
-    # Remove blockquote markers
-    text = re.sub(r"^>\s?", "", text, flags=re.MULTILINE)
-    # Remove horizontal rules
-    text = re.sub(r"^[-*_]{3,}\s*$", "", text, flags=re.MULTILINE)
-    # Remove images ![alt](url)
-    text = re.sub(r"!\[([^\]]*)\]\([^)]+\)", r"\1", text)
-    # Strip before newline conversion to avoid leading ". " from frontmatter gap
-    text = text.strip()
-    # Join paragraphs: collapse multiple newlines into ". " for natural pausing
-    text = re.sub(r"\n{2,}", ". ", text)
-    # Single newlines → space
-    text = re.sub(r"\n", " ", text)
-    # Clean up multiple spaces/periods
-    text = re.sub(r"\.\s*\.", ".", text)
-    text = re.sub(r"\s{2,}", " ", text)
-    return text.strip()
+__all__ = [
+    "Segment",
+    "TTSDocument",
+    "_INSTRUCT_PARTS",
+    "compose_instruct",
+    "parse_frontmatter",
+    "strip_markdown",
+    "parse_md_file",
+    "_parse_comment_kvs",
+    "_parse_segments",
+]
 
 
 def parse_md_file(path: Path) -> TTSDocument:
     """Parse a .md file into a TTSDocument."""
-    # Deferred import avoids circular dependency:
-    # _markdown_directives imports from this module at its module level,
-    # which is safe here because markdown.py is fully initialised before
-    # parse_md_file() is ever called.
+    # Deferred import keeps voicecli.markdown free of any back-reference at
+    # module load time; voicecli._markdown_directives now depends only on
+    # voicecli.markdown_types, so the historical cycle is gone.
     from voicecli._markdown_directives import parse_md_file as _parse  # type: ignore[import-not-found]
 
     return _parse(path)

--- a/src/voicecli/markdown_types.py
+++ b/src/voicecli/markdown_types.py
@@ -1,0 +1,117 @@
+"""Shared primitives for markdown TTS parsing.
+
+Holds the data types and pure helpers consumed by both ``voicecli.markdown``
+(public API) and ``voicecli._markdown_directives`` (internal directive parser).
+
+Lives in its own layer so neither side needs to import the other to access
+``Segment``, ``TTSDocument``, frontmatter parsing, or markdown stripping.
+"""
+
+import re
+from dataclasses import dataclass, field
+
+
+_INSTRUCT_PARTS = ("accent", "personality", "speed", "emotion")
+
+
+def compose_instruct(
+    accent: str | None = None,
+    personality: str | None = None,
+    speed: str | None = None,
+    emotion: str | None = None,
+) -> str | None:
+    """Join non-None instruct parts into a single instruct string."""
+    parts = [p for p in (accent, personality, speed, emotion) if p]
+    return ". ".join(parts) if parts else None
+
+
+@dataclass
+class Segment:
+    """A text segment with per-section overrides."""
+
+    text: str
+    instruct: str | None = None
+    accent: str | None = None
+    personality: str | None = None
+    speed: str | None = None
+    emotion: str | None = None
+    exaggeration: float | None = None
+    cfg_weight: float | None = None
+    flow_steps: int | None = None
+    cfg_alpha: float | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    min_p: float | None = None
+    repetition_penalty: float | None = None
+    segment_gap: int | None = None
+    crossfade: int | None = None
+    language: str | None = None
+    voice: str | None = None
+
+
+@dataclass
+class TTSDocument:
+    text: str
+    language: str | None = None
+    voice: str | None = None
+    engine: str | None = None
+    instruct: str | None = None
+    accent: str | None = None
+    personality: str | None = None
+    speed: str | None = None
+    emotion: str | None = None
+    exaggeration: float | None = None
+    cfg_weight: float | None = None
+    flow_steps: int | None = None
+    cfg_alpha: float | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    min_p: float | None = None
+    repetition_penalty: float | None = None
+    segment_gap: int | None = None
+    crossfade: int | None = None
+    extra: dict = field(default_factory=dict)
+    segments: list[Segment] = field(default_factory=list)
+
+
+def parse_frontmatter(content: str) -> tuple[dict, str]:
+    """Split YAML frontmatter from body. Returns (metadata, body)."""
+    match = re.match(r"^---\s*\n(.*?)\n---\s*\n(.*)", content, re.DOTALL)
+    if not match:
+        return {}, content
+
+    yaml_block, body = match.group(1), match.group(2)
+
+    metadata = {}
+    for line in yaml_block.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            value = value[1:-1]
+        metadata[key] = value
+
+    return metadata, body
+
+
+def strip_markdown(text: str) -> str:
+    """Strip markdown formatting to plain text, preserving paralinguistic tags like [laugh]."""
+    text = re.sub(r"^#{1,6}\s+", "", text, flags=re.MULTILINE)
+    text = re.sub(r"\*{1,3}([^*]+)\*{1,3}", r"\1", text)
+    text = re.sub(r"_{1,3}([^_]+)_{1,3}", r"\1", text)
+    text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+    text = re.sub(r"`([^`]+)`", r"\1", text)
+    text = re.sub(r"^>\s?", "", text, flags=re.MULTILINE)
+    text = re.sub(r"^[-*_]{3,}\s*$", "", text, flags=re.MULTILINE)
+    text = re.sub(r"!\[([^\]]*)\]\([^)]+\)", r"\1", text)
+    text = text.strip()
+    text = re.sub(r"\n{2,}", ". ", text)
+    text = re.sub(r"\n", " ", text)
+    text = re.sub(r"\.\s*\.", ".", text)
+    text = re.sub(r"\s{2,}", " ", text)
+    return text.strip()


### PR DESCRIPTION
## Summary
- Move `Segment`, `TTSDocument`, `_INSTRUCT_PARTS`, `compose_instruct`, `parse_frontmatter`, `strip_markdown` into a new `voicecli.markdown_types` module placed in its own (deeper) layer.
- Break the eager module-load cycle: `voicecli._markdown_directives` now imports from `voicecli.markdown_types` (no back-reference to `voicecli.markdown`); `voicecli.markdown` re-exports the types so existing call sites (api, translate, engines, tests) are untouched.
- Drop the `voicecli._markdown_directives -> voicecli.markdown` `ignore_imports` entry from `.importlinter`. The lazy `markdown -> _markdown_directives` delegation remains under its existing peer-import ignore.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #142: refactor(markdown): resolve circular dependency between _markdown_directives and markdown | OPEN |
| Implementation | 1 commit on `feat/142-resolve-circular-dep-markdown` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (437 passed, 1 skipped) lint-imports ✅ (2 kept, 0 broken) | Passed |

## Test Plan
- [ ] `uv run lint-imports` reports `Contracts: 2 kept, 0 broken`
- [ ] `uv run pytest tests/test_markdown.py` — 32 passed, no regressions
- [ ] `python -c "from voicecli.markdown import Segment, TTSDocument, parse_md_file"` — re-exports preserved
- [ ] `grep _markdown_directives .importlinter` — only the lazy `markdown -> _markdown_directives` entry remains

Closes #142

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`