### PR TITLE
fix(samples): validate WAV header after recording

### DIFF
--- a/src/voicecli/samples.py
+++ b/src/voicecli/samples.py
@@ -272,6 +272,13 @@ def record_sample(name: str, duration: float = 10.0, samplerate: int = 24000) ->
     if not dest.exists() or dest.stat().st_size == 0:
         raise RuntimeError("parecord produced no output — check microphone and PulseAudio")
 
+    import soundfile
+
+    try:
+        soundfile.info(dest)
+    except soundfile.LibsndfileError as e:
+        raise RuntimeError("recorded file appears corrupt — check microphone and PulseAudio") from e
+
     _chime("stop")
     print(f"Saved recording to {dest}")
     return dest

--- a/src/voicecli/samples.py
+++ b/src/voicecli/samples.py
@@ -244,6 +244,7 @@ def record_sample(name: str, duration: float = 10.0, samplerate: int = 24000) ->
     ensure_dir()
     if not name.endswith(".wav"):
         name = f"{name}.wav"
+    name = Path(name).name
     dest = SAMPLES_DIR / name
 
     _chime("start")
@@ -277,6 +278,7 @@ def record_sample(name: str, duration: float = 10.0, samplerate: int = 24000) ->
     try:
         soundfile.info(dest)
     except soundfile.LibsndfileError as e:
+        dest.unlink(missing_ok=True)
         raise RuntimeError("recorded file appears corrupt — check microphone and PulseAudio") from e
 
     _chime("stop")

--- a/tests/test_samples_record.py
+++ b/tests/test_samples_record.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-import soundfile
 
 from voicecli.samples import _check_tool, record_sample
 
@@ -19,6 +18,7 @@ def samples_env(tmp_path, monkeypatch):
     samples_dir = tmp_path / "samples"
     samples_dir.mkdir()
     monkeypatch.setattr("voicecli.samples.SAMPLES_DIR", samples_dir)
+    # soundfile.info patched so happy-path fixtures need not produce real WAV bytes
     monkeypatch.setattr("soundfile.info", lambda _: None)
     return samples_dir
 
@@ -76,7 +76,8 @@ class TestRecordSample:
 
     @patch("voicecli.samples.shutil.which", return_value="/usr/bin/parecord")
     def test_corrupt_wav_raises(self, _mock_which, samples_env, mock_chime, monkeypatch):
-        # Arrange — parecord writes non-empty bytes but soundfile.info rejects them
+        import soundfile
+
         def fake_run(cmd, *, timeout):
             Path(cmd[-1]).write_bytes(b"not a wav")
             raise subprocess.TimeoutExpired(cmd, timeout)
@@ -85,14 +86,12 @@ class TestRecordSample:
             raise soundfile.LibsndfileError("fake", 0)
 
         monkeypatch.setattr("soundfile.info", corrupt_info)
+        dest = samples_env / "corrupt.wav"
 
         with patch("voicecli.samples.subprocess.run", side_effect=fake_run):
             with pytest.raises(RuntimeError, match="recorded file appears corrupt"):
-                dest = samples_env / "corrupt.wav"
                 record_sample("corrupt", duration=2.0)
 
-        # dest must be cleaned up after corrupt-file detection
-        dest = samples_env / "corrupt.wav"
         assert not dest.exists()
 
     @patch("voicecli.samples.shutil.which", return_value=None)

--- a/tests/test_samples_record.py
+++ b/tests/test_samples_record.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import soundfile
 
 from voicecli.samples import _check_tool, record_sample
 
@@ -18,6 +19,7 @@ def samples_env(tmp_path, monkeypatch):
     samples_dir = tmp_path / "samples"
     samples_dir.mkdir()
     monkeypatch.setattr("voicecli.samples.SAMPLES_DIR", samples_dir)
+    monkeypatch.setattr("soundfile.info", lambda _: None)
     return samples_dir
 
 
@@ -71,6 +73,27 @@ class TestRecordSample:
             result = record_sample("noext", duration=2.0)
 
         assert result.name == "noext.wav"
+
+    @patch("voicecli.samples.shutil.which", return_value="/usr/bin/parecord")
+    def test_corrupt_wav_raises(self, _mock_which, samples_env, mock_chime, monkeypatch):
+        # Arrange — parecord writes non-empty bytes but soundfile.info rejects them
+        def fake_run(cmd, *, timeout):
+            Path(cmd[-1]).write_bytes(b"not a wav")
+            raise subprocess.TimeoutExpired(cmd, timeout)
+
+        def corrupt_info(_):
+            raise soundfile.LibsndfileError("fake", 0)
+
+        monkeypatch.setattr("soundfile.info", corrupt_info)
+
+        with patch("voicecli.samples.subprocess.run", side_effect=fake_run):
+            with pytest.raises(RuntimeError, match="recorded file appears corrupt"):
+                dest = samples_env / "corrupt.wav"
+                record_sample("corrupt", duration=2.0)
+
+        # dest must be cleaned up after corrupt-file detection
+        dest = samples_env / "corrupt.wav"
+        assert not dest.exists()
 
     @patch("voicecli.samples.shutil.which", return_value=None)
     def test_missing_parecord_raises(self, _mock_which):


### PR DESCRIPTION
## Summary
- After `parecord` returns, call `soundfile.info(dest)` to verify the WAV header.
- On `LibsndfileError`, raise `RuntimeError("recorded file appears corrupt — check microphone and PulseAudio")`.

Catches the case where `parecord` is killed mid-write (OOM, SIGKILL, mic unplug, PulseAudio crash) — the file exists with non-zero size but the header is truncated, so today `record_sample` returns success and the failure surfaces later as an opaque playback error.

Deferred from #141 review (C:75%).

Closes #143

## Test plan
- [ ] Normal recording → succeeds, no behavior change
- [ ] Truncate a recorded WAV mid-header (e.g. `head -c 20 sample.wav > broken.wav`) → `soundfile.info` raises → user sees the new error