### PR TITLE
fix(nats): adopt wait_ready=False worker opt-out

### DIFF
--- a/src/voicecli/adapters/nats/synthesize_adapter.py
+++ b/src/voicecli/adapters/nats/synthesize_adapter.py
@@ -75,6 +75,7 @@ class TtsNatsAdapter(NatsAdapterBase):
             heartbeat_subject=HEARTBEAT_SUBJECT,
             heartbeat_interval=heartbeat_interval,
             inbox_prefix="_inbox.voice-tts",
+            wait_ready=False,  # worker semantics — see NatsAdapterBase docstring
         )
         self.default_engine = default_engine
         self.max_concurrent = max_concurrent

--- a/src/voicecli/adapters/nats/transcribe_adapter.py
+++ b/src/voicecli/adapters/nats/transcribe_adapter.py
@@ -83,6 +83,7 @@ class SttNatsAdapter(NatsAdapterBase):
             heartbeat_interval=heartbeat_interval,
             drain_timeout=drain_timeout,
             inbox_prefix="_inbox.voice-stt",
+            wait_ready=False,  # worker semantics — see NatsAdapterBase docstring
         )
         self.default_model = default_model
         self.max_concurrent = max_concurrent

--- a/uv.lock
+++ b/uv.lock
@@ -1696,7 +1696,7 @@ wheels = [
 [[package]]
 name = "roxabi-contracts"
 version = "0.4.0"
-source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-contracts&branch=staging#e99cc6adec4097929bdab9afed0c15c2bbf23724" }
+source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-contracts&branch=staging#7a21ce8e1199147c083e5f65b0ed35cfddf6e892" }
 dependencies = [
     { name = "pydantic" },
 ]
@@ -1704,7 +1704,7 @@ dependencies = [
 [[package]]
 name = "roxabi-nats"
 version = "0.4.1"
-source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-nats&branch=staging#e99cc6adec4097929bdab9afed0c15c2bbf23724" }
+source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-nats&branch=staging#7a21ce8e1199147c083e5f65b0ed35cfddf6e892" }
 dependencies = [
     { name = "nats-py" },
     { name = "nkeys" },
@@ -2204,7 +2204,6 @@ all = [
     { name = "nkeys" },
     { name = "nvidia-ml-py" },
     { name = "qwen-tts" },
-    { name = "roxabi-contracts" },
     { name = "roxabi-nats" },
     { name = "torch" },
     { name = "torchaudio" },
@@ -2216,7 +2215,6 @@ nats = [
     { name = "nats-py" },
     { name = "nkeys" },
     { name = "nvidia-ml-py" },
-    { name = "roxabi-contracts" },
     { name = "roxabi-nats" },
 ]
 overlay = [
@@ -2265,7 +2263,6 @@ requires-dist = [
     { name = "pygobject", marker = "extra == 'overlay'", specifier = ">=3.42" },
     { name = "pynput", marker = "extra == 'hotkey'", specifier = ">=1.7" },
     { name = "qwen-tts", marker = "extra == 'tts'" },
-    { name = "roxabi-contracts", marker = "extra == 'nats'", git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-contracts&branch=staging" },
     { name = "roxabi-nats", marker = "extra == 'nats'", git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-nats&branch=staging" },
     { name = "scipy", marker = "extra == 'voxtral'" },
     { name = "soundfile" },


### PR DESCRIPTION
## Summary

- Pass `wait_ready=False` to `NatsAdapterBase.__init__` in both `SttNatsAdapter` and `TtsNatsAdapter` — they are workers (respond to RPC requests) and don't need the JetStream KV readiness probe.
- Refresh `uv.lock` to pull `roxabi-nats==0.4.1` (introduces the `wait_ready` opt-out) from `lyra@7a21ce8e`.

Closes the voice-side leg of the cross-repo cascade tied to lyra issue #1147.

## Why

Before this change, the worker startup logged `$JS.API.STREAM.INFO.kv_lyra-state` ACL denial warnings — workers don't hold those grants because they don't need to read hub state. `roxabi-nats` v0.4.1 (Roxabi/lyra#1285) exposes a `wait_ready: bool = True` kwarg specifically so worker-class subclasses can opt out of the readiness probe cleanly.

## Test plan

- [x] `uv run pytest tests/nats/` — 156 passed
- [ ] Boot worker against an ACL-enforced NATS in staging; verify no `$JS.API.>` denials

## References

- Roxabi/lyra#1147 (root issue)
- Roxabi/lyra#1285 (the v0.4.1 PR, merge commit `7a21ce8e`)