### PR TITLE
refactor(tests): drop `_mod.api` mutation in `_patch_transcribe` helper

### DIFF
--- a/tests/nats/test_stt_adapter.py
+++ b/tests/nats/test_stt_adapter.py
@@ -1,8 +1,8 @@
 """Tests for SttNatsAdapter (issue #44 T4).
 
 Mirrors the structure of test_tts_adapter.py.  All 16 cases exercise the
-real SttNatsAdapter code — api.transcribe is patched at the import site
-(voicecli.nats.stt_adapter.api) so actual coverage runs through the adapter.
+real SttNatsAdapter code — api.transcribe is patched at the source module
+(voicecli.api.transcribe) so actual coverage runs through the adapter.
 """
 
 from __future__ import annotations
@@ -128,23 +128,21 @@ def _patch_transcribe(
     *,
     side_effect=None,
 ):
-    """Context manager: patch api.transcribe at the adapter import site.
+    """Context manager: patch api.transcribe at the source module.
 
     Pass either ``mock_result`` (return_value) or ``side_effect`` — not both.
     Passing both raises TypeError to prevent silent mis-configuration.
+
+    _stt_runner.py does ``from voicecli import api`` (module reference, not a
+    name copy), so ``api.transcribe`` resolves through ``voicecli.api``.
+    Patching the source directly is sufficient and avoids the order-dependent
+    ``_mod.api = _api`` namespace mutation.
     """
     if mock_result is not None and side_effect is not None:
         raise TypeError("_patch_transcribe: pass either mock_result or side_effect, not both")
-    # The deferred `from voicecli import api` inside _run_transcription binds
-    # `api` on the stt_adapter module namespace.  We force that binding here
-    # so patch.object can reach it.
-    import voicecli.nats.stt_adapter as _mod
-    import voicecli.api as _api  # noqa: F401 — materialises the attribute
-
-    _mod.api = _api  # type: ignore[attr-defined]
     if side_effect is not None:
-        return patch("voicecli.nats.stt_adapter.api.transcribe", side_effect=side_effect)
-    return patch("voicecli.nats.stt_adapter.api.transcribe", return_value=mock_result)
+        return patch("voicecli.api.transcribe", side_effect=side_effect)
+    return patch("voicecli.api.transcribe", return_value=mock_result)
 
 
 def _patch_scoped_path(tmp_path: Path):
@@ -318,13 +316,8 @@ class TestSttNatsAdapter:
         _setup_adapter(adapter, msg)
         payload = _valid_payload(request_id="req-boom")
 
-        import voicecli.nats.stt_adapter as _mod
-        import voicecli.api as _api  # noqa: F401
-
-        _mod.api = _api  # type: ignore[attr-defined]
-
         with patch(
-            "voicecli.nats.stt_adapter.api.transcribe",
+            "voicecli.api.transcribe",
             side_effect=RuntimeError("model OOM"),
         ):
             with _patch_scoped_path(tmp_path):
@@ -473,13 +466,8 @@ class TestSttNatsAdapter:
         payload2 = _valid_payload(request_id="req-no-overrides")
         # payload2 has NO override fields
 
-        import voicecli.nats.stt_adapter as _mod
-        import voicecli.api as _api  # noqa: F401
-
-        _mod.api = _api  # type: ignore[attr-defined]
-
         with patch(
-            "voicecli.nats.stt_adapter.api.transcribe",
+            "voicecli.api.transcribe",
             return_value=_fake_result(),
         ) as mock_transcribe:
             with _patch_scoped_path(tmp_path):
@@ -560,14 +548,9 @@ class TestSttNatsAdapter:
 
         adapter = _make_adapter(max_concurrent=1)
 
-        import voicecli.nats.stt_adapter as _mod
-        import voicecli.api as _api  # noqa: F401
-
-        _mod.api = _api  # type: ignore[attr-defined]
-
         async def _run() -> None:
             with patch(
-                "voicecli.nats.stt_adapter.api.transcribe",
+                "voicecli.api.transcribe",
                 side_effect=_slow_transcribe,
             ):
                 with patch(
@@ -648,11 +631,6 @@ class TestSttNatsAdapter:
             observed["mode"] = _stat.S_IMODE(os.stat(audio_path).st_mode)
             return _fake_result()
 
-        import voicecli.api as _api  # noqa: F401
-        import voicecli.nats.stt_adapter as _mod
-
-        _mod.api = _api  # type: ignore[attr-defined]
-
         original_write_bytes = Path.write_bytes
 
         def _write_bytes_leak(self: Path, data: bytes) -> int:
@@ -663,7 +641,7 @@ class TestSttNatsAdapter:
             return result
 
         with (
-            patch("voicecli.nats.stt_adapter.api.transcribe", side_effect=_sniff_transcribe),
+            patch("voicecli.api.transcribe", side_effect=_sniff_transcribe),
             patch.object(Path, "write_bytes", _write_bytes_leak),
             _patch_scoped_path(tmp_path),
         ):
@@ -707,13 +685,8 @@ class TestSttNatsAdapter:
         payload = _valid_payload(request_id=request_id)
         temp_file = tmp_path / f"{request_id}.wav"
 
-        import voicecli.nats.stt_adapter as _mod
-        import voicecli.api as _api  # noqa: F401
-
-        _mod.api = _api  # type: ignore[attr-defined]
-
         with patch(
-            "voicecli.nats.stt_adapter.api.transcribe",
+            "voicecli.api.transcribe",
             side_effect=RuntimeError("kaboom"),
         ):
             with _patch_scoped_path(tmp_path):
@@ -773,13 +746,8 @@ class TestSttNatsAdapter:
                     segments=[{"start": 0.0, "end": 1.5, "text": "ok"}],
                 )
 
-            import voicecli.nats.stt_adapter as _mod
-            import voicecli.api as _api  # noqa: F401
-
-            _mod.api = _api  # type: ignore[attr-defined]
-
             with patch(
-                "voicecli.nats.stt_adapter.api.transcribe",
+                "voicecli.api.transcribe",
                 side_effect=_gated_transcribe,
             ):
                 with patch(


### PR DESCRIPTION
## Summary
- Patch `voicecli.api.transcribe` directly instead of forcing an `api` attribute onto the `voicecli.nats.stt_adapter` module namespace. `_stt_runner.py:108` does `from voicecli import api` (module reference, not name copy), so `api.transcribe` already resolves through the source module — no namespace mutation needed.
- Drops the order-dependent `_mod.api = _api` smell flagged in #148; removes 6 inline duplicates of the mutation block at individual test callsites.
- Net: -32 lines, no behavioral change. `_patch_transcribe` keeps its `mock_result` / `side_effect` dual mode + TypeError guard.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #148: refactor(tests): drop `_mod.api = _api` mutation in `_patch_transcribe` helper | Open |
| Implementation | 1 commit on `worktree-148-drop-mod-api-mutation` | Complete |
| Verification | Lint ✅ Format ✅ Tests ✅ (26/26 in `tests/nats/test_stt_adapter.py`) | Passed |

## Test Plan
- [x] `uv run pytest tests/nats/test_stt_adapter.py -q` — 26 passed
- [x] `uv run ruff check tests/nats/test_stt_adapter.py` — clean
- [x] `uv run ruff format --check tests/nats/test_stt_adapter.py` — already formatted
- [ ] Reviewer: confirm `test_value_error_from_transcribe_yields_param_validation_failed` still exercises the `ParamValidationError → param_validation_failed` path via `side_effect`

Closes #148

---
Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`