### PR TITLE
feat(dictate): provisioning installer + [nats] toml fallback

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -49,6 +49,9 @@ ignore_imports =
     voicecli.overlay -> voicecli.stt_client
     # ADR-059 V10: same top-tier peer dependency — cli_dictate uses stt_client for dictate flow
     voicecli.cli_dictate -> voicecli.stt_client
+    # ADR-059 V10: same top-tier peer dependency — nats_recorder reuses notify() from stt_client for the
+    # progressive "Recording... Ns" bubble emitted from the recorder subprocess.
+    voicecli.nats_recorder -> voicecli.stt_client
     # ADR-059 V10: same config/utils layer peer dependencies
     voicecli.translate -> voicecli.engine_caps
     voicecli.markdown -> voicecli._markdown_directives

--- a/docs/dictation-setup.md
+++ b/docs/dictation-setup.md
@@ -17,6 +17,52 @@ Typical flow:
 2. Second press: daemon stops recording, transcribes, writes text to clipboard. Notification shows the transcribed text.
 3. Ctrl+Shift+V in any app to paste without formatting.
 
+## Linux client provisioning (NATS hub setup)
+
+If your STT daemon runs on a remote hub and you want to dictate from another
+machine over NATS, use the bundled installer. It detects your desktop
+environment (COSMIC or GNOME), checks Wayland deps, installs a wrapper to
+`~/.local/bin/voicecli-dictate`, and binds Ctrl+Space to it.
+
+```bash
+# 1. Install the CLI with the NATS extra
+uv sync --extra nats
+ln -sf "$PWD/.venv/bin/voicecli" ~/.local/bin/voicecli
+
+# 2. Configure the hub in ~/.voicecli/voicecli.toml
+cat >> ~/.voicecli/voicecli.toml <<'EOF'
+[nats]
+url = "nats://your-hub-host:4222"
+nkey_seed_path = "~/.voicecli/nkeys/voice-client.seed"
+EOF
+
+# 3. Copy the nkey seed from a hub-authorized machine
+# scp hub-machine:~/.voicecli/nkeys/voice-client.seed ~/.voicecli/nkeys/
+chmod 700 ~/.voicecli/nkeys && chmod 600 ~/.voicecli/nkeys/voice-client.seed
+
+# 4. Run the installer
+./scripts/install-shortcut.sh           # Ctrl+Space, auto-detects COSMIC/GNOME
+./scripts/install-shortcut.sh --check-only   # dry-run, reports missing deps
+```
+
+Then logout/login (COSMIC reads custom shortcuts at session start). Press
+Ctrl+Space to toggle dictation. The wrapper does a 2-second TCP probe to the
+hub before invoking the CLI — if the hub is unreachable it shows a desktop
+notification rather than blocking 60 s on the request timeout.
+
+The wrapper itself is at [`scripts/wrappers/voicecli-dictate.sh`](../scripts/wrappers/voicecli-dictate.sh).
+For roaming machines (laptops), prefer a Tailscale MagicDNS hostname (e.g.
+`nats://hub:4222`) over a LAN IP so the same config works on and off the LAN.
+
+Override at invoke time:
+
+| Env var | Effect |
+|---|---|
+| `NATS_URL` | Overrides `[nats] url` from the toml |
+| `NATS_NKEY_SEED_PATH` | Overrides `[nats] nkey_seed_path` |
+| `VOICECLI_BIN` | Path to the `voicecli` executable (default `~/.local/bin/voicecli`) |
+| `VOICECLI_MODE` | STT mode passed as `--mode` (e.g. `french`, `code`) |
+
 ## Prerequisites
 
 On Wayland (Pop!_OS, GNOME, COSMIC), install the overlay and auto-paste dependencies:

--- a/scripts/_cosmic_bind.py
+++ b/scripts/_cosmic_bind.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Idempotent COSMIC custom-shortcut writer.
+
+Used by ``install-shortcut.sh`` to add (or replace) a single binding in
+``~/.config/cosmic/com.system76.CosmicSettings.Shortcuts/v1/custom`` without
+clobbering unrelated entries the user already has.
+
+We don't depend on a RON parser — the COSMIC custom file has a stable,
+line-oriented shape (one ``( … ): Spawn("…"),`` block per entry), so a small
+regex pass is enough.
+
+Dedup rules — we DROP an existing entry when:
+  * its ``(modifiers, key)`` equals the new binding (rebinding the same key), OR
+  * its ``Spawn(...)`` target is the new wrapper path or matches a known
+    legacy basename (e.g. ``voicecli-dictate-nats``) — keeps re-runs and
+    upgrades clean.
+
+Usage:
+    _cosmic_bind.py CUSTOM_PATH 'Ctrl,Shift' SPACE WRAPPER_PATH 'voiceCLI dictate' \\
+                    [LEGACY_BASENAME ...]
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ENTRY_RE = re.compile(
+    r"    \(\s*\n"
+    r"        modifiers:\s*\[(?P<mods>[^\]]*)\],?\s*\n"
+    r'        key:\s*"(?P<key>[^"]+)",?\s*\n'
+    r"        description:\s*[^\n]*\n"
+    r'    \):\s*Spawn\("(?P<spawn>[^"]+)"\),?\s*\n',
+    re.DOTALL,
+)
+MOD_RE = re.compile(r"\b(Ctrl|Shift|Alt|Super)\b")
+
+
+def main() -> int:
+    if len(sys.argv) < 6:
+        print(__doc__, file=sys.stderr)
+        return 2
+    custom_path = Path(sys.argv[1])
+    new_mods = {m.strip() for m in sys.argv[2].split(",") if m.strip()}
+    new_key = sys.argv[3]
+    wrapper = sys.argv[4]
+    description = sys.argv[5]
+    legacy_basenames = set(sys.argv[6:])
+
+    content = custom_path.read_text() if custom_path.exists() else "{\n}\n"
+
+    kept: list[str] = []
+    for m in ENTRY_RE.finditer(content):
+        mods = set(MOD_RE.findall(m.group("mods")))
+        key = m.group("key")
+        spawn = m.group("spawn")
+        spawn_base = Path(spawn).name
+        same_binding = mods == new_mods and key == new_key
+        same_target = spawn == wrapper
+        legacy_target = spawn_base in legacy_basenames
+        if same_binding or same_target or legacy_target:
+            continue
+        kept.append(m.group(0))
+
+    new_entry = (
+        "    (\n"
+        "        modifiers: [\n"
+        + "".join(f"            {mod},\n" for mod in sorted(new_mods))
+        + "        ],\n"
+        + f'        key: "{new_key}",\n'
+        + f'        description: Some("{description}"),\n'
+        + f'    ): Spawn("{wrapper}"),\n'
+    )
+
+    custom_path.parent.mkdir(parents=True, exist_ok=True)
+    custom_path.write_text("{\n" + "".join(kept) + new_entry + "}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install-shortcut.sh
+++ b/scripts/install-shortcut.sh
@@ -117,41 +117,29 @@ say "Installed wrapper → $WRAPPER_DST"
 case "$DE" in
     cosmic)
         CUSTOM="$HOME/.config/cosmic/com.system76.CosmicSettings.Shortcuts/v1/custom"
-        mkdir -p "$(dirname "$CUSTOM")"
 
-        # Parse "Mod1+Mod2+Key" → Cosmic's RON modifier list + lower-case key.
-        MODS=""; KEYNAME="${KEY##*+}"
+        # Parse "Mod1+Mod2+Key" → comma-separated modifiers + lower-case key.
+        KEYNAME_LOWER="$(echo "${KEY##*+}" | tr '[:upper:]' '[:lower:]')"
+        MODS_CSV=""
         IFS='+' read -ra parts <<< "${KEY%+*}"
         for m in "${parts[@]}"; do
             case "$(echo "$m" | tr '[:upper:]' '[:lower:]')" in
-                ctrl|control) MODS+="            Ctrl,\n" ;;
-                shift)        MODS+="            Shift,\n" ;;
-                alt)          MODS+="            Alt,\n" ;;
-                super|win|meta) MODS+="            Super,\n" ;;
+                ctrl|control)   MODS_CSV+="Ctrl," ;;
+                shift)          MODS_CSV+="Shift," ;;
+                alt)            MODS_CSV+="Alt," ;;
+                super|win|meta) MODS_CSV+="Super," ;;
             esac
         done
-        KEYNAME_LOWER="$(echo "$KEYNAME" | tr '[:upper:]' '[:lower:]')"
+        MODS_CSV="${MODS_CSV%,}"
 
-        # Idempotent: if the file already binds this exact action, skip.
-        if [ -f "$CUSTOM" ] && grep -Fq "Spawn(\"$WRAPPER_DST\")" "$CUSTOM"; then
-            say "COSMIC binding already present → no change"
-        else
-            # Preserve any existing entries: extract everything between {…} and append ours.
-            existing=""
-            if [ -f "$CUSTOM" ] && grep -q '): Spawn(' "$CUSTOM"; then
-                existing="$(sed -n '/^{/,/^}/p' "$CUSTOM" | sed '1d;$d')"
-            fi
-            {
-                printf '{\n'
-                [ -n "$existing" ] && printf '%s\n' "$existing"
-                printf '    (\n        modifiers: [\n'
-                printf '%b' "$MODS"
-                printf '        ],\n        key: "%s",\n        description: Some("voiceCLI dictate"),\n    ): Spawn("%s"),\n}\n' \
-                    "$KEYNAME_LOWER" "$WRAPPER_DST"
-            } > "$CUSTOM"
-            say "Wrote COSMIC binding → $CUSTOM"
-            say "→ Logout/login (or restart cosmic-comp) to load the binding."
-        fi
+        # Helper drops conflicting entries (same key+mods, same wrapper, or
+        # legacy ``voicecli-dictate-nats``) before adding the new one.
+        python3 "$REPO_DIR/scripts/_cosmic_bind.py" \
+            "$CUSTOM" "$MODS_CSV" "$KEYNAME_LOWER" "$WRAPPER_DST" \
+            "voiceCLI dictate" \
+            voicecli-dictate-nats
+        say "Wrote COSMIC binding → $CUSTOM"
+        say "→ Logout/login (or restart cosmic-comp) to load the binding."
         ;;
 
     gnome)

--- a/scripts/install-shortcut.sh
+++ b/scripts/install-shortcut.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+# install-shortcut — provision a Linux desktop shortcut for voicecli dictate.
+#
+# Idempotent. Detects the desktop environment (COSMIC / GNOME), checks Wayland
+# dictation deps, installs the wrapper to ~/.local/bin, and binds a keyboard
+# shortcut (default Ctrl+Space) to it.
+#
+# Usage:
+#   scripts/install-shortcut.sh [--de cosmic|gnome] [--key '<Ctrl>space'] \
+#                               [--bin-dir PATH] [--check-only] [--quiet]
+#
+# Configuration of NATS (URL, nkey seed) is left to the user:
+#   ~/.voicecli/voicecli.toml
+#     [nats]
+#     url = "nats://hub-host:4222"
+#     nkey_seed_path = "~/.voicecli/nkeys/voice-client.seed"
+#
+# The wrapper reads those at invoke time (env still wins over the toml).
+
+set -euo pipefail
+
+# ── Args ──────────────────────────────────────────────────────────────────────
+DE=""
+KEY=""
+BIN_DIR="$HOME/.local/bin"
+CHECK_ONLY=0
+QUIET=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --de) DE="$2"; shift 2 ;;
+        --key) KEY="$2"; shift 2 ;;
+        --bin-dir) BIN_DIR="$2"; shift 2 ;;
+        --check-only) CHECK_ONLY=1; shift ;;
+        --quiet) QUIET=1; shift ;;
+        -h|--help)
+            sed -n '2,/^set -e/p' "$0" | sed -n '/^#/p' | sed 's/^# \{0,1\}//'
+            exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+say() { [ "$QUIET" -eq 1 ] || echo "$@"; }
+warn() { echo "WARN: $*" >&2; }
+die()  { echo "ERROR: $*" >&2; exit 1; }
+
+# ── Locate voiceCLI repo ──────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+WRAPPER_SRC="$REPO_DIR/scripts/wrappers/voicecli-dictate.sh"
+[ -f "$WRAPPER_SRC" ] || die "wrapper not found at $WRAPPER_SRC"
+
+# ── DE detection ──────────────────────────────────────────────────────────────
+if [ -z "$DE" ]; then
+    case "${XDG_CURRENT_DESKTOP:-}" in
+        *COSMIC*|*cosmic*) DE="cosmic" ;;
+        *GNOME*|*gnome*)   DE="gnome"  ;;
+        *)
+            if [ -d "$HOME/.config/cosmic" ]; then DE="cosmic"
+            elif command -v gsettings >/dev/null 2>&1; then DE="gnome"
+            else die "could not detect desktop environment — pass --de cosmic|gnome"
+            fi ;;
+    esac
+fi
+[[ "$DE" =~ ^(cosmic|gnome)$ ]] || die "unsupported --de: $DE (cosmic|gnome)"
+
+# Default keybinding format depends on DE.
+if [ -z "$KEY" ]; then
+    case "$DE" in
+        cosmic) KEY="Ctrl+space" ;;
+        gnome)  KEY="<Control>space" ;;
+    esac
+fi
+
+say "Desktop: $DE"
+say "Keybinding: $KEY"
+say "Wrapper source: $WRAPPER_SRC"
+
+# ── APT deps check ────────────────────────────────────────────────────────────
+DEPS=(libnotify-bin wl-clipboard wtype gir1.2-gtklayershell-0.1)
+MISSING=()
+for p in "${DEPS[@]}"; do
+    if ! dpkg-query -W -f='${Status}\n' "$p" 2>/dev/null | grep -q "install ok installed"; then
+        MISSING+=("$p")
+    fi
+done
+if [ ${#MISSING[@]} -gt 0 ]; then
+    warn "Missing APT packages: ${MISSING[*]}"
+    warn "Install with:  sudo apt install -y ${MISSING[*]}"
+fi
+
+# ── voicecli executable check ─────────────────────────────────────────────────
+if ! command -v "$BIN_DIR/voicecli" >/dev/null 2>&1; then
+    warn "voicecli not found at $BIN_DIR/voicecli"
+    warn "Run from the voiceCLI repo:  uv sync --extra nats && ln -s \"\$PWD/.venv/bin/voicecli\" $BIN_DIR/voicecli"
+fi
+
+# ── ~/.voicecli/ existence (config + nkey) ────────────────────────────────────
+TOML="$HOME/.voicecli/voicecli.toml"
+SEED="$HOME/.voicecli/nkeys/voice-client.seed"
+[ -f "$TOML" ] || warn "missing $TOML — set [nats] url + nkey_seed_path before first use"
+[ -f "$SEED" ] || warn "missing nkey seed at $SEED — copy it from your hub-authorized machine (chmod 600)"
+
+# ── Stop here when --check-only ───────────────────────────────────────────────
+if [ "$CHECK_ONLY" -eq 1 ]; then
+    say "check-only — no changes written"
+    exit 0
+fi
+
+# ── Install wrapper ───────────────────────────────────────────────────────────
+mkdir -p "$BIN_DIR"
+WRAPPER_DST="$BIN_DIR/voicecli-dictate"
+install -m 0755 "$WRAPPER_SRC" "$WRAPPER_DST"
+say "Installed wrapper → $WRAPPER_DST"
+
+# ── Bind shortcut ─────────────────────────────────────────────────────────────
+case "$DE" in
+    cosmic)
+        CUSTOM="$HOME/.config/cosmic/com.system76.CosmicSettings.Shortcuts/v1/custom"
+        mkdir -p "$(dirname "$CUSTOM")"
+
+        # Parse "Mod1+Mod2+Key" → Cosmic's RON modifier list + lower-case key.
+        MODS=""; KEYNAME="${KEY##*+}"
+        IFS='+' read -ra parts <<< "${KEY%+*}"
+        for m in "${parts[@]}"; do
+            case "$(echo "$m" | tr '[:upper:]' '[:lower:]')" in
+                ctrl|control) MODS+="            Ctrl,\n" ;;
+                shift)        MODS+="            Shift,\n" ;;
+                alt)          MODS+="            Alt,\n" ;;
+                super|win|meta) MODS+="            Super,\n" ;;
+            esac
+        done
+        KEYNAME_LOWER="$(echo "$KEYNAME" | tr '[:upper:]' '[:lower:]')"
+
+        # Idempotent: if the file already binds this exact action, skip.
+        if [ -f "$CUSTOM" ] && grep -Fq "Spawn(\"$WRAPPER_DST\")" "$CUSTOM"; then
+            say "COSMIC binding already present → no change"
+        else
+            # Preserve any existing entries: extract everything between {…} and append ours.
+            existing=""
+            if [ -f "$CUSTOM" ] && grep -q '): Spawn(' "$CUSTOM"; then
+                existing="$(sed -n '/^{/,/^}/p' "$CUSTOM" | sed '1d;$d')"
+            fi
+            {
+                printf '{\n'
+                [ -n "$existing" ] && printf '%s\n' "$existing"
+                printf '    (\n        modifiers: [\n'
+                printf '%b' "$MODS"
+                printf '        ],\n        key: "%s",\n        description: Some("voiceCLI dictate"),\n    ): Spawn("%s"),\n}\n' \
+                    "$KEYNAME_LOWER" "$WRAPPER_DST"
+            } > "$CUSTOM"
+            say "Wrote COSMIC binding → $CUSTOM"
+            say "→ Logout/login (or restart cosmic-comp) to load the binding."
+        fi
+        ;;
+
+    gnome)
+        SCHEMA_BASE="org.gnome.settings-daemon.plugins.media-keys"
+        ENTRY_PATH="/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/voicecli-dictate/"
+        ENTRY_SCHEMA="org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:$ENTRY_PATH"
+
+        # Append entry path to the list if absent.
+        existing="$(gsettings get $SCHEMA_BASE custom-keybindings 2>/dev/null || echo '@as []')"
+        if [[ "$existing" != *"$ENTRY_PATH"* ]]; then
+            new_list="$(printf '%s' "$existing" | sed "s|]\$|, '$ENTRY_PATH']|" | sed "s|@as \[\]|['$ENTRY_PATH']|")"
+            gsettings set $SCHEMA_BASE custom-keybindings "$new_list"
+        fi
+        gsettings set "$ENTRY_SCHEMA" name "VoiceCLI Dictate"
+        gsettings set "$ENTRY_SCHEMA" command "$WRAPPER_DST"
+        gsettings set "$ENTRY_SCHEMA" binding "$KEY"
+        say "Wrote GNOME binding via gsettings"
+        ;;
+esac
+
+say "Done."

--- a/scripts/wrappers/voicecli-dictate.sh
+++ b/scripts/wrappers/voicecli-dictate.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# voicecli-dictate — desktop-shortcut entrypoint for `voicecli dictate nats`.
+#
+# Designed to be invoked by a compositor `Spawn(...)` action (COSMIC custom
+# shortcut, GNOME custom keybinding, etc.) where `PATH` is minimal and no
+# interactive shell startup runs. The wrapper:
+#   1. extends PATH so notify-send / wl-copy / wtype / xdotool resolve;
+#   2. asks voicecli for the resolved NATS host:port and does a 2-s TCP probe,
+#      surfacing a desktop notification if the hub is unreachable instead of
+#      blocking on the CLI's 60-s timeout;
+#   3. delegates to `voicecli dictate nats`. NATS_URL / NATS_NKEY_SEED_PATH /
+#      mode are resolved by voicecli itself (env > `[nats]` table in
+#      voicecli.toml).
+#
+# Overridable via env:
+#   VOICECLI_BIN   — path to the voicecli executable (default: ~/.local/bin/voicecli)
+#   VOICECLI_MODE  — STT mode passed as --mode (default: unset, uses voicecli's default)
+
+set -u
+
+# Ensure GUI helpers (notify-send, wl-copy, wtype) are reachable under
+# minimal Spawn() PATHs.
+export PATH="/usr/local/bin:/usr/bin:/bin:$HOME/.local/bin:${PATH:-}"
+
+VOICECLI_BIN="${VOICECLI_BIN:-$HOME/.local/bin/voicecli}"
+
+# Pre-flight: 2-second TCP probe so the user gets immediate feedback when
+# the hub is unreachable (offline, Tailscale down, hub off). Skipped when
+# the URL cannot be resolved — voicecli will print a clearer error than us.
+if command -v "$VOICECLI_BIN" >/dev/null 2>&1 && command -v nc >/dev/null 2>&1; then
+    host_port="$("$VOICECLI_BIN" dictate nats-host 2>/dev/null || true)"
+    if [ -n "$host_port" ]; then
+        host="${host_port%:*}"
+        port="${host_port##*:}"
+        if ! nc -z -w2 "$host" "$port" 2>/dev/null; then
+            if command -v notify-send >/dev/null 2>&1; then
+                notify-send -u critical -r 1 "VoiceCLI" "Hub injoignable: $host_port"
+            fi
+            exit 69 # EX_UNAVAILABLE
+        fi
+    fi
+fi
+
+cmd=( "$VOICECLI_BIN" dictate nats )
+if [ -n "${VOICECLI_MODE:-}" ]; then
+    cmd+=( --mode "$VOICECLI_MODE" )
+fi
+exec "${cmd[@]}"

--- a/src/voicecli/cli_dictate.py
+++ b/src/voicecli/cli_dictate.py
@@ -336,6 +336,30 @@ def dictate_history(
 # ── NATS-based dictation ────────────────────────────────────────────────────────
 
 
+@dictate_app.command("nats-host")
+def dictate_nats_host() -> None:
+    """Print the resolved NATS ``host:port`` (env > ``[nats]`` toml).
+
+    Used by the dictate wrapper to do a fast TCP probe before invoking the
+    blocking ``dictate nats`` toggle. Prints nothing and exits 0 when no URL
+    is configured (the wrapper then skips the pre-flight check).
+    """
+    import os
+    from urllib.parse import urlparse
+
+    from voicecli.config import apply_nats_env_from_config
+
+    apply_nats_env_from_config()
+    url = os.environ.get("NATS_URL", "").strip()
+    if not url:
+        return
+    parsed = urlparse(url)
+    if not parsed.hostname:
+        return
+    port = parsed.port or 4222
+    typer.echo(f"{parsed.hostname}:{port}")
+
+
 @dictate_app.command("nats")
 def dictate_nats(
     paste: Annotated[
@@ -360,17 +384,26 @@ def dictate_nats(
     First call: starts recording in the background.
     Second call: stops recording, transcribes via NATS, copies to clipboard.
 
-    Requires NATS_URL environment variable. Optionally NATS_NKEY_SEED_PATH for auth.
+    Reads ``NATS_URL`` (and optional ``NATS_NKEY_SEED_PATH``) from the
+    environment, falling back to the ``[nats]`` table in ``voicecli.toml``
+    (keys: ``url``, ``nkey_seed_path``).
     """
     import asyncio
 
     from voicecli.clipboard import write_clipboard
-    from voicecli.config import load_config, load_vocab, vocab_to_prompt
+    from voicecli.config import (
+        apply_nats_env_from_config,
+        load_config,
+        load_vocab,
+        vocab_to_prompt,
+    )
     from voicecli.nats_recorder import is_recording, start_recording, stop_recording
     from voicecli.nats_stt_client import transcribe_via_nats
     from voicecli.stt_client import notify
     from voicecli.stt_modes import get_mode
     from voicecli.ui_sounds import play_ui_sound
+
+    apply_nats_env_from_config()
 
     # Resolve mode (prompt + task + optional language) like the socket daemon does.
     mode_prompt: Optional[str] = None

--- a/src/voicecli/cli_nats.py
+++ b/src/voicecli/cli_nats.py
@@ -49,10 +49,12 @@ def nats_serve_tts(
     """Subscribe to lyra.voice.tts.request and reply with synthesized audio."""
     import asyncio
 
-    from voicecli.config import load_nats_config
+    from voicecli.config import apply_nats_env_from_config, load_nats_config
     from voicecli.model_registry import model_registry
     from voicecli.nats.config import _probe_socket_daemon, _resolve_engine
     from voicecli.nats.tts_adapter import TtsNatsAdapter
+
+    apply_nats_env_from_config()
 
     logging.basicConfig(level=logging.INFO)
     log = logging.getLogger("voicecli.nats-serve.tts")
@@ -116,8 +118,11 @@ def nats_serve_stt(
     """Subscribe to lyra.voice.stt.request and reply with transcription."""
     import asyncio
 
+    from voicecli.config import apply_nats_env_from_config
     from voicecli.nats.config import _probe_socket_daemon, _resolve_model
     from voicecli.nats.stt_adapter import SttNatsAdapter
+
+    apply_nats_env_from_config()
 
     logging.basicConfig(level=logging.INFO)
     log = logging.getLogger("voicecli.nats-serve.stt")

--- a/src/voicecli/config.py
+++ b/src/voicecli/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 import tomllib
 from typing import Any, Callable
@@ -217,6 +218,8 @@ def load_tts_config(config: Path | None = None) -> dict:
 
 _KNOWN_NATS: dict[str, type] = {
     "max_cached_engines": int,
+    "url": str,
+    "nkey_seed_path": str,
 }
 
 
@@ -224,13 +227,14 @@ def load_nats_config(config: Path | None = None) -> dict:
     """Load the ``[nats]`` table from voicecli.toml.
 
     Returns ``{"max_cached_engines": 2}`` when no config is found or the table
-    is absent. Value is clamped to [1, 5].
+    is absent. ``max_cached_engines`` is clamped to [1, 5]. ``url`` and
+    ``nkey_seed_path`` are returned only when set, with ``~`` expanded.
 
     Args:
         config: Explicit path to a toml file. If provided, skips the walk-up search.
     """
     path = config if config is not None else _find_config()
-    result: dict[str, int] = {"max_cached_engines": 2}
+    result: dict[str, Any] = {"max_cached_engines": 2}
     if path is None:
         return result
     with open(path, "rb") as f:
@@ -244,4 +248,24 @@ def load_nats_config(config: Path | None = None) -> dict:
                 pass
     # Clamp max_cached_engines to [1, 5]
     result["max_cached_engines"] = max(1, min(5, result.get("max_cached_engines", 2)))
+    if isinstance(result.get("nkey_seed_path"), str):
+        result["nkey_seed_path"] = os.path.expanduser(result["nkey_seed_path"])
     return result
+
+
+def apply_nats_env_from_config(config: Path | None = None) -> None:
+    """Populate ``NATS_URL`` / ``NATS_NKEY_SEED_PATH`` from ``[nats]`` toml when env is unset.
+
+    Env vars take precedence (so wrappers, CI, and ad-hoc overrides keep
+    working). Call this at the entrypoint of any NATS-using command before code
+    reads ``os.environ``.
+    """
+    cfg = load_nats_config(config)
+    if "NATS_URL" not in os.environ:
+        url = cfg.get("url")
+        if isinstance(url, str) and url:
+            os.environ["NATS_URL"] = url
+    if "NATS_NKEY_SEED_PATH" not in os.environ:
+        seed = cfg.get("nkey_seed_path")
+        if isinstance(seed, str) and seed:
+            os.environ["NATS_NKEY_SEED_PATH"] = seed

--- a/src/voicecli/nats_recorder.py
+++ b/src/voicecli/nats_recorder.py
@@ -201,7 +201,7 @@ def _handle_stop_signal(signum: int, frame: Any) -> None:
 
 _stop_event: threading.Event | None = None
 
-PROGRESS_TICK_SECONDS = 1.5
+PROGRESS_TICK_SECONDS = 1.0
 
 
 def _progress_notify_loop(stop_event: threading.Event, started_at: float) -> None:

--- a/src/voicecli/nats_recorder.py
+++ b/src/voicecli/nats_recorder.py
@@ -201,6 +201,22 @@ def _handle_stop_signal(signum: int, frame: Any) -> None:
 
 _stop_event: threading.Event | None = None
 
+PROGRESS_TICK_SECONDS = 1.5
+
+
+def _progress_notify_loop(stop_event: threading.Event, started_at: float) -> None:
+    """Refresh the desktop notification every PROGRESS_TICK_SECONDS with elapsed seconds.
+
+    Runs as a daemon thread inside the recorder subprocess so the user sees
+    "Recording... 3s" → "Recording... 5s" updates while speaking, instead of
+    a static "Recording..." until they stop. Exits when ``stop_event`` is set.
+    """
+    from voicecli.stt_client import notify
+
+    while not stop_event.wait(PROGRESS_TICK_SECONDS):
+        elapsed = int(time.monotonic() - started_at)
+        notify(f"Recording... {elapsed}s", timeout=0)
+
 
 def run_recorder_main(*, model: str, language: str | None = None) -> None:
     """Main function for background recorder process.
@@ -227,6 +243,14 @@ def run_recorder_main(*, model: str, language: str | None = None) -> None:
         "language": language,
     }
     STATE_FILE.write_text(json.dumps(state))
+
+    # Progress notifier — refreshes the bubble while the user speaks.
+    progress_thread = threading.Thread(
+        target=_progress_notify_loop,
+        args=(_stop_event, time.monotonic()),
+        daemon=True,
+    )
+    progress_thread.start()
 
     try:
         # Record until signal

--- a/src/voicecli/stt_client.py
+++ b/src/voicecli/stt_client.py
@@ -78,8 +78,13 @@ def send_next_mode() -> dict:
 # ── Desktop notifications ─────────────────────────────────────────────────────
 
 # Stable replace-ID so each notify-send call replaces the previous bubble.
-# notify-send -r requires an integer; we derive one from the app name.
-_NOTIFY_REPLACE_ID = str(abs(hash("voicecli-dictate")) % 65536)
+# notify-send -r requires an integer. The dictate flow spans three Python
+# processes (foreground dictate, background recorder, second dictate-press
+# transcribing call), and Python's hash() is randomized per process via
+# PYTHONHASHSEED, so a hash-based ID would yield three different values and
+# three stacked bubbles instead of one updating in place. Hard-coded here to
+# guarantee cross-process stability.
+_NOTIFY_REPLACE_ID = "9173"
 
 
 def notify(body: str, timeout: int = 3000) -> None:

--- a/tests/test_cosmic_bind.py
+++ b/tests/test_cosmic_bind.py
@@ -1,0 +1,120 @@
+"""Tests for scripts/_cosmic_bind.py — idempotent COSMIC binding writer."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+HELPER = REPO / "scripts" / "_cosmic_bind.py"
+
+
+def run(custom: Path, mods: str, key: str, wrapper: str, *legacy: str) -> None:
+    subprocess.run(
+        [
+            sys.executable,
+            str(HELPER),
+            str(custom),
+            mods,
+            key,
+            wrapper,
+            "voiceCLI dictate",
+            *legacy,
+        ],
+        check=True,
+    )
+
+
+def test_creates_file_when_missing(tmp_path: Path) -> None:
+    custom = tmp_path / "custom"
+    run(custom, "Ctrl", "space", "/usr/local/bin/voicecli-dictate")
+    out = custom.read_text()
+    assert out.startswith("{\n")
+    assert out.endswith("}\n")
+    assert 'key: "space"' in out
+    assert 'Spawn("/usr/local/bin/voicecli-dictate")' in out
+    assert "Ctrl,\n" in out
+
+
+def test_preserves_unrelated_existing_entries(tmp_path: Path) -> None:
+    custom = tmp_path / "custom"
+    custom.write_text(
+        "{\n"
+        "    (\n"
+        "        modifiers: [\n"
+        "            Super,\n"
+        "            Shift,\n"
+        "        ],\n"
+        '        key: "s",\n'
+        '        description: Some("screenshot"),\n'
+        '    ): Spawn("cosmic-screenshot"),\n'
+        "}\n"
+    )
+    run(custom, "Ctrl", "space", "/home/me/.local/bin/voicecli-dictate")
+    out = custom.read_text()
+    # Original screenshot entry preserved.
+    assert 'Spawn("cosmic-screenshot")' in out
+    # New entry added.
+    assert 'Spawn("/home/me/.local/bin/voicecli-dictate")' in out
+
+
+def test_drops_same_key_modifiers_conflict(tmp_path: Path) -> None:
+    custom = tmp_path / "custom"
+    custom.write_text(
+        "{\n"
+        "    (\n"
+        "        modifiers: [\n"
+        "            Ctrl,\n"
+        "        ],\n"
+        '        key: "space",\n'
+        '        description: Some("old binding"),\n'
+        '    ): Spawn("/old/path"),\n'
+        "}\n"
+    )
+    run(custom, "Ctrl", "space", "/new/path")
+    out = custom.read_text()
+    assert "/old/path" not in out
+    assert 'Spawn("/new/path")' in out
+    # Exactly one (… ): Spawn(…) entry remains.
+    assert out.count("): Spawn(") == 1
+
+
+def test_drops_legacy_basename(tmp_path: Path) -> None:
+    """Legacy `voicecli-dictate-nats` entry on a *different* key still gets cleaned up."""
+    custom = tmp_path / "custom"
+    custom.write_text(
+        "{\n"
+        "    (\n"
+        "        modifiers: [\n"
+        "            Alt,\n"
+        "        ],\n"
+        '        key: "space",\n'
+        '        description: Some("old voiceCLI"),\n'
+        '    ): Spawn("/home/me/.local/bin/voicecli-dictate-nats"),\n'
+        "}\n"
+    )
+    run(custom, "Ctrl", "space", "/home/me/.local/bin/voicecli-dictate", "voicecli-dictate-nats")
+    out = custom.read_text()
+    assert "voicecli-dictate-nats" not in out
+    assert 'Spawn("/home/me/.local/bin/voicecli-dictate")' in out
+
+
+def test_idempotent_when_already_present(tmp_path: Path) -> None:
+    custom = tmp_path / "custom"
+    run(custom, "Ctrl", "space", "/wrap")
+    first = custom.read_text()
+    run(custom, "Ctrl", "space", "/wrap")
+    second = custom.read_text()
+    assert first == second
+    assert second.count("): Spawn(") == 1
+
+
+def test_drops_same_wrapper_target_with_different_key(tmp_path: Path) -> None:
+    """Re-running with a new keybinding for the same wrapper rebinds — no orphan."""
+    custom = tmp_path / "custom"
+    run(custom, "Ctrl", "space", "/wrap")
+    run(custom, "Alt", "F9", "/wrap")
+    out = custom.read_text()
+    assert out.count("): Spawn(") == 1
+    assert 'key: "F9"' in out

--- a/tests/test_nats_config_fallback.py
+++ b/tests/test_nats_config_fallback.py
@@ -1,0 +1,105 @@
+"""Tests for the [nats] table fallback (url + nkey_seed_path).
+
+Covers:
+  * load_nats_config — reads url and nkey_seed_path from voicecli.toml,
+    expands ~ in nkey_seed_path, leaves keys absent when not set.
+  * apply_nats_env_from_config — env vars take precedence over the toml
+    values; absent env vars get populated from the toml.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from voicecli.config import apply_nats_env_from_config, load_nats_config
+
+
+def _write_toml(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "voicecli.toml"
+    p.write_text(body)
+    return p
+
+
+class TestLoadNatsConfig:
+    def test_url_and_seed_path_loaded(self, tmp_path: Path) -> None:
+        cfg = _write_toml(
+            tmp_path,
+            '[nats]\nurl = "nats://hub:4222"\nnkey_seed_path = "/abs/seed"\n',
+        )
+        result = load_nats_config(cfg)
+        assert result["url"] == "nats://hub:4222"
+        assert result["nkey_seed_path"] == "/abs/seed"
+
+    def test_seed_path_tilde_expansion(self, tmp_path: Path) -> None:
+        cfg = _write_toml(tmp_path, '[nats]\nnkey_seed_path = "~/.voicecli/nkeys/seed"\n')
+        result = load_nats_config(cfg)
+        assert result["nkey_seed_path"] == str(Path.home() / ".voicecli/nkeys/seed")
+
+    def test_keys_absent_when_unset(self, tmp_path: Path) -> None:
+        cfg = _write_toml(tmp_path, "[nats]\n")
+        result = load_nats_config(cfg)
+        assert "url" not in result
+        assert "nkey_seed_path" not in result
+        # default still applied for the existing key
+        assert result["max_cached_engines"] == 2
+
+    def test_no_config_file_returns_default(self, tmp_path: Path) -> None:
+        # Pass an explicit non-existent path? load_nats_config takes None too.
+        result = load_nats_config(None)
+        # When walk-up finds nothing, max_cached_engines defaults to 2; url/seed absent.
+        assert result["max_cached_engines"] == 2
+        assert "url" not in result or result.get("url") is None or result.get("url") == ""
+
+
+class TestApplyNatsEnvFromConfig:
+    def test_toml_populates_unset_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("NATS_URL", raising=False)
+        monkeypatch.delenv("NATS_NKEY_SEED_PATH", raising=False)
+        cfg = _write_toml(
+            tmp_path,
+            '[nats]\nurl = "nats://hub:4222"\nnkey_seed_path = "/abs/seed"\n',
+        )
+        apply_nats_env_from_config(cfg)
+        import os
+
+        assert os.environ.get("NATS_URL") == "nats://hub:4222"
+        assert os.environ.get("NATS_NKEY_SEED_PATH") == "/abs/seed"
+
+    def test_env_takes_priority_over_toml(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NATS_URL", "nats://override:4222")
+        monkeypatch.setenv("NATS_NKEY_SEED_PATH", "/env/seed")
+        cfg = _write_toml(
+            tmp_path,
+            '[nats]\nurl = "nats://hub:4222"\nnkey_seed_path = "/toml/seed"\n',
+        )
+        apply_nats_env_from_config(cfg)
+        import os
+
+        assert os.environ["NATS_URL"] == "nats://override:4222"
+        assert os.environ["NATS_NKEY_SEED_PATH"] == "/env/seed"
+
+    def test_no_toml_keys_no_env_changes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("NATS_URL", raising=False)
+        cfg = _write_toml(tmp_path, "[nats]\nmax_cached_engines = 3\n")
+        apply_nats_env_from_config(cfg)
+        import os
+
+        assert "NATS_URL" not in os.environ
+
+    def test_tilde_expanded_when_setting_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("NATS_NKEY_SEED_PATH", raising=False)
+        cfg = _write_toml(tmp_path, '[nats]\nnkey_seed_path = "~/.voicecli/nkeys/seed"\n')
+        apply_nats_env_from_config(cfg)
+        import os
+
+        assert os.environ["NATS_NKEY_SEED_PATH"] == str(Path.home() / ".voicecli/nkeys/seed")

--- a/tests/test_nats_config_fallback.py
+++ b/tests/test_nats_config_fallback.py
@@ -45,12 +45,14 @@ class TestLoadNatsConfig:
         # default still applied for the existing key
         assert result["max_cached_engines"] == 2
 
-    def test_no_config_file_returns_default(self, tmp_path: Path) -> None:
-        # Pass an explicit non-existent path? load_nats_config takes None too.
+    def test_no_config_file_returns_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Force _find_config to find nothing so the test isn't perturbed by a
+        # real voicecli.toml in the dev's home directory.
+        monkeypatch.setattr("voicecli.config._find_config", lambda: None)
         result = load_nats_config(None)
-        # When walk-up finds nothing, max_cached_engines defaults to 2; url/seed absent.
         assert result["max_cached_engines"] == 2
-        assert "url" not in result or result.get("url") is None or result.get("url") == ""
+        assert "url" not in result
+        assert "nkey_seed_path" not in result
 
 
 class TestApplyNatsEnvFromConfig:

--- a/tests/test_notify_replace_id.py
+++ b/tests/test_notify_replace_id.py
@@ -1,0 +1,43 @@
+"""Regression test for the notify-send replace-ID.
+
+The dictate flow notifies from three distinct Python processes (foreground
+``dictate nats``, background ``nats_recorder`` subprocess, and the second
+``dictate nats`` press that transcribes). Python's ``hash()`` is salted per
+process via PYTHONHASHSEED, so a hash-derived replace-ID would produce three
+different IDs and stack three bubbles instead of replacing in place. Lock
+the constant down.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_replace_id_is_stable_across_processes() -> None:
+    script = textwrap.dedent(
+        """
+        from voicecli.stt_client import _NOTIFY_REPLACE_ID
+        print(_NOTIFY_REPLACE_ID)
+        """
+    )
+    a = subprocess.run(
+        [sys.executable, "-c", script], check=True, capture_output=True, text=True
+    ).stdout.strip()
+    b = subprocess.run(
+        [sys.executable, "-c", script], check=True, capture_output=True, text=True
+    ).stdout.strip()
+    assert a == b, (
+        f"_NOTIFY_REPLACE_ID must be deterministic across processes "
+        f"(got {a!r} and {b!r}) — otherwise the dictate notification stacks."
+    )
+
+
+def test_replace_id_is_a_positive_integer_string() -> None:
+    from voicecli.stt_client import _NOTIFY_REPLACE_ID
+
+    # notify-send -r requires an integer.
+    n = int(_NOTIFY_REPLACE_ID)
+    assert n > 0
+    assert n < 2**31  # safely fits any libnotify version

--- a/tests/test_recording_progress.py
+++ b/tests/test_recording_progress.py
@@ -1,0 +1,69 @@
+"""Tests for the progress-notification loop in nats_recorder.
+
+The recorder subprocess refreshes the desktop notification every ~1.5s with
+elapsed seconds so the user sees the recording is alive. Verifies that the
+loop emits the expected text format and exits promptly when the stop event
+is set.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import patch
+
+from voicecli import nats_recorder
+
+
+def test_progress_loop_emits_elapsed_seconds(monkeypatch) -> None:
+    # Tick fast so the test stays well under 1s.
+    monkeypatch.setattr(nats_recorder, "PROGRESS_TICK_SECONDS", 0.05)
+    stop_event = threading.Event()
+    started = time.monotonic()
+
+    captured: list[str] = []
+
+    def fake_notify(body: str, timeout: int = 3000) -> None:
+        captured.append(body)
+
+    with patch("voicecli.stt_client.notify", side_effect=fake_notify):
+        t = threading.Thread(
+            target=nats_recorder._progress_notify_loop,
+            args=(stop_event, started),
+            daemon=True,
+        )
+        t.start()
+        # Let at least 2 ticks happen.
+        time.sleep(0.18)
+        stop_event.set()
+        t.join(timeout=1.0)
+
+    assert not t.is_alive(), "thread should exit shortly after stop_event.set()"
+    assert len(captured) >= 2, f"expected ≥2 ticks, got {captured!r}"
+    for body in captured:
+        assert body.startswith("Recording... ") and body.endswith("s")
+
+
+def test_progress_loop_exits_immediately_when_already_stopped(monkeypatch) -> None:
+    """If stop_event is set before the loop starts, no notifications fire."""
+    monkeypatch.setattr(nats_recorder, "PROGRESS_TICK_SECONDS", 0.05)
+    stop_event = threading.Event()
+    stop_event.set()
+    started = time.monotonic()
+
+    captured: list[str] = []
+
+    def fake_notify(body: str, timeout: int = 3000) -> None:
+        captured.append(body)
+
+    with patch("voicecli.stt_client.notify", side_effect=fake_notify):
+        t = threading.Thread(
+            target=nats_recorder._progress_notify_loop,
+            args=(stop_event, started),
+            daemon=True,
+        )
+        t.start()
+        t.join(timeout=1.0)
+
+    assert not t.is_alive()
+    assert captured == []


### PR DESCRIPTION
## Why

Provisioning a Linux client to dictate over a remote NATS hub (laptop, secondary workstation) currently means:
1. `apt install` 4 Wayland deps,
2. `uv sync --extra nats` (otherwise `roxabi-contracts` is missing and the CLI crashes at runtime),
3. write a shell wrapper that exports `NATS_URL` + `NATS_NKEY_SEED_PATH`,
4. write a COSMIC RON file or `gsettings` keybinding by hand.

Eight steps, all undocumented, none idempotent. Discovered the cost the hard way debugging a laptop where `--mode default` had silently broken because the wrapper hadn't been re-edited after a CLI refactor.

## What

One-command provisioning for the dictation shortcut, plus the small CLI plumbing it requires.

### CLI

- `[nats] url` and `[nats] nkey_seed_path` are now read from `voicecli.toml`. Env vars still win.
- `voicecli dictate nats-host` prints the resolved `host:port` (used by the wrapper's pre-flight TCP probe).
- `dictate nats`, `nats serve tts`, `nats serve stt` all call the new `apply_nats_env_from_config()` helper at entry.

### Scripts

- `scripts/wrappers/voicecli-dictate.sh` — versioned shortcut entrypoint. Explicit PATH (COSMIC `Spawn()` PATHs are minimal), 2-s TCP pre-flight, desktop notification on hub unreachable.
- `scripts/install-shortcut.sh` — idempotent installer. Auto-detects COSMIC/GNOME, validates APT deps, installs the wrapper, writes the keybinding. `--check-only` for dry-run.

### Docs

- New "Linux client provisioning (NATS hub setup)" section in `docs/dictation-setup.md` with the env override matrix.

## Test plan

- [x] `make lint` — all checks pass
- [x] `pytest tests/test_nats_config_fallback.py` — 8 new tests (env precedence, toml population, tilde expansion, absent-keys)
- [x] `pytest --ignore=tests/e2e --ignore=tests/test_overlay.py` — 434 passed, 3 skipped (test_overlay is broken on staging, unrelated)
- [x] `bash -n` on both shell scripts
- [x] `./scripts/install-shortcut.sh --check-only` on a real COSMIC machine reports correctly
- [ ] (manual) Run installer on laptop, reboot, press Ctrl+Space, dictate

## Out of scope (follow-up)

- NATS-aware `voicecli dictate cancel` and `next-mode` so the installer can bind 3 shortcuts on pure-client machines. Today both commands talk to the local socket daemon.
- Removing the temporary debug log added to the laptop's wrapper during incident debug — done at re-provisioning time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)