### PR TITLE
feat(quadlet): switch HF cache to host bind-mount

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,5 @@ Production hosts can run voiceCLI as a Podman container managed by systemd via Q
 | `deploy/entrypoint.sh` | Mode selector (`tts` \| `stt`) → `nats-serve` |
 | `deploy/quadlet/voicecli-tts.container` | TTS satellite systemd unit |
 | `deploy/quadlet/voicecli-stt.container` | STT satellite systemd unit |
-| `deploy/quadlet/voicecli-models.volume` | Shared HuggingFace cache volume |
 
 Full Quadlet setup: [`docs/NATS-SERVE.md#quadlet-deployment-podman--systemd`](docs/NATS-SERVE.md#quadlet-deployment-podman--systemd).

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,8 @@ deploy:  ## pull latest staging images on $(DEPLOY_HOST) and restart voicecli-tt
 
 quadlet-install:  ## install Quadlet units to $(QUADLET_DIR) + reload
 	@mkdir -p "$(QUADLET_DIR)"
+	@mkdir -p "$(HOME)/.cache/huggingface" "$(HOME)/.cache/voicecli"
 	@rm -f "$(QUADLET_DIR)"/voicecli*.{network,volume,container}
-	@cp deploy/quadlet/voicecli-models.volume        "$(QUADLET_DIR)/voicecli-models.volume"
 	@cp deploy/quadlet/voicecli-stt.container        "$(QUADLET_DIR)/voicecli-stt.container"
 	@cp deploy/quadlet/voicecli-tts.container        "$(QUADLET_DIR)/voicecli-tts.container"
 	@systemctl --user daemon-reload

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ deploy:  ## pull latest staging images on $(DEPLOY_HOST) and restart voicecli-tt
 quadlet-install:  ## install Quadlet units to $(QUADLET_DIR) + reload
 	@mkdir -p "$(QUADLET_DIR)"
 	@mkdir -p "$(HOME)/.cache/huggingface" "$(HOME)/.cache/voicecli"
-	@rm -f "$(QUADLET_DIR)"/voicecli*.{network,volume,container}
+	@rm -f "$(QUADLET_DIR)"/voicecli*.{network,container}
 	@cp deploy/quadlet/voicecli-stt.container        "$(QUADLET_DIR)/voicecli-stt.container"
 	@cp deploy/quadlet/voicecli-tts.container        "$(QUADLET_DIR)/voicecli-tts.container"
 	@systemctl --user daemon-reload

--- a/deploy/quadlet/voicecli-models.volume
+++ b/deploy/quadlet/voicecli-models.volume
@@ -1,2 +1,0 @@
-[Volume]
-VolumeName=voicecli-models

--- a/deploy/quadlet/voicecli-stt.container
+++ b/deploy/quadlet/voicecli-stt.container
@@ -10,8 +10,9 @@ Image=ghcr.io/roxabi/voicecli-stt:staging
 Label=io.containers.autoupdate=registry
 ContainerName=voicecli-stt
 Network=roxabi.network
-Volume=voicecli-models:/home/voicecli/.cache/huggingface
-Volume=voicecli-models:/home/voicecli/.cache/voicecli
+Volume=%h/.cache/huggingface:/home/voicecli/.cache/huggingface
+Volume=%h/.cache/voicecli:/home/voicecli/.cache/voicecli
+Environment=HF_HOME=/home/voicecli/.cache/huggingface
 Exec=stt
 Secret=voicecli-nats-stt,type=mount,target=/home/voicecli/.config/voicecli/nkeys/seed.seed,mode=0400,uid=1501,gid=1501
 AddDevice=nvidia.com/gpu=all

--- a/deploy/quadlet/voicecli-tts.container
+++ b/deploy/quadlet/voicecli-tts.container
@@ -10,8 +10,9 @@ Image=ghcr.io/roxabi/voicecli-tts:staging
 Label=io.containers.autoupdate=registry
 ContainerName=voicecli-tts
 Network=roxabi.network
-Volume=voicecli-models:/home/voicecli/.cache/huggingface
-Volume=voicecli-models:/home/voicecli/.cache/voicecli
+Volume=%h/.cache/huggingface:/home/voicecli/.cache/huggingface
+Volume=%h/.cache/voicecli:/home/voicecli/.cache/voicecli
+Environment=HF_HOME=/home/voicecli/.cache/huggingface
 Secret=voicecli-nats-tts,type=mount,target=/home/voicecli/.config/voicecli/nkeys/seed.seed,mode=0400,uid=1501,gid=1501
 AddDevice=nvidia.com/gpu=all
 # UID 1501 fixed in image; anchor mapping so secret mount (uid=1501) is readable inside.

--- a/docs/DEPLOYMENT-quadlet.md
+++ b/docs/DEPLOYMENT-quadlet.md
@@ -15,7 +15,6 @@ deploy library and image-naming convention come from ADR-055 D1 / D5.
 
 | Unit | Purpose |
 |---|---|
-| `voicecli-models.volume`   | Named volume for HuggingFace + voicecli model caches |
 | `voicecli-stt.container`   | STT worker — subscribes to `lyra.voice.stt.request` queue group (namespace matches Lyra's ACL matrix) |
 | `voicecli-tts.container`   | TTS worker — subscribes to `lyra.voice.tts.request` queue group |
 
@@ -53,7 +52,8 @@ Canonical ACLs are in Lyra's `deploy/nats/acl-matrix.json` under the
 
 ```bash
 make quadlet-install
-# copies deploy/quadlet/*.{container,volume} → ~/.config/containers/systemd/
+# creates ~/.cache/huggingface and ~/.cache/voicecli bind-mount sources if absent
+# copies deploy/quadlet/*.container → ~/.config/containers/systemd/
 # reloads systemd --user
 ```
 

--- a/docs/NATS-SERVE.md
+++ b/docs/NATS-SERVE.md
@@ -544,7 +544,6 @@ of containerized NATS satellites without manual podman commands.
 |---|---|
 | `voicecli-tts.container` | TTS satellite as a systemd service |
 | `voicecli-stt.container` | STT satellite as a systemd service |
-| `voicecli-models.volume` | Shared volume for HuggingFace model cache |
 
 ### Installation
 
@@ -553,7 +552,7 @@ of containerized NATS satellites without manual podman commands.
 
    ```bash
    mkdir -p ~/.config/containers/systemd
-   cp deploy/quadlet/*.container deploy/quadlet/*.volume ~/.config/containers/systemd/
+   cp deploy/quadlet/*.container ~/.config/containers/systemd/
    ```
 
 2. Create the NKey seed secrets (one per satellite):
@@ -586,23 +585,13 @@ of containerized NATS satellites without manual podman commands.
 ### Pre-seeding models
 
 On first run, each satellite downloads its model (~7 GB for TTS, ~2 GB for STT).
-To avoid a cold-start delay on production hosts, pre-seed the shared volume:
+Model cache is stored in `~/.cache/huggingface/` on the host (bind-mounted into the
+container). If the host already has models cached (e.g. from a dev box with 120G of
+HF cache), the satellites reuse them immediately with no extra steps.
 
-```bash
-# Build the image locally first
-podman build -t voicecli:latest .
-
-# Run a one-shot container to populate the cache
-podman run --rm -v voicecli-models:/root/.cache/huggingface voicecli:latest uv run voicecli --help
-# The TTS/STT model will download on first synthesis/transcription
-```
-
-Alternatively, copy an existing cache from another host:
-
-```bash
-podman volume create voicecli-models
-podman run --rm -v voicecli-models:/data alpine tar xf - -C /data < cache.tar
-```
+On a fresh production host, models auto-download on first use via `from_pretrained()`.
+No pre-seeding step is required — re-download (~15G on M₁) is the chosen migration
+strategy.
 
 ### Resource considerations
 


### PR DESCRIPTION
## Motivation

The `voicecli-models` named Podman volume was an opaque silo:

- Dev box (`M₂`) already has 120G in `~/.cache/huggingface` from direct use; the named volume duplicated it at no benefit.
- Cache was not host-inspectable or purgeable without `podman volume inspect`.
- Two separate patterns existed for HF cache vs app cache.

## What changed

- `voicecli-tts.container` and `voicecli-stt.container`: replaced `Volume=voicecli-models:…` (×2) with bind-mounts via `%h/.cache/{huggingface,voicecli}` and added `Environment=HF_HOME=…` for explicitness.
- `voicecli-models.volume`: deleted (both consumers gone).
- `docs/NATS-SERVE.md`: removed the volume row from the Files table, dropped the `*.volume` from the install `cp` command, replaced the pre-seeding section with a note that models auto-download from `~/.cache/huggingface`.

## uid/gid handling

`UserNS=keep-id:uid=1501,gid=1501` is already in both containers — writes from container uid 1501 map to host uid 1000 (mickael). Bind-mount writes Just Work. No `:z` label needed — neither M₁ (Ubuntu Server) nor M₂ (Pop!_OS) runs SELinux.

## Migration note for M₁ prod

On first `systemctl --user start voicecli-tts / voicecli-stt` after this deploy, HuggingFace will re-download models into `~/.cache/huggingface/` (~15G). No rsync required — `from_pretrained()` handles it, and NATS workers have no cold-start SLA.

Closes #160