### PR TITLE
fix(recorder): log stderr + wrapper notifies on stale .venv

### DIFF
--- a/artifacts/analyses/pr164-review-triage-consensus.mdx
+++ b/artifacts/analyses/pr164-review-triage-consensus.mdx
@@ -1,0 +1,91 @@
+---
+title: "PR #164 Review Triage — Expert Consensus"
+issue: null
+pr: 164
+status: consensus-reached
+date: 2026-05-21
+panel: architect, devops, product-lead
+confidence: high
+---
+
+## Problem
+
+PR #164 (recorder-error-surfacing) is a 138-line debugging-affordance fix: redirect recorder stderr from `/dev/null` to `~/.local/state/voicecli/recorder.log`, plus a wrapper notification when the log shows `ImportError`/`ModuleNotFoundError`. Multi-domain code review surfaced **14 findings** (4 tagged blockers, 5 suggestions, 5 nitpicks). Question: which to ACCEPT (fix now), DEFER (follow-up), or REJECT (disagree)?
+
+## Panel
+
+| Role | Focus |
+|---|---|
+| architect | scope discipline, maintainability |
+| devops | ops realism, signal semantics, disk usage |
+| product-lead | velocity, ceremony, solo-author context |
+
+## Consensus
+
+**Apply only:** #1, #6, #12. Defer everything else.
+
+### Triage table
+
+| # | Finding | Verdict | Vote (A/D/P) | Rationale |
+|---|---|---|---|---|
+| 1 | False-positive notify on exit 69 (network) | **ACCEPT** | A/A/A | Unanimous. Bug introduced by this PR — false alarm flips the PR's own purpose. 1-line guard: skip log-check when `EXIT_CODE -eq 69`. |
+| 2 | Happy-path test missing | DEFER | D/D/R | Test scaffolding doubles diff for a 47-line shim. Solo dev = author = reviewer. |
+| 3 | `PermissionError` branch untested | DEFER | D/D/R | Cold path on single-user dev box; ¬user-visible regression risk. |
+| 4 | Append-mode unverified | DEFER | D/D/R | `"a"` is a stdlib contract; pinning belongs in a dedicated log-contract suite. |
+| 5 | ExitStack file-handle lifecycle | REJECT | R/R/D | Current code correct; refactor is style-only, ¬correctness. |
+| 6 | `except Exception` → `except OSError` | **ACCEPT** | A/A/D | 1-word change, real value (narrows catch, lets programmer errors surface). |
+| 7 | `exec` → call signal semantics | DEFER | R/D/D | COSMIC Spawn() has no controlling TTY → SIGINT path doesn't apply. SIGTERM still propagates. |
+| 8 | `recorder.log` 0o644 traceback exposure | DEFER | A/D/D | Architect dissents (legit `secret-leak` class), but file lives in user-owned `~/.local/state/`; single-user threat model. |
+| 9 | Unbounded log growth | DEFER | D/D/D | Unanimous defer. Normal ops append 0 bytes (subprocess exits 0). Rotation matters only under crash-loop; ¬today's risk. |
+| 10 | `mkdir(mode=0o700)` no-op on existing | DEFER | D/R/D | Benign confusion; parent dir already user-owned. |
+| 11 | Path duplicated bash↔Python | DEFER | D/D/D | Unanimous defer. Real maintenance smell but ¬safety issue; fix when log path moves (XDG migration). |
+| 12 | `notify-send -u critical` overkill | **ACCEPT** | A/A/D | 1-word change (`critical` → `normal`). `critical` doesn't auto-dismiss; trains user to ignore alerts. |
+| 13 | Monkey-patch brittleness | DEFER | D/R/D | Acceptable for unit speed; revisit if symbols rename. |
+| 14 | Bash untested (add comment) | DEFER | A/D/R | 1-1-1 split → conservative defer. |
+
+### Rationale (consensus)
+
+- **ACCEPT only changes that are trivial (≤ 1 line each) AND advance the PR's stated goal** of making future regressions visible.
+- **#1 is the only finding all three agents flag as a must-fix blocker.** It's a bug introduced by this PR (spurious notification on network failure), not a pre-existing concern. Cannot defer.
+- **#6 and #12 are unanimous in two of three reviewers** and each costs <5 minutes; opportunistic accept.
+- **Test coverage (#2–4) defers because** the testing investment is disproportionate to the file size (47-line debugging shim, no production traffic, author = reviewer). A future test PR can cover the success branch + the `PermissionError` fallback + the append-mode contract together.
+- **Log rotation (#9) defers because** real-world growth is negligible (one append per recorder spawn, only on failure). Revisit when log size becomes observable.
+- **Path drift (#11) defers because** the two paths (bash + Python) are unlikely to diverge before someone touches both intentionally; a cross-file comment is sufficient and not blocking.
+
+### Trade-offs
+
+1. **Correctness vs scope on tests** — accepting #2-4 would double the diff and add brittle mocking. Defer trades verification confidence for reviewability.
+2. **Security purity vs threat realism on #8** — architect wants `0o600` perms (1 line); devops + product-lead say no real threat on single-user dev box. Majority wins; the fix is cheap enough that it'd be a low-cost stretch — but principle of "don't expand scope" overrides.
+3. **Ship-velocity vs review purity** — most findings are real but orthogonal to the PR's job. Filing follow-ups for each is more tracking overhead than the fixes are worth.
+
+## Alternatives
+
+| Option | Proposed by | Rejected because |
+|---|---|---|
+| Accept all 14 | implicit baseline | Bloats a 138-line PR to ~400 lines; mixes fixes with debugging-affordance change |
+| Accept #1 only, defer everything else | strict-minimum reading | Misses #6 and #12 which are trivially correct fixes already validated by two reviewers |
+| Reject all tests as ceremony | product-lead alone | Skill rubric tags them blockers; deferring (≠ rejecting) preserves the audit trail |
+
+## Dissent
+
+- **Architect dissents on #8** (file perms): considers it a legitimate `secret-leak` class. Recorded; majority overrides on threat-model grounds (single-user dev box).
+- **Product-lead dissents on tests #2-4** (advocates REJECT): considers them ceremony for a debugging shim. Recorded; defer (not reject) preserves traceability without expanding this PR.
+- **Devops dissents on #10, #13** (advocates REJECT): treats them as not-actionable nitpicks. Recorded; defer keeps options open.
+
+None of the dissents block consensus on the ACCEPT set (#1, #6, #12).
+
+## Implementation Notes
+
+For `/fix` to apply:
+
+1. **#1** — `scripts/wrappers/voicecli-dictate.sh` lines 80-88: add `[ "$EXIT_CODE" -eq 69 ] && exit 69` (or equivalent guard) before the log-check block. Verify: previous TCP-probe-fail path still exits 69 cleanly without firing the stale-venv notification.
+
+2. **#6** — `src/voicecli/nats_recorder.py:108`: change `except Exception as e:` → `except OSError as e:`. Verify: `uv run pytest tests/test_nats_recorder_log_path.py -x` still green; `uv run pyright src/voicecli/nats_recorder.py` still clean.
+
+3. **#12** — `scripts/wrappers/voicecli-dictate.sh:85`: change `notify-send -u critical` → `notify-send -u normal`. (Note: the TCP-probe notification at line 66 stays `-u critical` — different severity.)
+
+All three fixes are ≤ 1 line each. Single follow-up commit on the same worktree.
+
+## Next
+
+`/fix` — apply the 3 accepted findings. After fix lands, the PR is ready to merge.

--- a/scripts/wrappers/voicecli-dictate.sh
+++ b/scripts/wrappers/voicecli-dictate.sh
@@ -77,11 +77,14 @@ fi
 "${cmd[@]}"
 EXIT_CODE=$?
 
-if [ "$EXIT_CODE" -ne 0 ]; then
+# Exit 69 = TCP probe failed (hub unreachable, already notified above). Skip
+# the log check so a stale ImportError from a prior run doesn't surface a
+# spurious "stale .venv" notification on top of an unrelated network failure.
+if [ "$EXIT_CODE" -ne 0 ] && [ "$EXIT_CODE" -ne 69 ]; then
     LOG="$HOME/.local/state/voicecli/recorder.log"
     if [ -f "$LOG" ] && command -v notify-send >/dev/null 2>&1; then
         if tail -n 50 "$LOG" | grep -qE "ImportError|ModuleNotFoundError"; then
-            notify-send -u critical "voicecli-dictate" \
+            notify-send -u normal "voicecli-dictate" \
                 "Recorder failed: stale .venv. Run: cd ~/projects/voiceCLI && uv sync --extra nats"
         fi
     fi

--- a/scripts/wrappers/voicecli-dictate.sh
+++ b/scripts/wrappers/voicecli-dictate.sh
@@ -74,4 +74,17 @@ cmd=( "$VOICECLI_BIN" dictate nats )
 if [ -n "${VOICECLI_MODE:-}" ]; then
     cmd+=( --mode "$VOICECLI_MODE" )
 fi
-exec "${cmd[@]}"
+"${cmd[@]}"
+EXIT_CODE=$?
+
+if [ "$EXIT_CODE" -ne 0 ]; then
+    LOG="$HOME/.local/state/voicecli/recorder.log"
+    if [ -f "$LOG" ] && command -v notify-send >/dev/null 2>&1; then
+        if tail -n 50 "$LOG" | grep -q "ImportError"; then
+            notify-send -u critical "voicecli-dictate" \
+                "Recorder failed: stale .venv. Run: cd ~/projects/voiceCLI && uv sync --extra nats"
+        fi
+    fi
+fi
+
+exit "$EXIT_CODE"

--- a/scripts/wrappers/voicecli-dictate.sh
+++ b/scripts/wrappers/voicecli-dictate.sh
@@ -80,7 +80,7 @@ EXIT_CODE=$?
 if [ "$EXIT_CODE" -ne 0 ]; then
     LOG="$HOME/.local/state/voicecli/recorder.log"
     if [ -f "$LOG" ] && command -v notify-send >/dev/null 2>&1; then
-        if tail -n 50 "$LOG" | grep -q "ImportError"; then
+        if tail -n 50 "$LOG" | grep -qE "ImportError|ModuleNotFoundError"; then
             notify-send -u critical "voicecli-dictate" \
                 "Recorder failed: stale .venv. Run: cd ~/projects/voiceCLI && uv sync --extra nats"
         fi

--- a/src/voicecli/nats_recorder.py
+++ b/src/voicecli/nats_recorder.py
@@ -31,6 +31,9 @@ STATE_FILE = STATE_DIR / "nats-recording.json"
 WAV_FILE = STATE_DIR / "nats-recording.wav"
 WAV_PARTIAL = STATE_DIR / "nats-recording.wav.partial"
 
+LOG_DIR = Path.home() / ".local" / "state" / "voicecli"
+RECORDER_LOG = LOG_DIR / "recorder.log"
+
 
 def _ensure_state_dir() -> None:
     STATE_DIR.mkdir(parents=True, exist_ok=True)
@@ -98,17 +101,25 @@ def start_recording(
     if language:
         cmd.extend(["--language", language])
 
+    log_fh = None
     try:
-        # Use start_new_session to detach from terminal
+        LOG_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
+        log_fh = RECORDER_LOG.open("a")
+    except Exception as e:
+        log.error("Failed to open recorder log: %s", e)
+    try:
         proc = subprocess.Popen(
             cmd,
             start_new_session=True,
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stderr=log_fh if log_fh is not None else subprocess.DEVNULL,
         )
     except Exception as e:
         log.error("Failed to spawn recorder: %s", e)
         return {"error": f"cannot start recorder: {e}"}
+    finally:
+        if log_fh is not None:
+            log_fh.close()
 
     # Give it a moment to write state file
     for _ in range(10):
@@ -117,8 +128,8 @@ def start_recording(
             break
 
     if not STATE_FILE.exists():
-        log.error("Recorder did not write state file")
-        return {"error": "recorder failed to start"}
+        log.error("Recorder did not write state file — see %s", RECORDER_LOG)
+        return {"error": f"recorder failed to start — see {RECORDER_LOG}"}
 
     return {"status": "recording", "pid": proc.pid}
 

--- a/src/voicecli/nats_recorder.py
+++ b/src/voicecli/nats_recorder.py
@@ -203,7 +203,7 @@ def _record_until_signal(stop_event: threading.Event) -> bytes:
         return _record_parecord(stop_event)
 
 
-def _handle_stop_signal(signum: int, frame: Any) -> None:
+def _handle_stop_signal(_signum: int, _frame: Any) -> None:
     """Signal handler to stop recording."""
     global _stop_event
     if _stop_event:

--- a/src/voicecli/nats_recorder.py
+++ b/src/voicecli/nats_recorder.py
@@ -105,7 +105,7 @@ def start_recording(
     try:
         LOG_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
         log_fh = RECORDER_LOG.open("a")
-    except Exception as e:
+    except OSError as e:
         log.error("Failed to open recorder log: %s", e)
     try:
         proc = subprocess.Popen(

--- a/tests/test_nats_recorder_log_path.py
+++ b/tests/test_nats_recorder_log_path.py
@@ -12,8 +12,6 @@ import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from voicecli import nats_recorder
 
 

--- a/tests/test_nats_recorder_log_path.py
+++ b/tests/test_nats_recorder_log_path.py
@@ -1,0 +1,49 @@
+"""Test that start_recording surfaces the log path when the recorder fails to start.
+
+Covers the branch where the spawned subprocess exits immediately (e.g. due to an
+ImportError) and never writes the state file within the poll window.  The returned
+error dict must include the RECORDER_LOG path so the caller — and the wrapper —
+can surface it to the user.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from voicecli import nats_recorder
+
+
+def test_start_recording_error_includes_log_path(tmp_path: Path) -> None:
+    """When the recorder subprocess fails to write the state file, the error
+    message must include the RECORDER_LOG path."""
+
+    # Arrange: patch STATE_DIR so no real filesystem state is touched, and
+    # override the poll loop to skip sleeping by making STATE_FILE never appear.
+    fake_state_dir = tmp_path / "share" / "voicecli"
+    fake_state_file = fake_state_dir / "nats-recording.json"
+    fake_log_dir = tmp_path / "state" / "voicecli"
+
+    fake_proc = MagicMock(spec=subprocess.Popen)
+    fake_proc.pid = 99999
+
+    with (
+        patch.object(nats_recorder, "STATE_DIR", fake_state_dir),
+        patch.object(nats_recorder, "STATE_FILE", fake_state_file),
+        patch.object(nats_recorder, "LOG_DIR", fake_log_dir),
+        patch.object(nats_recorder, "RECORDER_LOG", fake_log_dir / "recorder.log"),
+        patch.object(nats_recorder, "is_recording", return_value=False),
+        patch("subprocess.Popen", return_value=fake_proc),
+        patch("time.sleep"),  # skip the 100 ms poll sleeps
+    ):
+        # Act: state file never gets written → poll loop exhausts → error
+        result = nats_recorder.start_recording(model="large-v3-turbo")
+
+    # Assert
+    assert "error" in result
+    assert str(fake_log_dir / "recorder.log") in result["error"], (
+        f"Expected log path in error message, got: {result['error']!r}"
+    )


### PR DESCRIPTION
## Summary
- Recorder subprocess stderr now appends to `~/.local/state/voicecli/recorder.log` (previously discarded via `subprocess.DEVNULL` → failures were invisible)
- `voicecli-dictate` wrapper checks the log on non-zero exit, fires `notify-send` if it sees `ImportError`/`ModuleNotFoundError` — hints at `uv sync --extra nats`

## Lifecycle

| Phase | Artifact | Status |
|---|---|---|
| Implementation | 2 commits on `recorder-error-surfacing` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (1 new) | Passed |

## Test Plan
- [ ] Inject `import nonexistent_module_xyz` into `stt_daemon.py:21`, fire wrapper → log gets traceback, notification fires
- [ ] Same with `from os import nonexistent_xyz` (covers `ImportError` vs `ModuleNotFoundError`)
- [ ] Happy path: wrapper fires recording, 2nd press transcribes — no traceback, no notification

Context: discovered while debugging a Ctrl+Space failure caused by a stale `.venv` (uv.lock had been bumped but `uv sync` hadn't run). Fix was a single `uv sync` but the failure was invisible because the recorder's stderr was muted.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) via \`/pr\`