### PR TITLE
fix(ci): allowlist nats_stt_client.py for lyra.* subject literals

### DIFF
--- a/scripts/check-lyra-literals.sh
+++ b/scripts/check-lyra-literals.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 
 # Designated adapter modules (actual subject string usage)
 # cli.py: docstrings only, not subject literals
-ALLOWLIST="src/voicecli/nats/stt_adapter.py src/voicecli/nats/tts_adapter.py src/voicecli/cli_nats.py"
+# nats_stt_client.py: one-shot NATS STT adapter for `voicecli dictate nats`
+ALLOWLIST="src/voicecli/nats/stt_adapter.py src/voicecli/nats/tts_adapter.py src/voicecli/cli_nats.py src/voicecli/nats_stt_client.py"
 
 # Find files with lyra. literals, excluding allowlisted paths
 VIOLATORS=$(grep -rln "lyra\." src/ --include='*.py' 2>/dev/null | grep -vE "^($(echo "$ALLOWLIST" | tr ' ' '|'))$" || true)


### PR DESCRIPTION
## Summary
- Add `src/voicecli/nats_stt_client.py` to the allowlist in `scripts/check-lyra-literals.sh`.
- The file is the one-shot NATS STT adapter used by `voicecli dictate nats` (cross-host dictation). It legitimately holds the `SUBJECT = "lyra.voice.stt.request"` literal, but was never added to the ADR-047 Rule 3 allowlist when introduced.
- Result: CI's `Check lyra.* subject literals` step has been red on every staging push since `nats_stt_client.py` landed; this fix turns it green.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Implementation | 1 commit on `fix/ci-lyra-literals-allowlist-stt-client` | Complete |
| Verification | `bash scripts/check-lyra-literals.sh` → `OK: No lyra.* subject literals outside designated adapter modules.` | Passed |

## Test Plan
- [ ] CI's `Check lyra.* subject literals` step passes on this PR
- [ ] `bash scripts/check-lyra-literals.sh` exits 0 locally

## Context
Surfaced while landing #142 — its CI hit the same pre-existing failure. Unblocking this gate first so #142 can merge cleanly.

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`