### PR TITLE
refactor(nats): typed ingress — SttRequest + TtsRequest + Segment

### DIFF
--- a/src/voicecli/adapters/nats/_audio_utils.py
+++ b/src/voicecli/adapters/nats/_audio_utils.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import logging
 
+from voicecli.runtime.transcribe import Segment
+
 log = logging.getLogger(__name__)
 
 # 25 MB base64 → ~18.75 MB decoded audio (~10 min at 8 kHz, ~2 min at 64 kHz).
@@ -27,22 +29,11 @@ _MIME_TO_EXT: dict[str, str] = {
 }
 
 
-def _duration_from_segments(segments: list[dict]) -> float:
-    """End timestamp of the last whisper segment; 0.0 on missing/non-numeric `end`."""
+def _duration_from_segments(segments: list[Segment]) -> float:
+    """End timestamp of the last whisper segment; 0.0 on empty list."""
     if not segments:
         return 0.0
-    last = segments[-1]
-    if "end" not in last:
-        log.warning("segment_missing_end_key", extra={"segments_count": len(segments)})
-        return 0.0
-    try:
-        return float(last["end"])
-    except (TypeError, ValueError):
-        log.warning(
-            "segment_end_not_numeric",
-            extra={"segments_count": len(segments), "end_type": type(last["end"]).__name__},
-        )
-        return 0.0
+    return segments[-1].end
 
 
 def _ext_from_mime(mime_type: str | None) -> str:

--- a/src/voicecli/adapters/nats/_validation.py
+++ b/src/voicecli/adapters/nats/_validation.py
@@ -27,6 +27,12 @@ from typing import Callable
 
 from roxabi_nats._validate import validate_nats_token
 
+from voicecli.adapters.nats.requests import (
+    MalformedRequestError,
+    SttRequest,
+    TtsRequest,
+)
+
 log = logging.getLogger(__name__)
 
 # request_id pattern: 1–128 alphanumeric/underscore/hyphen chars.
@@ -67,10 +73,12 @@ class SttValidationOutcome:
         overrides: Dict of optional transcription parameters supplied in the
             payload (None values excluded).  Present only on success; always
             a dict (possibly empty) — never ``None`` on success.
+        request: The successfully parsed ``SttRequest``, present only on success.
     """
 
     error_code: str | None
     overrides: dict | None = None
+    request: SttRequest | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -102,11 +110,9 @@ def validate_tts_request(
         ``TtsValidationOutcome`` with ``error_code=None`` on success, or a
         non-None ``error_code`` string on the first failing check.
     """
-    from voicecli.adapters.nats.tts_adapter import TtsRequest
-
     try:
         req = TtsRequest.from_payload(payload)
-    except (ValueError, TypeError, KeyError):
+    except (MalformedRequestError, TypeError, KeyError):
         return _MALFORMED
 
     if not _REQUEST_ID_RE.match(req.request_id):
@@ -171,14 +177,12 @@ def validate_stt_request(payload: dict) -> SttValidationOutcome:
         dict (possibly empty) on success, or ``error_code="malformed_request"``
         on the first failing check.
     """
-    from voicecli.adapters.nats.stt_adapter import SttRequest
-
     try:
         req = SttRequest.from_payload(payload)
-    except (ValueError, TypeError, KeyError):
+    except (MalformedRequestError, TypeError, KeyError):
         return _STT_MALFORMED
 
     if not _REQUEST_ID_RE.match(req.request_id):
         return _STT_MALFORMED
 
-    return SttValidationOutcome(error_code=None, overrides=req.to_overrides())
+    return SttValidationOutcome(error_code=None, overrides=req.to_overrides(), request=req)

--- a/src/voicecli/adapters/nats/_validation.py
+++ b/src/voicecli/adapters/nats/_validation.py
@@ -62,6 +62,7 @@ class TtsValidationOutcome:
     error_code: str | None
     cleaned_text: str | None = None
     engine: str | None = None
+    request: TtsRequest | None = None
 
 
 @dataclass(frozen=True)
@@ -153,7 +154,7 @@ def validate_tts_request(
     if not engine_available(engine):
         return TtsValidationOutcome(error_code="engine_unavailable")
 
-    return TtsValidationOutcome(error_code=None, cleaned_text=text, engine=engine)
+    return TtsValidationOutcome(error_code=None, cleaned_text=text, engine=engine, request=req)
 
 
 # ---------------------------------------------------------------------------

--- a/src/voicecli/adapters/nats/_validation.py
+++ b/src/voicecli/adapters/nats/_validation.py
@@ -88,14 +88,9 @@ def validate_tts_request(
 ) -> TtsValidationOutcome:
     """Validate a decoded TTS NATS request payload.
 
-    Checks (in order):
-    1. ``request_id`` present and non-empty.
-    2. ``request_id`` matches ``^[A-Za-z0-9_-]{1,128}$``.
-    3. ``text`` present and a ``str`` instance.
-    4. Newline normalisation: ``\\r\\n`` → space, ``\\r`` → space, ``\\n`` → space.
-    5. ``text`` non-empty after ``.strip()``.
-    6. Engine token valid (``validate_nats_token``).
-    7. Engine available per ``engine_available`` callback.
+    Delegates typed construction to ``TtsRequest.from_payload()``; performs
+    semantic validation (newline stripping, engine token, availability) on the
+    typed result.
 
     Args:
         payload: Decoded JSON dict from the NATS message.
@@ -107,51 +102,48 @@ def validate_tts_request(
         ``TtsValidationOutcome`` with ``error_code=None`` on success, or a
         non-None ``error_code`` string on the first failing check.
     """
-    # 1. request_id presence
-    request_id = payload.get("request_id", "")
-    if not request_id:
+    from voicecli.adapters.nats.tts_adapter import TtsRequest
+
+    try:
+        req = TtsRequest.from_payload(payload)
+    except (ValueError, TypeError, KeyError):
         return _MALFORMED
 
-    # 2. request_id format
-    if not _REQUEST_ID_RE.match(request_id):
+    if not _REQUEST_ID_RE.match(req.request_id):
         return _MALFORMED
 
-    # 3. text presence and type
-    text = payload.get("text")
-    if not isinstance(text, str) or not text:
-        return _MALFORMED
-
-    # 4. Newline normalisation — \r\n first to avoid double-space
+    # Newline normalisation — \r\n first to avoid double-space
+    text = req.text
     _newline_count = text.count("\n") + text.count("\r")
     if _newline_count:
         text = text.replace("\r\n", " ").replace("\r", " ").replace("\n", " ")
         log.debug(
             "text_newlines_stripped",
             extra={
-                "request_id": payload.get("request_id", ""),
+                "request_id": req.request_id,
                 "removed": _newline_count,
             },
         )
 
-    # 5. Non-empty after strip
+    # Non-empty after strip
     if not text.strip():
         log.warning(
             "text_empty_after_strip",
             extra={
-                "request_id": payload.get("request_id", ""),
-                "original_length": len(payload.get("text") or ""),
+                "request_id": req.request_id,
+                "original_length": len(req.text),
             },
         )
         return _MALFORMED
 
-    # 6. Engine token validation
-    engine = payload.get("engine") or default_engine
+    # Engine token validation
+    engine = req.engine or default_engine
     try:
         validate_nats_token(engine, kind="engine")
     except ValueError:
         return _MALFORMED
 
-    # 7. Engine availability
+    # Engine availability
     if not engine_available(engine):
         return TtsValidationOutcome(error_code="engine_unavailable")
 
@@ -164,38 +156,12 @@ def validate_tts_request(
 
 _STT_MALFORMED = SttValidationOutcome(error_code="malformed_request")
 
-# Optional fields: (key, accepted types) — mirrors stt_adapter.py handle()
-_STT_OPTIONAL_TYPE_MAP: tuple[tuple[str, tuple[type, ...]], ...] = (
-    ("language", (str,)),
-    ("language_detection_threshold", (int, float)),
-    ("language_detection_segments", (int,)),
-    ("language_fallback", (str,)),
-    ("initial_prompt", (str,)),
-    ("task", (str,)),
-)
-
-_STT_OVERRIDE_KEYS = (
-    "language",
-    "language_detection_threshold",
-    "language_detection_segments",
-    "language_fallback",
-    "initial_prompt",
-    "task",
-)
-
 
 def validate_stt_request(payload: dict) -> SttValidationOutcome:
     """Validate a decoded STT NATS request payload.
 
-    Checks (in order):
-    1. ``request_id`` present and non-empty.
-    2. ``request_id`` matches ``^[A-Za-z0-9_-]{1,128}$``.
-    3. ``audio_b64`` present and a ``str`` instance.
-    4. Optional field type checks (language, thresholds, task…).
-       ``language_detection_segments`` must be ``int`` but NOT ``bool``
-       (bool is a subclass of int in Python).
-    5. ``task`` value in ``("transcribe", "translate")`` when present.
-    6. Builds ``overrides`` dict from non-None optional fields.
+    Delegates typed construction to ``SttRequest.from_payload()``; returns
+    ``malformed_request`` on any type mismatch or format violation.
 
     Args:
         payload: Decoded JSON dict from the NATS message.
@@ -205,37 +171,14 @@ def validate_stt_request(payload: dict) -> SttValidationOutcome:
         dict (possibly empty) on success, or ``error_code="malformed_request"``
         on the first failing check.
     """
-    # 1. request_id presence
-    request_id = payload.get("request_id", "")
-    if not request_id:
+    from voicecli.adapters.nats.stt_adapter import SttRequest
+
+    try:
+        req = SttRequest.from_payload(payload)
+    except (ValueError, TypeError, KeyError):
         return _STT_MALFORMED
 
-    # 2. request_id format
-    if not _REQUEST_ID_RE.match(request_id):
+    if not _REQUEST_ID_RE.match(req.request_id):
         return _STT_MALFORMED
 
-    # 3. audio_b64 presence and type
-    audio_b64 = payload.get("audio_b64")
-    if not isinstance(audio_b64, str) or not audio_b64:
-        return _STT_MALFORMED
-
-    # 4. Optional field type checks
-    for key, expected_types in _STT_OPTIONAL_TYPE_MAP:
-        val = payload.get(key)
-        if val is None:
-            continue
-        # bool is a subclass of int — reject explicitly for segments field
-        if key == "language_detection_segments" and isinstance(val, bool):
-            return _STT_MALFORMED
-        if not isinstance(val, expected_types):
-            return _STT_MALFORMED
-
-    # 5. task value check
-    task_val = payload.get("task")
-    if task_val is not None and task_val not in ("transcribe", "translate"):
-        return _STT_MALFORMED
-
-    # 6. Build overrides dict (None values excluded)
-    overrides = {k: v for k in _STT_OVERRIDE_KEYS if (v := payload.get(k)) is not None}
-
-    return SttValidationOutcome(error_code=None, overrides=overrides)
+    return SttValidationOutcome(error_code=None, overrides=req.to_overrides())

--- a/src/voicecli/adapters/nats/requests.py
+++ b/src/voicecli/adapters/nats/requests.py
@@ -117,7 +117,7 @@ class TtsRequest:
     request_id: str
     trace_id: str = ""
     contract_version: str = ""
-    engine: str = ""
+    engine: str | None = None
     language: str | None = None
     voice: str | None = None
     speed: float | None = None

--- a/src/voicecli/adapters/nats/requests.py
+++ b/src/voicecli/adapters/nats/requests.py
@@ -1,0 +1,239 @@
+"""Typed request dataclasses for NATS adapter ingress."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class MalformedRequestError(ValueError):
+    """Raised when a NATS payload fails typed construction or format checks."""
+
+
+@dataclass(frozen=True)
+class SttRequest:
+    """Typed STT request constructed from NATS payload dict."""
+
+    audio_b64: str
+    request_id: str
+    trace_id: str = ""
+    contract_version: str = ""
+    mime_type: str = ""
+    language: str | None = None
+    language_detection_threshold: float | None = None
+    language_detection_segments: int | None = None
+    language_fallback: str | None = None
+    initial_prompt: str | None = None
+    task: str | None = None
+
+    @classmethod
+    def from_payload(cls, payload: dict) -> "SttRequest":
+        """Construct from decoded JSON payload; raise MalformedRequestError on type mismatch."""
+        audio_b64 = payload.get("audio_b64")
+        if not isinstance(audio_b64, str) or not audio_b64:
+            raise MalformedRequestError("audio_b64 must be a non-empty str")
+
+        request_id = payload.get("request_id", "")
+        if not isinstance(request_id, str) or not request_id:
+            raise MalformedRequestError("request_id must be a non-empty str")
+
+        language = payload.get("language")
+        if language is not None and not isinstance(language, str):
+            raise MalformedRequestError("language must be a str")
+
+        threshold = payload.get("language_detection_threshold")
+        if threshold is not None and (
+            not isinstance(threshold, (int, float)) or isinstance(threshold, bool)
+        ):
+            raise MalformedRequestError(
+                "language_detection_threshold must be int or float (not bool)"
+            )
+
+        segments = payload.get("language_detection_segments")
+        if segments is not None:
+            if isinstance(segments, bool) or not isinstance(segments, int):
+                raise MalformedRequestError("language_detection_segments must be an int (not bool)")
+
+        fallback = payload.get("language_fallback")
+        if fallback is not None and not isinstance(fallback, str):
+            raise MalformedRequestError("language_fallback must be a str")
+
+        prompt = payload.get("initial_prompt")
+        if prompt is not None and not isinstance(prompt, str):
+            raise MalformedRequestError("initial_prompt must be a str")
+
+        task = payload.get("task")
+        if task is not None and task not in ("transcribe", "translate"):
+            raise MalformedRequestError("task must be 'transcribe' or 'translate'")
+
+        trace_id = payload.get("trace_id")
+        if trace_id is not None and not isinstance(trace_id, str):
+            raise MalformedRequestError("trace_id must be a str")
+
+        contract_version = payload.get("contract_version")
+        if contract_version is not None and not isinstance(contract_version, str):
+            raise MalformedRequestError("contract_version must be a str")
+
+        mime_type = payload.get("mime_type")
+        if mime_type is not None and not isinstance(mime_type, str):
+            raise MalformedRequestError("mime_type must be a str")
+
+        return cls(
+            audio_b64=audio_b64,
+            request_id=request_id,
+            trace_id=trace_id or "",
+            contract_version=contract_version or "",
+            mime_type=mime_type or "",
+            language=language,
+            language_detection_threshold=float(threshold) if threshold is not None else None,
+            language_detection_segments=segments,
+            language_fallback=fallback,
+            initial_prompt=prompt,
+            task=task,
+        )
+
+    def to_overrides(self) -> dict:
+        """Build kwargs dict for api.transcribe from non-None optional fields."""
+        overrides: dict = {}
+        if self.language is not None:
+            overrides["language"] = self.language
+        if self.language_detection_threshold is not None:
+            overrides["language_detection_threshold"] = self.language_detection_threshold
+        if self.language_detection_segments is not None:
+            overrides["language_detection_segments"] = self.language_detection_segments
+        if self.language_fallback is not None:
+            overrides["language_fallback"] = self.language_fallback
+        if self.initial_prompt is not None:
+            overrides["initial_prompt"] = self.initial_prompt
+        if self.task is not None:
+            overrides["task"] = self.task
+        return overrides
+
+
+@dataclass(frozen=True)
+class TtsRequest:
+    """Typed TTS request constructed from NATS payload dict."""
+
+    text: str
+    request_id: str
+    trace_id: str = ""
+    contract_version: str = ""
+    engine: str = ""
+    language: str | None = None
+    voice: str | None = None
+    speed: float | None = None
+    exaggeration: float | None = None
+    cfg_weight: float | None = None
+    accent: str | None = None
+    personality: str | None = None
+    emotion: str | None = None
+    chunked: bool | None = None
+    chunk_size: int | None = None
+    segment_gap: float | None = None
+    crossfade: float | None = None
+    fallback_language: str | None = None
+
+    @classmethod
+    def from_payload(cls, payload: dict) -> "TtsRequest":
+        """Construct from decoded JSON payload; raise MalformedRequestError on type mismatch."""
+        text = payload.get("text")
+        if not isinstance(text, str) or not text:
+            raise MalformedRequestError("text must be a non-empty str")
+
+        request_id = payload.get("request_id", "")
+        if not isinstance(request_id, str) or not request_id:
+            raise MalformedRequestError("request_id must be a non-empty str")
+
+        engine = payload.get("engine", "")
+        if engine is not None and not isinstance(engine, str):
+            raise MalformedRequestError("engine must be a str or None")
+
+        speed = payload.get("speed")
+        if speed is not None and (not isinstance(speed, (int, float)) or isinstance(speed, bool)):
+            raise MalformedRequestError("speed must be int or float (not bool)")
+
+        exaggeration = payload.get("exaggeration")
+        if exaggeration is not None and (
+            not isinstance(exaggeration, (int, float)) or isinstance(exaggeration, bool)
+        ):
+            raise MalformedRequestError("exaggeration must be int or float (not bool)")
+
+        cfg_weight = payload.get("cfg_weight")
+        if cfg_weight is not None and (
+            not isinstance(cfg_weight, (int, float)) or isinstance(cfg_weight, bool)
+        ):
+            raise MalformedRequestError("cfg_weight must be int or float (not bool)")
+
+        chunk_size = payload.get("chunk_size")
+        if chunk_size is not None and (
+            not isinstance(chunk_size, int) or isinstance(chunk_size, bool)
+        ):
+            raise MalformedRequestError("chunk_size must be an int (not bool)")
+
+        segment_gap = payload.get("segment_gap")
+        if segment_gap is not None and (
+            not isinstance(segment_gap, (int, float)) or isinstance(segment_gap, bool)
+        ):
+            raise MalformedRequestError("segment_gap must be int or float (not bool)")
+
+        crossfade = payload.get("crossfade")
+        if crossfade is not None and (
+            not isinstance(crossfade, (int, float)) or isinstance(crossfade, bool)
+        ):
+            raise MalformedRequestError("crossfade must be int or float (not bool)")
+
+        chunked = payload.get("chunked")
+        if chunked is not None and not isinstance(chunked, bool):
+            raise MalformedRequestError("chunked must be a bool")
+
+        language = payload.get("language")
+        if language is not None and not isinstance(language, str):
+            raise MalformedRequestError("language must be a str")
+
+        voice = payload.get("voice")
+        if voice is not None and not isinstance(voice, str):
+            raise MalformedRequestError("voice must be a str")
+
+        accent = payload.get("accent")
+        if accent is not None and not isinstance(accent, str):
+            raise MalformedRequestError("accent must be a str")
+
+        personality = payload.get("personality")
+        if personality is not None and not isinstance(personality, str):
+            raise MalformedRequestError("personality must be a str")
+
+        emotion = payload.get("emotion")
+        if emotion is not None and not isinstance(emotion, str):
+            raise MalformedRequestError("emotion must be a str")
+
+        trace_id = payload.get("trace_id")
+        if trace_id is not None and not isinstance(trace_id, str):
+            raise MalformedRequestError("trace_id must be a str")
+
+        contract_version = payload.get("contract_version")
+        if contract_version is not None and not isinstance(contract_version, str):
+            raise MalformedRequestError("contract_version must be a str")
+
+        fallback_language = payload.get("fallback_language")
+        if fallback_language is not None and not isinstance(fallback_language, str):
+            raise MalformedRequestError("fallback_language must be a str")
+
+        return cls(
+            text=text,
+            request_id=request_id,
+            trace_id=trace_id or "",
+            contract_version=contract_version or "",
+            engine=engine,
+            language=language,
+            voice=voice,
+            speed=float(speed) if speed is not None else None,
+            exaggeration=float(exaggeration) if exaggeration is not None else None,
+            cfg_weight=float(cfg_weight) if cfg_weight is not None else None,
+            accent=accent,
+            personality=personality,
+            emotion=emotion,
+            chunked=chunked,
+            chunk_size=chunk_size,
+            segment_gap=float(segment_gap) if segment_gap is not None else None,
+            crossfade=float(crossfade) if crossfade is not None else None,
+            fallback_language=fallback_language,
+        )

--- a/src/voicecli/adapters/nats/stt_adapter.py
+++ b/src/voicecli/adapters/nats/stt_adapter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
@@ -13,7 +14,7 @@ from roxabi_contracts.voice import SUBJECTS as VOICE_SUBJECTS
 from roxabi_contracts.voice.models import SttResponse
 from roxabi_nats import NatsAdapterBase
 from voicecli.adapters.nats._stt_runner import SttRunnerState, run_transcription
-from voicecli.adapters.nats._validation import validate_stt_request
+from voicecli.adapters.nats._validation import _REQUEST_ID_RE
 from voicecli.adapters.nats.queue_groups import STT_WORKERS
 from voicecli.adapters.nats.tempdir import cleanup, scoped_path
 
@@ -21,6 +22,91 @@ from voicecli.adapters.nats.tempdir import cleanup, scoped_path
 # and avoid pulling torch/faster-whisper when only inspecting the adapter (e.g. --help).
 
 log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SttRequest:
+    """Typed STT request constructed from NATS payload dict."""
+
+    audio_b64: str
+    request_id: str
+    trace_id: str = ""
+    contract_version: str = ""
+    mime_type: str = ""
+    language: str | None = None
+    language_detection_threshold: float | None = None
+    language_detection_segments: int | None = None
+    language_fallback: str | None = None
+    initial_prompt: str | None = None
+    task: str | None = None
+
+    @classmethod
+    def from_payload(cls, payload: dict) -> "SttRequest":
+        """Construct from decoded JSON payload; raise ValueError on type mismatch."""
+        audio_b64 = payload.get("audio_b64")
+        if not isinstance(audio_b64, str) or not audio_b64:
+            raise ValueError("audio_b64 must be a non-empty str")
+
+        request_id = payload.get("request_id", "")
+        if not request_id:
+            raise ValueError("request_id is required")
+
+        language = payload.get("language")
+        if language is not None and not isinstance(language, str):
+            raise ValueError("language must be a str")
+
+        threshold = payload.get("language_detection_threshold")
+        if threshold is not None and not isinstance(threshold, (int, float)):
+            raise ValueError("language_detection_threshold must be int or float")
+
+        segments = payload.get("language_detection_segments")
+        if segments is not None:
+            if isinstance(segments, bool) or not isinstance(segments, int):
+                raise ValueError("language_detection_segments must be an int (not bool)")
+
+        fallback = payload.get("language_fallback")
+        if fallback is not None and not isinstance(fallback, str):
+            raise ValueError("language_fallback must be a str")
+
+        prompt = payload.get("initial_prompt")
+        if prompt is not None and not isinstance(prompt, str):
+            raise ValueError("initial_prompt must be a str")
+
+        task = payload.get("task")
+        if task is not None and task not in ("transcribe", "translate"):
+            raise ValueError("task must be 'transcribe' or 'translate'")
+
+        return cls(
+            audio_b64=audio_b64,
+            request_id=request_id,
+            trace_id=payload.get("trace_id") or "",
+            contract_version=payload.get("contract_version", ""),
+            mime_type=payload.get("mime_type", ""),
+            language=language,
+            language_detection_threshold=float(threshold) if threshold is not None else None,
+            language_detection_segments=segments,
+            language_fallback=fallback,
+            initial_prompt=prompt,
+            task=task,
+        )
+
+    def to_overrides(self) -> dict:
+        """Build kwargs dict for api.transcribe from non-None optional fields."""
+        overrides: dict = {}
+        if self.language is not None:
+            overrides["language"] = self.language
+        if self.language_detection_threshold is not None:
+            overrides["language_detection_threshold"] = self.language_detection_threshold
+        if self.language_detection_segments is not None:
+            overrides["language_detection_segments"] = self.language_detection_segments
+        if self.language_fallback is not None:
+            overrides["language_fallback"] = self.language_fallback
+        if self.initial_prompt is not None:
+            overrides["initial_prompt"] = self.initial_prompt
+        if self.task is not None:
+            overrides["task"] = self.task
+        return overrides
+
 
 SUBJECT = VOICE_SUBJECTS.stt_request
 HEARTBEAT_SUBJECT = VOICE_SUBJECTS.stt_heartbeat
@@ -41,6 +127,7 @@ __all__ = [
     "_MIME_TO_EXT",
     "_duration_from_segments",
     "_ext_from_mime",
+    "SttRequest",
     "SttNatsAdapter",
     "SUBJECT",
     "HEARTBEAT_SUBJECT",
@@ -124,30 +211,42 @@ class SttNatsAdapter(NatsAdapterBase):
             await self.reply(msg, _err_stt(trace_id, "", "malformed_request"))
             return
 
-        outcome = validate_stt_request(payload)
-        if outcome.error_code is not None:
-            await self.reply(msg, _err_stt(trace_id, request_id, outcome.error_code))
+        try:
+            req = SttRequest.from_payload(payload)
+        except (ValueError, TypeError, KeyError):
+            await self.reply(msg, _err_stt(trace_id, request_id, "malformed_request"))
             return
-        audio_b64 = payload["audio_b64"]  # validated by validate_stt_request to be str
-        overrides = outcome.overrides or {}
+        if not _REQUEST_ID_RE.match(req.request_id):
+            await self.reply(msg, _err_stt(trace_id, req.request_id, "malformed_request"))
+            return
 
         if self.reject_when_full:
             # Non-blocking acquire: avoid the race in _sem.locked()
             try:
                 await asyncio.wait_for(self._sem.acquire(), timeout=0)
             except asyncio.TimeoutError:
-                await self.reply(msg, _err_stt(trace_id, request_id, "capacity_exceeded"))
+                await self.reply(msg, _err_stt(trace_id, req.request_id, "capacity_exceeded"))
                 return
             try:
                 await self._run_transcription(
-                    msg, payload, request_id, audio_b64, overrides, trace_id=trace_id
+                    msg,
+                    payload,
+                    req.request_id,
+                    req.audio_b64,
+                    req.to_overrides(),
+                    trace_id=trace_id,
                 )
             finally:
                 self._sem.release()
         else:
             async with self._sem:
                 await self._run_transcription(
-                    msg, payload, request_id, audio_b64, overrides, trace_id=trace_id
+                    msg,
+                    payload,
+                    req.request_id,
+                    req.audio_b64,
+                    req.to_overrides(),
+                    trace_id=trace_id,
                 )
 
     async def _run_transcription(

--- a/src/voicecli/adapters/nats/stt_adapter.py
+++ b/src/voicecli/adapters/nats/stt_adapter.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import logging
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
@@ -14,98 +13,15 @@ from roxabi_contracts.voice import SUBJECTS as VOICE_SUBJECTS
 from roxabi_contracts.voice.models import SttResponse
 from roxabi_nats import NatsAdapterBase
 from voicecli.adapters.nats._stt_runner import SttRunnerState, run_transcription
-from voicecli.adapters.nats._validation import _REQUEST_ID_RE
+from voicecli.adapters.nats._validation import validate_stt_request
 from voicecli.adapters.nats.queue_groups import STT_WORKERS
+from voicecli.adapters.nats.requests import SttRequest
 from voicecli.adapters.nats.tempdir import cleanup, scoped_path
 
 # voicecli.api is NOT imported at module level — deferred to keep startup fast
 # and avoid pulling torch/faster-whisper when only inspecting the adapter (e.g. --help).
 
 log = logging.getLogger(__name__)
-
-
-@dataclass(frozen=True)
-class SttRequest:
-    """Typed STT request constructed from NATS payload dict."""
-
-    audio_b64: str
-    request_id: str
-    trace_id: str = ""
-    contract_version: str = ""
-    mime_type: str = ""
-    language: str | None = None
-    language_detection_threshold: float | None = None
-    language_detection_segments: int | None = None
-    language_fallback: str | None = None
-    initial_prompt: str | None = None
-    task: str | None = None
-
-    @classmethod
-    def from_payload(cls, payload: dict) -> "SttRequest":
-        """Construct from decoded JSON payload; raise ValueError on type mismatch."""
-        audio_b64 = payload.get("audio_b64")
-        if not isinstance(audio_b64, str) or not audio_b64:
-            raise ValueError("audio_b64 must be a non-empty str")
-
-        request_id = payload.get("request_id", "")
-        if not request_id:
-            raise ValueError("request_id is required")
-
-        language = payload.get("language")
-        if language is not None and not isinstance(language, str):
-            raise ValueError("language must be a str")
-
-        threshold = payload.get("language_detection_threshold")
-        if threshold is not None and not isinstance(threshold, (int, float)):
-            raise ValueError("language_detection_threshold must be int or float")
-
-        segments = payload.get("language_detection_segments")
-        if segments is not None:
-            if isinstance(segments, bool) or not isinstance(segments, int):
-                raise ValueError("language_detection_segments must be an int (not bool)")
-
-        fallback = payload.get("language_fallback")
-        if fallback is not None and not isinstance(fallback, str):
-            raise ValueError("language_fallback must be a str")
-
-        prompt = payload.get("initial_prompt")
-        if prompt is not None and not isinstance(prompt, str):
-            raise ValueError("initial_prompt must be a str")
-
-        task = payload.get("task")
-        if task is not None and task not in ("transcribe", "translate"):
-            raise ValueError("task must be 'transcribe' or 'translate'")
-
-        return cls(
-            audio_b64=audio_b64,
-            request_id=request_id,
-            trace_id=payload.get("trace_id") or "",
-            contract_version=payload.get("contract_version", ""),
-            mime_type=payload.get("mime_type", ""),
-            language=language,
-            language_detection_threshold=float(threshold) if threshold is not None else None,
-            language_detection_segments=segments,
-            language_fallback=fallback,
-            initial_prompt=prompt,
-            task=task,
-        )
-
-    def to_overrides(self) -> dict:
-        """Build kwargs dict for api.transcribe from non-None optional fields."""
-        overrides: dict = {}
-        if self.language is not None:
-            overrides["language"] = self.language
-        if self.language_detection_threshold is not None:
-            overrides["language_detection_threshold"] = self.language_detection_threshold
-        if self.language_detection_segments is not None:
-            overrides["language_detection_segments"] = self.language_detection_segments
-        if self.language_fallback is not None:
-            overrides["language_fallback"] = self.language_fallback
-        if self.initial_prompt is not None:
-            overrides["initial_prompt"] = self.initial_prompt
-        if self.task is not None:
-            overrides["task"] = self.task
-        return overrides
 
 
 SUBJECT = VOICE_SUBJECTS.stt_request
@@ -211,14 +127,11 @@ class SttNatsAdapter(NatsAdapterBase):
             await self.reply(msg, _err_stt(trace_id, "", "malformed_request"))
             return
 
-        try:
-            req = SttRequest.from_payload(payload)
-        except (ValueError, TypeError, KeyError):
-            await self.reply(msg, _err_stt(trace_id, request_id, "malformed_request"))
+        outcome = validate_stt_request(payload)
+        if outcome.error_code is not None:
+            await self.reply(msg, _err_stt(trace_id, request_id, outcome.error_code))
             return
-        if not _REQUEST_ID_RE.match(req.request_id):
-            await self.reply(msg, _err_stt(trace_id, req.request_id, "malformed_request"))
-            return
+        req = outcome.request
 
         if self.reject_when_full:
             # Non-blocking acquire: avoid the race in _sem.locked()

--- a/src/voicecli/adapters/nats/tts_adapter.py
+++ b/src/voicecli/adapters/nats/tts_adapter.py
@@ -6,7 +6,6 @@ import asyncio
 import base64  # noqa: F401 — test patch anchor for voicecli.adapters.nats.tts_adapter.base64.b64encode
 import logging
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
@@ -23,92 +22,6 @@ from voicecli.adapters.nats.tempdir import cleanup, scoped_path
 # and avoid pulling torch when only inspecting the adapter (e.g. for --help).
 
 log = logging.getLogger(__name__)
-
-
-@dataclass(frozen=True)
-class TtsRequest:
-    """Typed TTS request constructed from NATS payload dict."""
-
-    text: str
-    request_id: str
-    trace_id: str = ""
-    contract_version: str = ""
-    engine: str = ""
-    language: str | None = None
-    voice: str | None = None
-    speed: float | None = None
-    exaggeration: float | None = None
-    cfg_weight: float | None = None
-    accent: str | None = None
-    personality: str | None = None
-    emotion: str | None = None
-    chunked: bool | None = None
-    chunk_size: int | None = None
-    segment_gap: float | None = None
-    crossfade: float | None = None
-    fallback_language: str | None = None
-
-    @classmethod
-    def from_payload(cls, payload: dict) -> "TtsRequest":
-        """Construct from decoded JSON payload; raise ValueError on type mismatch."""
-        text = payload.get("text")
-        if not isinstance(text, str) or not text:
-            raise ValueError("text must be a non-empty str")
-
-        request_id = payload.get("request_id", "")
-        if not request_id:
-            raise ValueError("request_id is required")
-
-        engine = payload.get("engine", "")
-
-        speed = payload.get("speed")
-        if speed is not None and not isinstance(speed, (int, float)):
-            raise ValueError("speed must be int or float")
-
-        exaggeration = payload.get("exaggeration")
-        if exaggeration is not None and not isinstance(exaggeration, (int, float)):
-            raise ValueError("exaggeration must be int or float")
-
-        cfg_weight = payload.get("cfg_weight")
-        if cfg_weight is not None and not isinstance(cfg_weight, (int, float)):
-            raise ValueError("cfg_weight must be int or float")
-
-        chunk_size = payload.get("chunk_size")
-        if chunk_size is not None and not isinstance(chunk_size, int):
-            raise ValueError("chunk_size must be an int")
-
-        segment_gap = payload.get("segment_gap")
-        if segment_gap is not None and not isinstance(segment_gap, (int, float)):
-            raise ValueError("segment_gap must be int or float")
-
-        crossfade = payload.get("crossfade")
-        if crossfade is not None and not isinstance(crossfade, (int, float)):
-            raise ValueError("crossfade must be int or float")
-
-        chunked = payload.get("chunked")
-        if chunked is not None and not isinstance(chunked, bool):
-            raise ValueError("chunked must be a bool")
-
-        return cls(
-            text=text,
-            request_id=request_id,
-            trace_id=payload.get("trace_id") or "",
-            contract_version=payload.get("contract_version", ""),
-            engine=engine,
-            language=payload.get("language"),
-            voice=payload.get("voice"),
-            speed=float(speed) if speed is not None else None,
-            exaggeration=float(exaggeration) if exaggeration is not None else None,
-            cfg_weight=float(cfg_weight) if cfg_weight is not None else None,
-            accent=payload.get("accent"),
-            personality=payload.get("personality"),
-            emotion=payload.get("emotion"),
-            chunked=chunked,
-            chunk_size=chunk_size,
-            segment_gap=float(segment_gap) if segment_gap is not None else None,
-            crossfade=float(crossfade) if crossfade is not None else None,
-            fallback_language=payload.get("fallback_language"),
-        )
 
 
 SUBJECT = VOICE_SUBJECTS.tts_request

--- a/src/voicecli/adapters/nats/tts_adapter.py
+++ b/src/voicecli/adapters/nats/tts_adapter.py
@@ -6,6 +6,7 @@ import asyncio
 import base64  # noqa: F401 — test patch anchor for voicecli.adapters.nats.tts_adapter.base64.b64encode
 import logging
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
@@ -22,6 +23,92 @@ from voicecli.adapters.nats.tempdir import cleanup, scoped_path
 # and avoid pulling torch when only inspecting the adapter (e.g. for --help).
 
 log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TtsRequest:
+    """Typed TTS request constructed from NATS payload dict."""
+
+    text: str
+    request_id: str
+    trace_id: str = ""
+    contract_version: str = ""
+    engine: str = ""
+    language: str | None = None
+    voice: str | None = None
+    speed: float | None = None
+    exaggeration: float | None = None
+    cfg_weight: float | None = None
+    accent: str | None = None
+    personality: str | None = None
+    emotion: str | None = None
+    chunked: bool | None = None
+    chunk_size: int | None = None
+    segment_gap: float | None = None
+    crossfade: float | None = None
+    fallback_language: str | None = None
+
+    @classmethod
+    def from_payload(cls, payload: dict) -> "TtsRequest":
+        """Construct from decoded JSON payload; raise ValueError on type mismatch."""
+        text = payload.get("text")
+        if not isinstance(text, str) or not text:
+            raise ValueError("text must be a non-empty str")
+
+        request_id = payload.get("request_id", "")
+        if not request_id:
+            raise ValueError("request_id is required")
+
+        engine = payload.get("engine", "")
+
+        speed = payload.get("speed")
+        if speed is not None and not isinstance(speed, (int, float)):
+            raise ValueError("speed must be int or float")
+
+        exaggeration = payload.get("exaggeration")
+        if exaggeration is not None and not isinstance(exaggeration, (int, float)):
+            raise ValueError("exaggeration must be int or float")
+
+        cfg_weight = payload.get("cfg_weight")
+        if cfg_weight is not None and not isinstance(cfg_weight, (int, float)):
+            raise ValueError("cfg_weight must be int or float")
+
+        chunk_size = payload.get("chunk_size")
+        if chunk_size is not None and not isinstance(chunk_size, int):
+            raise ValueError("chunk_size must be an int")
+
+        segment_gap = payload.get("segment_gap")
+        if segment_gap is not None and not isinstance(segment_gap, (int, float)):
+            raise ValueError("segment_gap must be int or float")
+
+        crossfade = payload.get("crossfade")
+        if crossfade is not None and not isinstance(crossfade, (int, float)):
+            raise ValueError("crossfade must be int or float")
+
+        chunked = payload.get("chunked")
+        if chunked is not None and not isinstance(chunked, bool):
+            raise ValueError("chunked must be a bool")
+
+        return cls(
+            text=text,
+            request_id=request_id,
+            trace_id=payload.get("trace_id") or "",
+            contract_version=payload.get("contract_version", ""),
+            engine=engine,
+            language=payload.get("language"),
+            voice=payload.get("voice"),
+            speed=float(speed) if speed is not None else None,
+            exaggeration=float(exaggeration) if exaggeration is not None else None,
+            cfg_weight=float(cfg_weight) if cfg_weight is not None else None,
+            accent=payload.get("accent"),
+            personality=payload.get("personality"),
+            emotion=payload.get("emotion"),
+            chunked=chunked,
+            chunk_size=chunk_size,
+            segment_gap=float(segment_gap) if segment_gap is not None else None,
+            crossfade=float(crossfade) if crossfade is not None else None,
+            fallback_language=payload.get("fallback_language"),
+        )
 
 
 SUBJECT = VOICE_SUBJECTS.tts_request

--- a/src/voicecli/runtime/transcribe.py
+++ b/src/voicecli/runtime/transcribe.py
@@ -142,6 +142,10 @@ class Segment:
     end: float
     text: str
 
+    def __post_init__(self) -> None:
+        self.start = float(self.start)
+        self.end = float(self.end)
+
 
 @dataclass
 class TranscriptionResult:

--- a/src/voicecli/runtime/transcribe.py
+++ b/src/voicecli/runtime/transcribe.py
@@ -137,10 +137,17 @@ def _strip_hallucinations(text: str) -> str:
 
 
 @dataclass
+class Segment:
+    start: float
+    end: float
+    text: str
+
+
+@dataclass
 class TranscriptionResult:
     text: str
     language: str | None  # detected language code ("en", "fr", ...)
-    segments: list[dict]  # [{start, end, text}, ...]
+    segments: list[Segment]  # [{start, end, text}, ...]
 
 
 def _try_daemon(
@@ -195,10 +202,13 @@ def _try_daemon(
             sock.close()
 
         if resp.get("status") == "ok":
+            raw_segments = resp.get("segments") or []
             return TranscriptionResult(
                 text=resp.get("text", ""),
                 language=resp.get("language"),
-                segments=resp.get("segments", []),
+                segments=[
+                    Segment(start=s["start"], end=s["end"], text=s["text"]) for s in raw_segments
+                ],
             )
     except Exception:
         pass
@@ -289,13 +299,13 @@ def transcribe(
         seg_text = _strip_hallucinations(s.text.strip())
         if not seg_text:
             continue
-        seg_list.append({"start": s.start, "end": s.end, "text": seg_text})
+        seg_list.append(Segment(start=s.start, end=s.end, text=seg_text))
         duration = s.end - s.start
         print(
             f"[stt] segment [{s.start:.2f}s–{s.end:.2f}s, {duration:.2f}s]: {seg_text}",
             file=__import__("sys").stderr,
         )
-    full_text = _strip_hallucinations(" ".join(s["text"] for s in seg_list))
+    full_text = _strip_hallucinations(" ".join(s.text for s in seg_list))
     return TranscriptionResult(text=full_text, language=info.language, segments=seg_list)
 
 

--- a/tests/nats/test_stt_adapter.py
+++ b/tests/nats/test_stt_adapter.py
@@ -32,7 +32,7 @@ try:
         _duration_from_segments,
         _ext_from_mime,
     )
-    from voicecli.runtime.transcribe import TranscriptionResult
+    from voicecli.runtime.transcribe import Segment, TranscriptionResult
 
     _IMPORT_ERROR: ImportError | None = None
 except ImportError as _e:
@@ -107,7 +107,7 @@ def _fake_result(
     return TranscriptionResult(
         text=text,
         language=language,
-        segments=[{"start": 0.0, "end": end, "text": text}],
+        segments=[Segment(start=0.0, end=end, text=text)],
     )
 
 
@@ -282,6 +282,37 @@ class TestSttNatsAdapter:
         asyncio.run(adapter.handle(msg, payload))
 
         # Assert
+        reply = msg.last_reply()
+        assert reply["ok"] is False
+        assert reply["error"] == "malformed_request"
+
+    # ------------------------------------------------------------------
+    # Case 5b: wrong-type override fields yield malformed_request
+    # ------------------------------------------------------------------
+    def test_malformed_language_detection_threshold_type(self, tmp_path: Path) -> None:
+        _require_imports()
+        adapter = _make_adapter(max_concurrent=1)
+        msg = MockMsg()
+        _setup_adapter(adapter, msg)
+        payload = _valid_payload()
+        payload["language_detection_threshold"] = "high"
+
+        asyncio.run(adapter.handle(msg, payload))
+
+        reply = msg.last_reply()
+        assert reply["ok"] is False
+        assert reply["error"] == "malformed_request"
+
+    def test_malformed_language_detection_segments_bool(self, tmp_path: Path) -> None:
+        _require_imports()
+        adapter = _make_adapter(max_concurrent=1)
+        msg = MockMsg()
+        _setup_adapter(adapter, msg)
+        payload = _valid_payload()
+        payload["language_detection_segments"] = True
+
+        asyncio.run(adapter.handle(msg, payload))
+
         reply = msg.last_reply()
         assert reply["ok"] is False
         assert reply["error"] == "malformed_request"
@@ -745,7 +776,7 @@ class TestSttNatsAdapter:
                 return TranscriptionResult(
                     text="ok",
                     language="en",
-                    segments=[{"start": 0.0, "end": 1.5, "text": "ok"}],
+                    segments=[Segment(start=0.0, end=1.5, text="ok")],
                 )
 
             with patch(

--- a/tests/nats/test_stt_runner.py
+++ b/tests/nats/test_stt_runner.py
@@ -16,6 +16,8 @@ from typing import Any
 import pytest
 from _fakes import SyncExecutor
 
+from voicecli.runtime.transcribe import Segment, TranscriptionResult
+
 from voicecli.adapters.nats._stt_runner import (
     SttRunnerState,
     run_transcription,
@@ -43,9 +45,9 @@ class _FakeApi:
         if self._transcribe_behavior is not None:
             return self._transcribe_behavior(out_path, model=model, **overrides)
         # Default: minimal TranscriptionResult-shaped object
-        from voicecli.runtime.transcribe import TranscriptionResult
-
-        return TranscriptionResult(text="hello", language="en", segments=[{"end": 1.5}])
+        return TranscriptionResult(
+            text="hello", language="en", segments=[Segment(end=1.5, start=0.0, text="")]
+        )
 
     def warmup_model(self, model: str) -> None:
         self.warmup_calls.append(model)
@@ -379,8 +381,6 @@ class TestRunTranscriptionModelLoad:
 
         def _fake_transcribe(out_path, *, model, _skip_daemon=True, **kw):
             transcribe_calls.append(model)
-            from voicecli.runtime.transcribe import TranscriptionResult
-
             return TranscriptionResult(text="x", language="en", segments=[])
 
         monkeypatch.setattr("voicecli.api.warmup_model", _fail_warmup)
@@ -531,9 +531,9 @@ class TestRunTranscriptionOverridesForwarding:
 
         def _capturing_transcribe(out_path, *, model, _skip_daemon=True, **kw):
             captured.update(kw)
-            from voicecli.runtime.transcribe import TranscriptionResult
-
-            return TranscriptionResult(text="bonjour", language="fr", segments=[{"end": 1.0}])
+            return TranscriptionResult(
+                text="bonjour", language="fr", segments=[Segment(end=1.0, start=0.0, text="")]
+            )
 
         monkeypatch.setattr("voicecli.api.warmup_model", lambda m: None)
         monkeypatch.setattr("voicecli.api.transcribe", _capturing_transcribe)
@@ -567,9 +567,9 @@ class TestRunTranscriptionOverridesForwarding:
 
         def _capturing_transcribe(out_path, *, model, _skip_daemon=True, **kw):
             captured.update(kw)
-            from voicecli.runtime.transcribe import TranscriptionResult
-
-            return TranscriptionResult(text="hi", language="en", segments=[{"end": 0.5}])
+            return TranscriptionResult(
+                text="hi", language="en", segments=[Segment(end=0.5, start=0.0, text="")]
+            )
 
         monkeypatch.setattr("voicecli.api.warmup_model", lambda m: None)
         monkeypatch.setattr("voicecli.api.transcribe", _capturing_transcribe)
@@ -604,9 +604,9 @@ class TestRunTranscriptionOverridesForwarding:
 
         def _capturing_transcribe(out_path, *, model, _skip_daemon=True, **kw):
             captured.update(kw)
-            from voicecli.runtime.transcribe import TranscriptionResult
-
-            return TranscriptionResult(text="hallo", language="de", segments=[{"end": 2.0}])
+            return TranscriptionResult(
+                text="hallo", language="de", segments=[Segment(end=2.0, start=0.0, text="")]
+            )
 
         monkeypatch.setattr("voicecli.api.warmup_model", lambda m: None)
         monkeypatch.setattr("voicecli.api.transcribe", _capturing_transcribe)

--- a/tests/nats/test_tts_adapter.py
+++ b/tests/nats/test_tts_adapter.py
@@ -573,6 +573,42 @@ class TestTtsNatsAdapter:
         assert reply["ok"] is False
         assert reply["error"] == "malformed_request"
 
+    def test_malformed_speed_type(self, tmp_path: Path) -> None:
+        _require_imports()
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        _setup_adapter(adapter, msg)
+        payload = _valid_payload()
+        payload["speed"] = "fast"
+
+        with patch(
+            "voicecli.engines.engine._get_registry",
+            return_value={"mock": _stub_engine_factory(tmp_path)},
+        ):
+            asyncio.run(adapter.handle(msg, payload))
+
+        reply = msg.last_reply()
+        assert reply["ok"] is False
+        assert reply["error"] == "malformed_request"
+
+    def test_malformed_chunked_type(self, tmp_path: Path) -> None:
+        _require_imports()
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        _setup_adapter(adapter, msg)
+        payload = _valid_payload()
+        payload["chunked"] = "yes"
+
+        with patch(
+            "voicecli.engines.engine._get_registry",
+            return_value={"mock": _stub_engine_factory(tmp_path)},
+        ):
+            asyncio.run(adapter.handle(msg, payload))
+
+        reply = msg.last_reply()
+        assert reply["ok"] is False
+        assert reply["error"] == "malformed_request"
+
     def test_engine_env_var_fallback(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         _require_imports()
         # Arrange


### PR DESCRIPTION
## Summary
- Replace raw dict payload forwarding at NATS adapter boundary with frozen stdlib dataclasses (SttRequest, TtsRequest, Segment).
- Add `from_payload()` factories for fail-fast type validation, returning `malformed_request` on mismatch.
- Add `to_overrides()` on SttRequest to build `api.transcribe()` kwargs.
- Type `TranscriptionResult.segments` as `list[Segment]`; update daemon and whisper paths to construct Segment instances.
- Simplify `_duration_from_segments` to use typed `Segment.end`.
- Remove PR #51 `isinstance` guards from `_validation.py` — now handled by typed construction.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #53: refactor(nats): typed adapter ingress | OPEN |
| Spec | [53-typed-adapter-ingress-spec.mdx](artifacts/specs/53-typed-adapter-ingress-spec.mdx) | Present |
| Plan | [53-typed-adapter-ingress-plan.mdx](artifacts/plans/53-typed-adapter-ingress-plan.mdx) | Present |
| Implementation | 1 commit on `feat/53-typed-ingress` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (4 new type-mismatch tests) | Passed |

## Test Plan
- [ ] Verify NATS STT request with invalid `language_detection_threshold` type returns `malformed_request`
- [ ] Verify NATS TTS request with invalid `speed` type returns `malformed_request`
- [ ] Verify `TranscriptionResult.segments` is `list[Segment]` in both daemon and whisper paths

Closes #53

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`