### PR TITLE
refactor(runtime): split stt_daemon.py into recording + dictation modules

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -16,8 +16,8 @@ layers =
     voicecli.ports
     voicecli.core
 ignore_imports =
-    # ADR-003 V11: runtime.stt_daemon uses clipboard and ui_sounds — cross-layer (runtime → ui)
-    voicecli.runtime.stt_daemon -> voicecli.ui.clipboard
+    # ADR-003 V11: runtime.stt_daemon uses ui_sounds; dictation uses clipboard — cross-layer (runtime → ui)
+    voicecli.runtime.dictation -> voicecli.ui.clipboard
     voicecli.runtime.stt_daemon -> voicecli.ui.sounds
     # Transitional: engines import Segment/TTSDocument from voicecli.api.markdown — pure data types, moving to
     # a shared primitives layer is tracked by ADR-003; engines need Segment for type-hinted segment iteration

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -20,6 +20,8 @@
     "src/voicecli/core/models.py",
     "src/voicecli/runtime/stt_daemon.py",
     "src/voicecli/runtime/transcribe.py",
+    "src/voicecli/runtime/dictation.py",
+    "src/voicecli/runtime/recording.py",
     "src/voicecli/cli/doctor.py"
   ],
   "reportMissingImports": "error",

--- a/src/voicecli/runtime/dictation.py
+++ b/src/voicecli/runtime/dictation.py
@@ -1,0 +1,286 @@
+"""Dictation action handlers for the STT daemon."""
+
+from __future__ import annotations
+
+import gc
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from voicecli.runtime.recording import _save_recording
+from voicecli.runtime.wire_protocol import send_json as _send_json
+from voicecli.core.history import append_history, wav_duration_s
+
+if TYPE_CHECKING:
+    from voicecli.runtime.stt_daemon import SttDaemon
+
+
+def handle_ping(daemon: "SttDaemon", conn) -> None:
+    _send_json(conn, {"status": "ok"})
+
+
+def handle_status(daemon: "SttDaemon", conn) -> None:
+    with daemon._lock:
+        state = daemon._state.value
+        mode = daemon._current_mode or daemon.default_mode
+    _send_json(conn, {"status": "ok", "state": state, "mode": mode})
+
+
+def handle_unknown(daemon: "SttDaemon", conn, action: str | None) -> None:
+    _send_json(conn, {"status": "error", "message": f"unknown action: {action}"})
+
+
+def handle_transcribe_file(daemon: "SttDaemon", conn, req: dict) -> None:
+    """Transcribe an audio file using the warm model. No state-machine interaction."""
+    audio_path = req.get("audio_path")
+    if not audio_path:
+        _send_json(conn, {"status": "error", "message": "missing required field: 'audio_path'"})
+        return
+    path = Path(audio_path)
+    if not path.exists():
+        _send_json(conn, {"status": "error", "message": f"file not found: {audio_path}"})
+        return
+
+    language = req.get("language")
+    task = req.get("task", "transcribe")
+    initial_prompt = req.get("initial_prompt")
+    language_detection_threshold = req.get("language_detection_threshold")
+    language_detection_segments = req.get("language_detection_segments")
+    language_fallback = req.get("language_fallback")
+
+    # Use daemon-level defaults when caller doesn't specify
+    if language_detection_threshold is None:
+        language_detection_threshold = daemon.language_detection_threshold
+    if language_detection_segments is None:
+        language_detection_segments = daemon.language_detection_segments
+    if language_fallback is None:
+        language_fallback = daemon.language_fallback
+
+    from voicecli.runtime.transcribe import transcribe
+
+    try:
+        import torch
+
+        _oom_type: type = torch.cuda.OutOfMemoryError
+    except (ImportError, AttributeError):
+        _oom_type = type(None)  # never matches — no torch, no OOM handling
+
+    max_retries = 3
+    delay = 5
+    for attempt in range(1, max_retries + 1):
+        try:
+            result = transcribe(
+                path,
+                model=daemon.model,
+                language=language,
+                language_detection_threshold=language_detection_threshold,
+                language_detection_segments=language_detection_segments,
+                language_fallback=language_fallback,
+                task=task,
+                initial_prompt=initial_prompt,
+            )
+            _send_json(
+                conn,
+                {
+                    "status": "ok",
+                    "text": result.text,
+                    "language": result.language,
+                    "segments": result.segments,
+                },
+            )
+            return
+        except Exception as e:  # noqa: BLE001
+            if isinstance(e, _oom_type):
+                print(
+                    f"[voicecli stt] OOM loading model, retry {attempt}/{max_retries}"
+                    f" in {delay}s...",
+                    file=sys.stderr,
+                )
+                gc.collect()
+                torch.cuda.empty_cache()
+                time.sleep(delay)
+                delay *= 2
+            else:
+                print(f"[stt] transcribe_file error: {e}", file=sys.stderr)
+                _send_json(conn, {"status": "error", "message": str(e)})
+                return
+
+    _send_json(conn, {"status": "error", "message": f"CUDA OOM after {max_retries} retries"})
+
+
+def handle_toggle(daemon: "SttDaemon", conn, mode: str | None = None) -> None:
+    from voicecli.runtime.stt_daemon import State
+
+    with daemon._lock:
+        state = daemon._state
+    if state == State.IDLE:
+        daemon._start_recording(conn, mode=mode)
+    elif state == State.RECORDING:
+        # stop_and_transcribe blocks until transcription is done, then sends
+        # the response via conn.  The caller (_handle) must NOT close conn
+        # afterwards — stop_and_transcribe takes ownership.
+        stop_and_transcribe(daemon, conn)
+    elif state == State.TRANSCRIBING:
+        daemon._queue_recording(conn)
+    elif state == State.QUEUED:
+        _send_json(conn, {"status": "ok", "state": State.QUEUED.value})
+
+
+def handle_cancel(daemon: "SttDaemon", conn) -> None:
+    from voicecli.runtime.stt_daemon import State
+
+    with daemon._lock:
+        state = daemon._state
+        if state not in (State.RECORDING, State.QUEUED):
+            _send_json(conn, {"status": "ok", "state": State.IDLE.value})
+            return
+        daemon._state = State.IDLE
+        rt = daemon._recording_thread
+        daemon._recording_thread = None
+        stop_ev = daemon._parecord_stop_event
+        daemon._parecord_stop_event = None
+
+    if rt is not None:
+        threading.Thread(target=rt.stop, daemon=True).start()
+    if stop_ev is not None:
+        stop_ev.set()
+    _send_json(conn, {"status": "ok", "state": State.IDLE.value})
+
+
+def handle_next_mode(daemon: "SttDaemon", conn) -> None:
+    """Cycle to the next available mode and update default_mode."""
+    from voicecli.core.config import _find_config
+    from voicecli.core.stt_modes import load_modes
+
+    cfg_path = _find_config()
+    raw_cfg: dict = {}
+    if cfg_path:
+        import tomllib
+
+        with open(cfg_path, "rb") as f:
+            raw_cfg = tomllib.load(f)
+    modes = load_modes(raw_cfg)
+    mode_names = sorted(modes.keys())
+    current = daemon._current_mode or daemon.default_mode
+    if current in mode_names:
+        idx = (mode_names.index(current) + 1) % len(mode_names)
+    else:
+        idx = 0
+    next_mode = mode_names[idx]
+    daemon.default_mode = next_mode
+    daemon._current_mode = next_mode if daemon._state.value == "recording" else None
+    desc = modes[next_mode].get("description", next_mode)
+    _send_json(conn, {"status": "ok", "mode": next_mode, "description": desc})
+
+
+def stop_and_transcribe(daemon: "SttDaemon", conn) -> None:
+    from voicecli.runtime.stt_daemon import State
+
+    with daemon._lock:
+        daemon._state = State.TRANSCRIBING
+        rt = daemon._recording_thread
+        daemon._recording_thread = None
+        parecord_stop_ev = daemon._parecord_stop_event
+        daemon._parecord_stop_event = None
+        current_mode = daemon._current_mode
+        daemon._current_mode = None
+
+    # Collect WAV bytes from whichever recording path was active
+    if rt is not None:
+        wav_bytes = rt.stop()
+    elif parecord_stop_ev is not None:
+        parecord_stop_ev.set()
+        parecord_thread = daemon._parecord_thread
+        wav_holder = daemon._parecord_wav_holder
+        if parecord_thread is not None:
+            parecord_thread.join(timeout=3.0)
+        wav_bytes = wav_holder[0] if wav_holder else b""
+    else:
+        wav_bytes = b""
+
+    # Resolve mode params (mode overrides daemon-level settings)
+    transcribe_language = daemon.language
+    transcribe_task = "transcribe"
+    transcribe_prompt: str | None = None
+    if current_mode is not None:
+        try:
+            from voicecli.core.config import load_config
+            from voicecli.core.stt_modes import get_mode
+
+            mode_cfg = get_mode(current_mode, load_config())
+            if "language" in mode_cfg:
+                transcribe_language = mode_cfg["language"]
+            if "task" in mode_cfg:
+                transcribe_task = mode_cfg["task"]
+            if "prompt" in mode_cfg:
+                transcribe_prompt = mode_cfg["prompt"]
+        except Exception as e:
+            print(f"[stt] mode resolve error: {e}", file=sys.stderr)
+
+    # Prepend personal vocab to the mode prompt (loaded fresh — no restart needed)
+    try:
+        from voicecli.core.config import load_vocab, vocab_to_prompt
+
+        vocab_fragment = vocab_to_prompt(load_vocab())
+        if vocab_fragment:
+            transcribe_prompt = (
+                vocab_fragment + " " + transcribe_prompt if transcribe_prompt else vocab_fragment
+            )
+    except Exception as e:
+        print(f"[stt] vocab load error: {e}", file=sys.stderr)
+
+    # Lazy imports so test patches on stt_daemon module are respected
+    from voicecli.runtime.stt_daemon import _write_tempfile
+    from voicecli.runtime.stt_daemon import write_clipboard
+
+    tmp_path = _write_tempfile(wav_bytes)
+    text: str = ""
+    language: str | None = None
+    try:
+        from voicecli.runtime.transcribe import transcribe
+
+        result = transcribe(
+            tmp_path,
+            model=daemon.model,
+            language=transcribe_language,
+            language_detection_threshold=daemon.language_detection_threshold,
+            language_detection_segments=daemon.language_detection_segments,
+            language_fallback=daemon.language_fallback,
+            task=transcribe_task,
+            initial_prompt=transcribe_prompt,
+        )
+        text = result.text
+        language = result.language
+        print(f"[stt] detected language: {language}", file=sys.stderr)
+    except Exception as e:
+        print(f"[stt] transcription error: {e}", file=sys.stderr)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+    try:
+        write_clipboard(text)
+    except Exception as e:
+        print(f"[stt] clipboard error: {e}", file=sys.stderr)
+
+    if text and daemon.auto_paste:
+        from voicecli.ui.clipboard import auto_paste
+
+        threading.Thread(target=auto_paste, daemon=True).start()
+
+    _save_recording(wav_bytes, text, language)
+
+    duration_s = wav_duration_s(wav_bytes)
+    append_history(text, language, current_mode, duration_s)
+
+    with daemon._lock:
+        queued = daemon._state == State.QUEUED
+        daemon._state = State.IDLE
+
+    _send_json(
+        conn, {"status": "ok", "state": State.IDLE.value, "text": text, "language": language}
+    )
+
+    if queued:
+        daemon._start_recording_async()

--- a/src/voicecli/runtime/dictation.py
+++ b/src/voicecli/runtime/dictation.py
@@ -118,10 +118,10 @@ def handle_toggle(daemon: "SttDaemon", conn, mode: str | None = None) -> None:
     if state == State.IDLE:
         daemon._start_recording(conn, mode=mode)
     elif state == State.RECORDING:
-        # stop_and_transcribe blocks until transcription is done, then sends
-        # the response via conn.  The caller (_handle) must NOT close conn
-        # afterwards — stop_and_transcribe takes ownership.
-        stop_and_transcribe(daemon, conn)
+        # _stop_and_transcribe blocks until transcription is done, then sends
+        # the response via conn.  conn lifecycle remains managed by _handle's
+        # finally block.
+        _stop_and_transcribe(daemon, conn)
     elif state == State.TRANSCRIBING:
         daemon._queue_recording(conn)
     elif state == State.QUEUED:
@@ -168,14 +168,16 @@ def handle_next_mode(daemon: "SttDaemon", conn) -> None:
         idx = (mode_names.index(current) + 1) % len(mode_names)
     else:
         idx = 0
+    from voicecli.runtime.stt_daemon import State
+
     next_mode = mode_names[idx]
     daemon.default_mode = next_mode
-    daemon._current_mode = next_mode if daemon._state.value == "recording" else None
+    daemon._current_mode = next_mode if daemon._state == State.RECORDING else None
     desc = modes[next_mode].get("description", next_mode)
     _send_json(conn, {"status": "ok", "mode": next_mode, "description": desc})
 
 
-def stop_and_transcribe(daemon: "SttDaemon", conn) -> None:
+def _stop_and_transcribe(daemon: "SttDaemon", conn) -> None:
     from voicecli.runtime.stt_daemon import State
 
     with daemon._lock:

--- a/src/voicecli/runtime/dictation.py
+++ b/src/voicecli/runtime/dictation.py
@@ -231,9 +231,9 @@ def stop_and_transcribe(daemon: "SttDaemon", conn) -> None:
     except Exception as e:
         print(f"[stt] vocab load error: {e}", file=sys.stderr)
 
-    # Lazy imports so test patches on stt_daemon module are respected
-    from voicecli.runtime.stt_daemon import _write_tempfile
-    from voicecli.runtime.stt_daemon import write_clipboard
+    # Lazy imports so test patches are respected
+    from voicecli.runtime.recording import _write_tempfile
+    from voicecli.ui.clipboard import write_clipboard
 
     tmp_path = _write_tempfile(wav_bytes)
     text: str = ""

--- a/src/voicecli/runtime/recording.py
+++ b/src/voicecli/runtime/recording.py
@@ -1,0 +1,216 @@
+"""Recording infrastructure for the STT daemon."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import wave
+from io import BytesIO
+from pathlib import Path
+
+
+def _probe_pyaudio() -> bool:
+    """Return True if pyaudio is usable; print warning and return False otherwise."""
+    try:
+        import pyaudio
+
+        # Suppress ALSA/JACK noise that pyaudio prints unconditionally on startup
+        devnull_fd = os.open(os.devnull, os.O_WRONLY)
+        saved_stderr = os.dup(2)
+        os.dup2(devnull_fd, 2)
+        try:
+            pa = pyaudio.PyAudio()
+            try:
+                stream = pa.open(
+                    format=pyaudio.paInt16,
+                    channels=1,
+                    rate=16000,
+                    input=True,
+                    frames_per_buffer=1024,
+                )
+                stream.close()
+            finally:
+                pa.terminate()
+        finally:
+            os.dup2(saved_stderr, 2)
+            os.close(saved_stderr)
+            os.close(devnull_fd)
+        return True
+    except Exception as e:
+        print(f"[stt] pyaudio unavailable ({e}), falling back to parecord", file=sys.stderr)
+        return False
+
+
+def _frames_to_wav(frames: list[bytes], samplerate: int) -> bytes:
+    buf = BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(samplerate)
+        wf.writeframes(b"".join(frames))
+    return buf.getvalue()
+
+
+def _write_tempfile(wav_bytes: bytes) -> Path:
+    fd, name = tempfile.mkstemp(suffix=".wav")
+    try:
+        os.write(fd, wav_bytes)
+    finally:
+        os.close(fd)
+    return Path(name)
+
+
+def _save_recording(wav_bytes: bytes, text: str, language: str | None) -> None:
+    """Save WAV audio and transcript to STT/audio_in and STT/texts_out."""
+    if not wav_bytes and not text:
+        return
+    from datetime import datetime
+
+    from voicecli.core.config import VOICECLI_DIR
+
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    lang_tag = f"_{language}" if language else ""
+
+    if wav_bytes:
+        audio_dir = VOICECLI_DIR / "STT" / "audio_in"
+        audio_dir.mkdir(parents=True, exist_ok=True)
+        audio_path = audio_dir / f"dictate{lang_tag}_{ts}.wav"
+        audio_path.write_bytes(wav_bytes)
+        print(f"[stt] saved audio: {audio_path}", file=sys.stderr)
+
+    if text:
+        text_dir = VOICECLI_DIR / "STT" / "texts_out"
+        text_dir.mkdir(parents=True, exist_ok=True)
+        text_path = text_dir / f"dictate{lang_tag}_{ts}.txt"
+        text_path.write_text(text, encoding="utf-8")
+        print(f"[stt] saved transcript: {text_path}", file=sys.stderr)
+
+
+class RecordingThread(threading.Thread):
+    SAMPLERATE = 16000
+    CHANNELS = 1
+    CHUNK = 1024
+
+    def __init__(self, level_callback=None):
+        super().__init__(daemon=True)
+        self.level_callback = level_callback
+        self.frames: list[bytes] = []
+        self._stop_event = threading.Event()
+
+    def run(self) -> None:
+        import numpy as np
+        import pyaudio
+
+        # Suppress ALSA/JACK chatter on stream open
+        devnull_fd = os.open(os.devnull, os.O_WRONLY)
+        saved_stderr = os.dup(2)
+        os.dup2(devnull_fd, 2)
+        try:
+            pa = pyaudio.PyAudio()
+            stream = pa.open(
+                format=pyaudio.paInt16,
+                channels=self.CHANNELS,
+                rate=self.SAMPLERATE,
+                input=True,
+                frames_per_buffer=self.CHUNK,
+            )
+        finally:
+            os.dup2(saved_stderr, 2)
+            os.close(saved_stderr)
+            os.close(devnull_fd)
+
+        while not self._stop_event.is_set():
+            data = stream.read(self.CHUNK, exception_on_overflow=False)
+            self.frames.append(data)
+            if self.level_callback:
+                level = np.abs(np.frombuffer(data, dtype=np.int16)).mean() / 32768.0
+                self.level_callback(level)
+        stream.stop_stream()
+        stream.close()
+        pa.terminate()
+
+    def stop(self) -> bytes:
+        self._stop_event.set()
+        self.join(timeout=2.0)
+        if self.is_alive():
+            print(
+                "[stt] WARNING: RecordingThread did not stop in 2s — audio may be truncated",
+                file=sys.stderr,
+                flush=True,
+            )
+        return _frames_to_wav(self.frames, self.SAMPLERATE)
+
+
+def _record_parecord(stop_event: threading.Event, level_callback=None) -> bytes:
+    """Record via PulseAudio until stop_event is set; return WAV bytes.
+
+    Prefers `parec` (raw PCM to stdout) which enables real-time level callbacks.
+    Falls back to `parecord` (WAV to temp file, no levels) if parec is absent.
+    """
+    SAMPLERATE = 16000
+    CHUNK = 3200  # ~100 ms at 16 kHz 16-bit mono
+
+    parec = shutil.which("parec")
+    if parec:
+        # parec writes raw s16le to stdout — ideal for real-time processing
+        proc = subprocess.Popen(
+            [parec, "--format=s16le", f"--rate={SAMPLERATE}", "--channels=1"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+        frames: list[bytes] = []
+
+        def _reader() -> None:
+            import numpy as np
+
+            assert proc.stdout is not None
+            while True:
+                data = proc.stdout.read(CHUNK)
+                if not data:
+                    break
+                frames.append(data)
+                if level_callback and len(data) >= 2:
+                    samps = np.frombuffer(data, dtype=np.int16)
+                    level_callback(float(np.sqrt(np.mean(samps.astype(np.float32) ** 2))) / 32768.0)
+
+        reader = threading.Thread(target=_reader, daemon=True)
+        reader.start()
+        stop_event.wait()
+        proc.terminate()
+        try:
+            proc.wait(timeout=2.0)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        reader.join(timeout=2.0)
+        return _frames_to_wav(frames, SAMPLERATE)
+
+    # Fallback: parecord writes WAV to a temp file (no real-time level data)
+    parecord = shutil.which("parecord")
+    if not parecord:
+        return b""
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+        tmp_path = Path(f.name)
+    try:
+        proc2 = subprocess.Popen(
+            [
+                parecord,
+                "--format=s16le",
+                f"--rate={SAMPLERATE}",
+                "--channels=1",
+                "--file-format=wav",
+                str(tmp_path),
+            ]
+        )
+        stop_event.wait()
+        proc2.terminate()
+        try:
+            proc2.wait(timeout=2.0)
+        except subprocess.TimeoutExpired:
+            proc2.kill()
+        return tmp_path.read_bytes() if tmp_path.exists() else b""
+    finally:
+        tmp_path.unlink(missing_ok=True)

--- a/src/voicecli/runtime/stt_daemon.py
+++ b/src/voicecli/runtime/stt_daemon.py
@@ -2,12 +2,6 @@
 
 Protocol: newline-delimited JSON over AF_UNIX SOCK_STREAM.
 Socket path: ~/.local/share/voicecli/stt-daemon.sock
-
-Actions:
-  ping             — liveness check
-  status           — return current state
-  toggle           — start recording (idle→recording) or stop+transcribe (recording→transcribing→idle)
-  transcribe_file  — transcribe an audio file using the warm model
 """
 
 from __future__ import annotations
@@ -22,11 +16,9 @@ from pathlib import Path
 
 from roxabi_nats import sanitize_for_wire
 
-from voicecli.ui.clipboard import auto_paste, write_clipboard
 from voicecli.core.config import load_stt_config
 from voicecli.runtime.wire_protocol import recv_json
 from voicecli.runtime.wire_protocol import send_json as _send_json
-from voicecli.core.history import append_history, wav_duration_s
 from voicecli.core.paths import STT_SOCKET_PATH as SOCKET_PATH
 from voicecli.ui.sounds import play_ui_sound
 
@@ -34,8 +26,6 @@ from voicecli.runtime.recording import (
     RecordingThread,
     _probe_pyaudio,
     _record_parecord,
-    _write_tempfile,
-    _save_recording,
 )
 
 MAX_MSG = 65536
@@ -48,17 +38,11 @@ def _recv_json(sock: socket.socket) -> dict:
 LEVEL_FILE = Path("/tmp/voicecli_audio_level")
 
 
-# ── State machine ─────────────────────────────────────────────────────────────
-
-
 class State(Enum):
     IDLE = "idle"
     RECORDING = "recording"
     TRANSCRIBING = "transcribing"
     QUEUED = "queued"
-
-
-# ── Overlay launcher ──────────────────────────────────────────────────────────
 
 
 def _spawn_overlay(
@@ -69,7 +53,6 @@ def _spawn_overlay(
 ) -> None:
     """Launch the waveform overlay from the daemon process (survives WSL session exit)."""
     import subprocess
-    import sys
 
     env = os.environ.copy()
     if mode:
@@ -90,16 +73,11 @@ def _spawn_overlay(
         print(f"[stt] overlay spawn failed: {e}", file=sys.stderr)
 
 
-# ── warmup (re-exported so tests can patch voicecli.stt_daemon.warmup) ────────
-
-
 def warmup(model: str) -> None:
+    """Re-exported so tests can patch voicecli.stt_daemon.warmup."""
     from voicecli.runtime.transcribe import warmup as _warmup
 
     _warmup(model)
-
-
-# ── SttDaemon ────────────────────────────────────────────────────────────────
 
 
 class SttDaemon:
@@ -140,8 +118,6 @@ class SttDaemon:
         self._hotkey_cancel: str = _stt_cfg.get("hotkey_cancel", "alt+shift+esc")
         self._hotkey_mode: str = _stt_cfg.get("hotkey_mode", "alt+shift+tab")
 
-    # ── Public control ────────────────────────────────────────────────────────
-
     def stop(self) -> None:
         """Signal the accept loop to exit (used by tests)."""
         if self._server_socket is not None:
@@ -149,8 +125,6 @@ class SttDaemon:
                 self._server_socket.close()
             except Exception:
                 pass
-
-    # ── Serve (accept loop) ───────────────────────────────────────────────────
 
     def serve(self) -> None:
         self._use_pyaudio = _probe_pyaudio()
@@ -216,23 +190,33 @@ class SttDaemon:
         except Exception:
             pass  # SO_PEERCRED unavailable (non-Linux) — skip check
         try:
+            from voicecli.runtime.dictation import (
+                handle_cancel,
+                handle_next_mode,
+                handle_ping,
+                handle_status,
+                handle_toggle,
+                handle_transcribe_file,
+                handle_unknown,
+            )
+
             req = _recv_json(conn)
             action = req.get("action")
             mode = req.get("mode") or None
             if action == "ping":
-                self._handle_ping(conn)
+                handle_ping(self, conn)
             elif action == "status":
-                self._handle_status(conn)
+                handle_status(self, conn)
             elif action == "toggle":
-                self._handle_toggle(conn, mode=mode)
+                handle_toggle(self, conn, mode=mode)
             elif action == "cancel":
-                self._handle_cancel(conn)
+                handle_cancel(self, conn)
             elif action == "next_mode":
-                self._handle_next_mode(conn)
+                handle_next_mode(self, conn)
             elif action == "transcribe_file":
-                self._handle_transcribe_file(conn, req)
+                handle_transcribe_file(self, conn, req)
             else:
-                self._handle_unknown(conn, action)
+                handle_unknown(self, conn, action)
         except Exception as exc:
             try:
                 _send_json(conn, {"status": "error", "message": sanitize_for_wire(exc)})
@@ -240,115 +224,6 @@ class SttDaemon:
                 pass
         finally:
             conn.close()
-
-    def _handle_ping(self, conn: socket.socket) -> None:
-        _send_json(conn, {"status": "ok"})
-
-    def _handle_status(self, conn: socket.socket) -> None:
-        with self._lock:
-            state = self._state.value
-            mode = self._current_mode or self.default_mode
-        _send_json(conn, {"status": "ok", "state": state, "mode": mode})
-
-    def _handle_unknown(self, conn: socket.socket, action: str | None) -> None:
-        _send_json(conn, {"status": "error", "message": f"unknown action: {action}"})
-
-    def _handle_transcribe_file(self, conn: socket.socket, req: dict) -> None:
-        """Transcribe an audio file using the warm model. No state-machine interaction."""
-        audio_path = req.get("audio_path")
-        if not audio_path:
-            _send_json(conn, {"status": "error", "message": "missing required field: 'audio_path'"})
-            return
-        path = Path(audio_path)
-        if not path.exists():
-            _send_json(conn, {"status": "error", "message": f"file not found: {audio_path}"})
-            return
-
-        language = req.get("language")
-        task = req.get("task", "transcribe")
-        initial_prompt = req.get("initial_prompt")
-        language_detection_threshold = req.get("language_detection_threshold")
-        language_detection_segments = req.get("language_detection_segments")
-        language_fallback = req.get("language_fallback")
-
-        # Use daemon-level defaults when caller doesn't specify
-        if language_detection_threshold is None:
-            language_detection_threshold = self.language_detection_threshold
-        if language_detection_segments is None:
-            language_detection_segments = self.language_detection_segments
-        if language_fallback is None:
-            language_fallback = self.language_fallback
-
-        import gc
-        import time
-
-        from voicecli.runtime.transcribe import transcribe
-
-        try:
-            import torch
-
-            _oom_type: type = torch.cuda.OutOfMemoryError
-        except (ImportError, AttributeError):
-            _oom_type = type(None)  # never matches — no torch, no OOM handling
-
-        max_retries = 3
-        delay = 5
-        for attempt in range(1, max_retries + 1):
-            try:
-                result = transcribe(
-                    path,
-                    model=self.model,
-                    language=language,
-                    language_detection_threshold=language_detection_threshold,
-                    language_detection_segments=language_detection_segments,
-                    language_fallback=language_fallback,
-                    task=task,
-                    initial_prompt=initial_prompt,
-                )
-                _send_json(
-                    conn,
-                    {
-                        "status": "ok",
-                        "text": result.text,
-                        "language": result.language,
-                        "segments": result.segments,
-                    },
-                )
-                return
-            except Exception as e:  # noqa: BLE001
-                if isinstance(e, _oom_type):
-                    print(
-                        f"[voicecli stt] OOM loading model, retry {attempt}/{max_retries}"
-                        f" in {delay}s...",
-                        file=sys.stderr,
-                    )
-                    gc.collect()
-                    torch.cuda.empty_cache()
-                    time.sleep(delay)
-                    delay *= 2
-                else:
-                    print(f"[stt] transcribe_file error: {e}", file=sys.stderr)
-                    _send_json(conn, {"status": "error", "message": str(e)})
-                    return
-
-        _send_json(conn, {"status": "error", "message": f"CUDA OOM after {max_retries} retries"})
-
-    def _handle_toggle(self, conn: socket.socket, mode: str | None = None) -> None:
-        with self._lock:
-            state = self._state
-        if state == State.IDLE:
-            self._start_recording(conn, mode=mode)
-        elif state == State.RECORDING:
-            # _stop_and_transcribe blocks until transcription is done, then sends
-            # the response via conn.  The caller (_handle) must NOT close conn
-            # afterwards — _stop_and_transcribe takes ownership.
-            self._stop_and_transcribe(conn)
-        elif state == State.TRANSCRIBING:
-            self._queue_recording(conn)
-        elif state == State.QUEUED:
-            _send_json(conn, {"status": "ok", "state": State.QUEUED.value})
-
-    # ── State transitions ─────────────────────────────────────────────────────
 
     def _start_parecord_recording(self, level_callback=None) -> None:
         """Start parecord subprocess recording. Must be called with self._lock held."""
@@ -394,153 +269,6 @@ class SttDaemon:
             daemon=True,
         ).start()
         _send_json(conn, {"status": "ok", "state": State.RECORDING.value})
-
-    def _stop_and_transcribe(self, conn: socket.socket) -> None:
-        with self._lock:
-            self._state = State.TRANSCRIBING
-            rt = self._recording_thread
-            self._recording_thread = None
-            parecord_stop_ev = self._parecord_stop_event
-            self._parecord_stop_event = None
-            current_mode = self._current_mode
-            self._current_mode = None
-
-        # Collect WAV bytes from whichever recording path was active
-        if rt is not None:
-            wav_bytes = rt.stop()
-        elif parecord_stop_ev is not None:
-            parecord_stop_ev.set()
-            parecord_thread = self._parecord_thread
-            wav_holder = self._parecord_wav_holder
-            if parecord_thread is not None:
-                parecord_thread.join(timeout=3.0)
-            wav_bytes = wav_holder[0] if wav_holder else b""
-        else:
-            wav_bytes = b""
-
-        # Resolve mode params (mode overrides daemon-level settings)
-        transcribe_language = self.language
-        transcribe_task = "transcribe"
-        transcribe_prompt: str | None = None
-        if current_mode is not None:
-            try:
-                from voicecli.core.config import load_config
-                from voicecli.core.stt_modes import get_mode
-
-                mode_cfg = get_mode(current_mode, load_config())
-                if "language" in mode_cfg:
-                    transcribe_language = mode_cfg["language"]
-                if "task" in mode_cfg:
-                    transcribe_task = mode_cfg["task"]
-                if "prompt" in mode_cfg:
-                    transcribe_prompt = mode_cfg["prompt"]
-            except Exception as e:
-                print(f"[stt] mode resolve error: {e}", file=sys.stderr)
-
-        # Prepend personal vocab to the mode prompt (loaded fresh — no restart needed)
-        try:
-            from voicecli.core.config import load_vocab, vocab_to_prompt
-
-            vocab_fragment = vocab_to_prompt(load_vocab())
-            if vocab_fragment:
-                transcribe_prompt = (
-                    vocab_fragment + " " + transcribe_prompt
-                    if transcribe_prompt
-                    else vocab_fragment
-                )
-        except Exception as e:
-            print(f"[stt] vocab load error: {e}", file=sys.stderr)
-
-        tmp_path = _write_tempfile(wav_bytes)
-        text: str = ""
-        language: str | None = None
-        try:
-            from voicecli.runtime.transcribe import transcribe
-
-            result = transcribe(
-                tmp_path,
-                model=self.model,
-                language=transcribe_language,
-                language_detection_threshold=self.language_detection_threshold,
-                language_detection_segments=self.language_detection_segments,
-                language_fallback=self.language_fallback,
-                task=transcribe_task,
-                initial_prompt=transcribe_prompt,
-            )
-            text = result.text
-            language = result.language
-            print(f"[stt] detected language: {language}", file=sys.stderr)
-        except Exception as e:
-            print(f"[stt] transcription error: {e}", file=sys.stderr)
-        finally:
-            tmp_path.unlink(missing_ok=True)
-
-        try:
-            write_clipboard(text)
-        except Exception as e:
-            print(f"[stt] clipboard error: {e}", file=sys.stderr)
-
-        if text and self.auto_paste:
-            threading.Thread(target=auto_paste, daemon=True).start()
-
-        _save_recording(wav_bytes, text, language)
-
-        duration_s = wav_duration_s(wav_bytes)
-        append_history(text, language, current_mode, duration_s)
-
-        with self._lock:
-            queued = self._state == State.QUEUED
-            self._state = State.IDLE
-
-        _send_json(
-            conn, {"status": "ok", "state": State.IDLE.value, "text": text, "language": language}
-        )
-
-        if queued:
-            self._start_recording_async()
-
-    def _handle_cancel(self, conn: socket.socket) -> None:
-        with self._lock:
-            state = self._state
-            if state not in (State.RECORDING, State.QUEUED):
-                _send_json(conn, {"status": "ok", "state": State.IDLE.value})
-                return
-            self._state = State.IDLE
-            rt = self._recording_thread
-            self._recording_thread = None
-            stop_ev = self._parecord_stop_event
-            self._parecord_stop_event = None
-
-        if rt is not None:
-            threading.Thread(target=rt.stop, daemon=True).start()
-        if stop_ev is not None:
-            stop_ev.set()
-        _send_json(conn, {"status": "ok", "state": State.IDLE.value})
-
-    def _handle_next_mode(self, conn: socket.socket) -> None:
-        """Cycle to the next available mode and update default_mode."""
-        from voicecli.core.config import _find_config
-        from voicecli.core.stt_modes import load_modes
-
-        cfg_path = _find_config()
-        raw_cfg: dict = {}
-        if cfg_path:
-            import tomllib
-
-            with open(cfg_path, "rb") as f:
-                raw_cfg = tomllib.load(f)
-        modes = load_modes(raw_cfg)
-        mode_names = sorted(modes.keys())
-        current = self._current_mode or self.default_mode
-        if current in mode_names:
-            idx = (mode_names.index(current) + 1) % len(mode_names)
-        else:
-            idx = 0
-        next_mode = mode_names[idx]
-        self.default_mode = next_mode
-        self._current_mode = next_mode if self._state == State.RECORDING else None
-        desc = modes[next_mode].get("description", next_mode)
-        _send_json(conn, {"status": "ok", "mode": next_mode, "description": desc})
 
     def _queue_recording(self, conn: socket.socket) -> None:
         with self._lock:

--- a/src/voicecli/runtime/stt_daemon.py
+++ b/src/voicecli/runtime/stt_daemon.py
@@ -27,6 +27,15 @@ from voicecli.runtime.recording import (
     _probe_pyaudio,
     _record_parecord,
 )
+from voicecli.runtime.dictation import (
+    handle_cancel,
+    handle_next_mode,
+    handle_ping,
+    handle_status,
+    handle_toggle,
+    handle_transcribe_file,
+    handle_unknown,
+)
 
 MAX_MSG = 65536
 
@@ -190,16 +199,6 @@ class SttDaemon:
         except Exception:
             pass  # SO_PEERCRED unavailable (non-Linux) — skip check
         try:
-            from voicecli.runtime.dictation import (
-                handle_cancel,
-                handle_next_mode,
-                handle_ping,
-                handle_status,
-                handle_toggle,
-                handle_transcribe_file,
-                handle_unknown,
-            )
-
             req = _recv_json(conn)
             action = req.get("action")
             mode = req.get("mode") or None

--- a/src/voicecli/runtime/stt_daemon.py
+++ b/src/voicecli/runtime/stt_daemon.py
@@ -30,6 +30,14 @@ from voicecli.core.history import append_history, wav_duration_s
 from voicecli.core.paths import STT_SOCKET_PATH as SOCKET_PATH
 from voicecli.ui.sounds import play_ui_sound
 
+from voicecli.runtime.recording import (
+    RecordingThread,
+    _probe_pyaudio,
+    _record_parecord,
+    _write_tempfile,
+    _save_recording,
+)
+
 MAX_MSG = 65536
 
 
@@ -48,98 +56,6 @@ class State(Enum):
     RECORDING = "recording"
     TRANSCRIBING = "transcribing"
     QUEUED = "queued"
-
-
-# ── pyaudio probe ─────────────────────────────────────────────────────────────
-
-
-def _probe_pyaudio() -> bool:
-    """Return True if pyaudio is usable; print warning and return False otherwise."""
-    try:
-        import pyaudio
-
-        # Suppress ALSA/JACK noise that pyaudio prints unconditionally on startup
-        devnull_fd = os.open(os.devnull, os.O_WRONLY)
-        saved_stderr = os.dup(2)
-        os.dup2(devnull_fd, 2)
-        try:
-            pa = pyaudio.PyAudio()
-            try:
-                stream = pa.open(
-                    format=pyaudio.paInt16,
-                    channels=1,
-                    rate=16000,
-                    input=True,
-                    frames_per_buffer=1024,
-                )
-                stream.close()
-            finally:
-                pa.terminate()
-        finally:
-            os.dup2(saved_stderr, 2)
-            os.close(saved_stderr)
-            os.close(devnull_fd)
-        return True
-    except Exception as e:
-        print(f"[stt] pyaudio unavailable ({e}), falling back to parecord", file=sys.stderr)
-        return False
-
-
-# ── WAV helpers ───────────────────────────────────────────────────────────────
-
-
-def _frames_to_wav(frames: list[bytes], samplerate: int) -> bytes:
-    import io
-    import wave
-
-    buf = io.BytesIO()
-    with wave.open(buf, "wb") as wf:
-        wf.setnchannels(1)
-        wf.setsampwidth(2)
-        wf.setframerate(samplerate)
-        wf.writeframes(b"".join(frames))
-    return buf.getvalue()
-
-
-def _write_tempfile(wav_bytes: bytes) -> Path:
-    import os
-    import tempfile
-
-    fd, name = tempfile.mkstemp(suffix=".wav")
-    try:
-        os.write(fd, wav_bytes)
-    finally:
-        os.close(fd)
-    return Path(name)
-
-
-# ── Recording saver ───────────────────────────────────────────────────────────
-
-
-def _save_recording(wav_bytes: bytes, text: str, language: str | None) -> None:
-    """Save WAV audio and transcript to STT/audio_in and STT/texts_out."""
-    if not wav_bytes and not text:
-        return
-    from datetime import datetime
-
-    from voicecli.core.config import VOICECLI_DIR
-
-    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-    lang_tag = f"_{language}" if language else ""
-
-    if wav_bytes:
-        audio_dir = VOICECLI_DIR / "STT" / "audio_in"
-        audio_dir.mkdir(parents=True, exist_ok=True)
-        audio_path = audio_dir / f"dictate{lang_tag}_{ts}.wav"
-        audio_path.write_bytes(wav_bytes)
-        print(f"[stt] saved audio: {audio_path}", file=sys.stderr)
-
-    if text:
-        text_dir = VOICECLI_DIR / "STT" / "texts_out"
-        text_dir.mkdir(parents=True, exist_ok=True)
-        text_path = text_dir / f"dictate{lang_tag}_{ts}.txt"
-        text_path.write_text(text, encoding="utf-8")
-        print(f"[stt] saved transcript: {text_path}", file=sys.stderr)
 
 
 # ── Overlay launcher ──────────────────────────────────────────────────────────
@@ -181,142 +97,6 @@ def warmup(model: str) -> None:
     from voicecli.runtime.transcribe import warmup as _warmup
 
     _warmup(model)
-
-
-# ── Recording thread (pyaudio path) ──────────────────────────────────────────
-
-
-class RecordingThread(threading.Thread):
-    SAMPLERATE = 16000
-    CHANNELS = 1
-    CHUNK = 1024
-
-    def __init__(self, level_callback=None):
-        super().__init__(daemon=True)
-        self.level_callback = level_callback
-        self.frames: list[bytes] = []
-        self._stop_event = threading.Event()
-
-    def run(self) -> None:
-        import numpy as np
-        import pyaudio
-
-        # Suppress ALSA/JACK chatter on stream open
-        devnull_fd = os.open(os.devnull, os.O_WRONLY)
-        saved_stderr = os.dup(2)
-        os.dup2(devnull_fd, 2)
-        try:
-            pa = pyaudio.PyAudio()
-            stream = pa.open(
-                format=pyaudio.paInt16,
-                channels=self.CHANNELS,
-                rate=self.SAMPLERATE,
-                input=True,
-                frames_per_buffer=self.CHUNK,
-            )
-        finally:
-            os.dup2(saved_stderr, 2)
-            os.close(saved_stderr)
-            os.close(devnull_fd)
-
-        while not self._stop_event.is_set():
-            data = stream.read(self.CHUNK, exception_on_overflow=False)
-            self.frames.append(data)
-            if self.level_callback:
-                level = np.abs(np.frombuffer(data, dtype=np.int16)).mean() / 32768.0
-                self.level_callback(level)
-        stream.stop_stream()
-        stream.close()
-        pa.terminate()
-
-    def stop(self) -> bytes:
-        self._stop_event.set()
-        self.join(timeout=2.0)
-        if self.is_alive():
-            print(
-                "[stt] WARNING: RecordingThread did not stop in 2s — audio may be truncated",
-                file=sys.stderr,
-                flush=True,
-            )
-        return _frames_to_wav(self.frames, self.SAMPLERATE)
-
-
-# ── parecord fallback ─────────────────────────────────────────────────────────
-
-
-def _record_parecord(stop_event: threading.Event, level_callback=None) -> bytes:
-    """Record via PulseAudio until stop_event is set; return WAV bytes.
-
-    Prefers `parec` (raw PCM to stdout) which enables real-time level callbacks.
-    Falls back to `parecord` (WAV to temp file, no levels) if parec is absent.
-    """
-    import shutil
-    import subprocess
-    import tempfile
-
-    SAMPLERATE = 16000
-    CHUNK = 3200  # ~100 ms at 16 kHz 16-bit mono
-
-    parec = shutil.which("parec")
-    if parec:
-        # parec writes raw s16le to stdout — ideal for real-time processing
-        proc = subprocess.Popen(
-            [parec, "--format=s16le", f"--rate={SAMPLERATE}", "--channels=1"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-        )
-        frames: list[bytes] = []
-
-        def _reader() -> None:
-            import numpy as np
-
-            assert proc.stdout is not None
-            while True:
-                data = proc.stdout.read(CHUNK)
-                if not data:
-                    break
-                frames.append(data)
-                if level_callback and len(data) >= 2:
-                    samps = np.frombuffer(data, dtype=np.int16)
-                    level_callback(float(np.sqrt(np.mean(samps.astype(np.float32) ** 2))) / 32768.0)
-
-        reader = threading.Thread(target=_reader, daemon=True)
-        reader.start()
-        stop_event.wait()
-        proc.terminate()
-        try:
-            proc.wait(timeout=2.0)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-        reader.join(timeout=2.0)
-        return _frames_to_wav(frames, SAMPLERATE)
-
-    # Fallback: parecord writes WAV to a temp file (no real-time level data)
-    parecord = shutil.which("parecord")
-    if not parecord:
-        return b""
-    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
-        tmp_path = Path(f.name)
-    try:
-        proc2 = subprocess.Popen(
-            [
-                parecord,
-                "--format=s16le",
-                f"--rate={SAMPLERATE}",
-                "--channels=1",
-                "--file-format=wav",
-                str(tmp_path),
-            ]
-        )
-        stop_event.wait()
-        proc2.terminate()
-        try:
-            proc2.wait(timeout=2.0)
-        except subprocess.TimeoutExpired:
-            proc2.kill()
-        return tmp_path.read_bytes() if tmp_path.exists() else b""
-    finally:
-        tmp_path.unlink(missing_ok=True)
 
 
 # ── SttDaemon ────────────────────────────────────────────────────────────────

--- a/tests/test_stt_daemon.py
+++ b/tests/test_stt_daemon.py
@@ -1,8 +1,4 @@
-"""Tests for voicecli.stt_daemon — RED phase.
-
-The implementation (src/voicecli/stt_daemon.py) does not exist yet.
-All tests are expected to fail with ImportError until the GREEN phase.
-"""
+"""Tests for voicecli.runtime.stt_daemon."""
 
 from __future__ import annotations
 
@@ -62,11 +58,11 @@ def daemon_send(tmp_path):
     mock_warmup = MagicMock()
 
     with (
-        patch("voicecli.runtime.stt_daemon._probe_pyaudio", return_value=True),
-        patch("voicecli.runtime.stt_daemon.RecordingThread", mock_recording_thread_cls),
+        patch("voicecli.runtime.recording._probe_pyaudio", return_value=True),
+        patch("voicecli.runtime.recording.RecordingThread", mock_recording_thread_cls),
         patch("voicecli.runtime.stt_daemon.play_ui_sound", mock_play_ui_sound),
         patch("voicecli.runtime.stt_daemon._spawn_overlay", MagicMock()),
-        patch("voicecli.runtime.stt_daemon.write_clipboard", mock_write_clipboard),
+        patch("voicecli.ui.clipboard.write_clipboard", mock_write_clipboard),
         patch("voicecli.runtime.stt_daemon.warmup", mock_warmup),
         # stt_daemon._stop_and_transcribe() imports transcribe via a deferred
         # `from voicecli.runtime.transcribe import transcribe` inside the function body.
@@ -254,16 +250,16 @@ class TestTranscriptionAndClipboard:
         created_paths: list[Path] = []
 
         # Wrap _write_tempfile to capture the path it creates.
-        import voicecli.runtime.stt_daemon as stt_mod
+        import voicecli.runtime.recording as recording_mod
 
-        original_write_tempfile = stt_mod._write_tempfile
+        original_write_tempfile = recording_mod._write_tempfile
 
         def tracking_write_tempfile(wav_bytes: bytes) -> Path:
             p = original_write_tempfile(wav_bytes)
             created_paths.append(p)
             return p
 
-        monkeypatch.setattr(stt_mod, "_write_tempfile", tracking_write_tempfile)
+        monkeypatch.setattr(recording_mod, "_write_tempfile", tracking_write_tempfile)
 
         # Arrange
         send("toggle")  # N3
@@ -279,18 +275,18 @@ class TestTranscriptionAndClipboard:
         """Tempfile is deleted even when transcribe() raises an exception."""
         send, _, _ = daemon_send
 
-        import voicecli.runtime.stt_daemon as stt_mod
+        import voicecli.runtime.recording as recording_mod
         import voicecli.runtime.transcribe as transcribe_mod
 
         created_paths: list[Path] = []
-        original_write_tempfile = stt_mod._write_tempfile
+        original_write_tempfile = recording_mod._write_tempfile
 
         def tracking_write_tempfile(wav_bytes: bytes) -> Path:
             p = original_write_tempfile(wav_bytes)
             created_paths.append(p)
             return p
 
-        monkeypatch.setattr(stt_mod, "_write_tempfile", tracking_write_tempfile)
+        monkeypatch.setattr(recording_mod, "_write_tempfile", tracking_write_tempfile)
         from unittest.mock import MagicMock
 
         monkeypatch.setattr(
@@ -323,7 +319,7 @@ class TestTranscriptionAndClipboard:
         from unittest.mock import MagicMock
 
         monkeypatch.setattr(
-            "voicecli.runtime.stt_daemon.write_clipboard",
+            "voicecli.ui.clipboard.write_clipboard",
             MagicMock(side_effect=OSError("no display")),
         )
         send("toggle")  # N3: start recording
@@ -474,8 +470,6 @@ class TestQueueSupport:
 
         # Cleanup: stop the auto-started recording
         # Use a new non-blocking transcribe for cleanup
-        import voicecli.runtime.stt_daemon as stt_mod
-
         monkeypatch.setattr(transcribe_mod, "transcribe", lambda *a, **kw: _MOCK_TRANSCRIPTION)
         send("toggle")  # N4 on the auto-started recording
 
@@ -506,12 +500,12 @@ class TestPaRecordFallback:
         mock_warmup = MagicMock()
 
         with (
-            patch("voicecli.runtime.stt_daemon._probe_pyaudio", return_value=False),
-            patch("voicecli.runtime.stt_daemon._record_parecord", mock_record_parecord),
-            patch("voicecli.runtime.stt_daemon.RecordingThread", mock_recording_thread_cls),
+            patch("voicecli.runtime.recording._probe_pyaudio", return_value=False),
+            patch("voicecli.runtime.recording._record_parecord", mock_record_parecord),
+            patch("voicecli.runtime.recording.RecordingThread", mock_recording_thread_cls),
             patch("voicecli.runtime.stt_daemon.play_ui_sound", MagicMock()),
             patch("voicecli.runtime.stt_daemon._spawn_overlay", MagicMock()),
-            patch("voicecli.runtime.stt_daemon.write_clipboard", mock_write_clipboard),
+            patch("voicecli.ui.clipboard.write_clipboard", mock_write_clipboard),
             patch("voicecli.runtime.stt_daemon.warmup", mock_warmup),
             patch("voicecli.runtime.transcribe.transcribe", return_value=_MOCK_TRANSCRIPTION),
         ):

--- a/tests/test_stt_daemon.py
+++ b/tests/test_stt_daemon.py
@@ -64,7 +64,7 @@ def daemon_send(tmp_path):
         patch("voicecli.runtime.stt_daemon._spawn_overlay", MagicMock()),
         patch("voicecli.ui.clipboard.write_clipboard", mock_write_clipboard),
         patch("voicecli.runtime.stt_daemon.warmup", mock_warmup),
-        # stt_daemon._stop_and_transcribe() imports transcribe via a deferred
+        # dictation._stop_and_transcribe() imports transcribe via a deferred
         # `from voicecli.runtime.transcribe import transcribe` inside the function body.
         # Patching voicecli.transcribe.transcribe intercepts this import at call
         # time.  S4 tests use monkeypatch.setattr(transcribe_mod, "transcribe", …)

--- a/tests/test_vram_lifecycle.py
+++ b/tests/test_vram_lifecycle.py
@@ -15,6 +15,8 @@ import pytest
 
 pytest.importorskip("torch", reason="torch is opt-in via [stt]/[tts]/[all] extras")
 
+from voicecli.runtime.dictation import handle_transcribe_file
+
 
 class TestVramCleanup:
     def test_calls_gc_collect(self):
@@ -224,7 +226,7 @@ class TestSttOomRetry:
             req = {"action": "transcribe_file", "audio_path": str(audio_path)}
 
             # Act
-            daemon._handle_transcribe_file(fake_conn, req)
+            handle_transcribe_file(daemon, fake_conn, req)
 
         # Assert — exactly 2 transcribe calls (1 OOM + 1 success)
         assert call_count["n"] == 2
@@ -260,7 +262,7 @@ class TestSttOomRetry:
             req = {"action": "transcribe_file", "audio_path": str(audio_path)}
 
             # Act
-            daemon._handle_transcribe_file(fake_conn, req)
+            handle_transcribe_file(daemon, fake_conn, req)
 
         # Assert — daemon sends one final error response after exhausting retries
         assert fake_conn.sendall.call_count >= 1
@@ -298,7 +300,7 @@ class TestSttOomRetry:
             req = {"action": "transcribe_file", "audio_path": str(audio_path)}
 
             # Act
-            daemon._handle_transcribe_file(fake_conn, req)
+            handle_transcribe_file(daemon, fake_conn, req)
 
         # Assert — error returned immediately, no sleep/retry
         assert fake_conn.sendall.call_count >= 1

--- a/tools/file_exemptions.txt
+++ b/tools/file_exemptions.txt
@@ -4,7 +4,6 @@
 src/voicecli/cli/main.py https://github.com/Roxabi/voiceCLI/issues/129
 src/voicecli/cli/dictate.py https://github.com/Roxabi/voiceCLI/issues/129
 src/voicecli/api/api.py https://github.com/Roxabi/voiceCLI/issues/81
-src/voicecli/runtime/stt_daemon.py https://github.com/Roxabi/voiceCLI/issues/82
 src/voicecli/runtime/wire_protocol.py https://github.com/Roxabi/voiceCLI/issues/82
 src/voicecli/runtime/transcribe.py https://github.com/Roxabi/voiceCLI/issues/82
 src/voicecli/adapters/synthesis.py https://github.com/Roxabi/voiceCLI/issues/170


### PR DESCRIPTION
## Summary
- Extract 784-line `stt_daemon.py` god object into focused layer modules:
  - `recording.py` — pyaudio/parecord recording, WAV helpers, temp files
  - `dictation.py` — socket action handlers (toggle, cancel, transcribe, etc.)
- Thin `stt_daemon.py` to 292 LOC bootstrap (state machine + socket loop + dispatch)
- Remove file-length exemption (now under 300 LOC budget)
- Preserve CLI surface (`voicecli stt-serve`) and AF_UNIX JSON socket contract

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #82: split src/voicecli/stt_daemon.py (993 LOC) into focused modules | OPEN |
| Frame | [82-split-runtime-stt-daemon-frame.mdx](artifacts/frames/82-split-runtime-stt-daemon-frame.mdx) | Present |
| Spec | [82-split-runtime-stt-daemon-spec.mdx](artifacts/specs/82-split-runtime-stt-daemon-spec.mdx) | Present |
| Plan | [82-split-runtime-stt-daemon-plan.mdx](artifacts/plans/82-split-runtime-stt-daemon-plan.mdx) | Present |
| Implementation | 3 commits on `feat/82-split-runtime-stt-daemon` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (596 passed) | Passed |

## Test Plan
- [ ] `voicecli stt-serve` starts and responds to ping/status/toggle/cancel
- [ ] Full toggle cycle (idle→recording→transcribing→idle) returns transcript
- [ ] PaRecord fallback path works when pyaudio is unavailable
- [ ] Queue behavior (toggle during transcribing → queued → auto-restart)

Closes #82

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`