### PR TITLE
feat(nats): TTS NATS client — voicecli generate --via-nats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,18 @@ voicecli stt-serve &
 
 ¬allow-coexist on RTX 3080 (10GB) prod — OOMs under concurrent synthesis. Full guard + exit codes: [`docs/NATS-SERVE.md#vram-sequencing`](docs/NATS-SERVE.md#vram-sequencing).
 
+### NATS client — synthesize from any host
+
+From a non-satellite host (M₂, laptop, …) → `voicecli generate --via-nats "text"` routes synthesis to the hub TTS satellite over NATS, decodes the reply, writes the WAV locally. ¬loads model on caller. Mirror of `voicecli dictate nats` (STT side).
+
+| Flag / env | Effect |
+|---|---|
+| `--via-nats` ∨ `VOICECLI_VIA_NATS=1` | Bypass socket-daemon/standalone; request/reply on `lyra.voice.tts.request` |
+| `--timeout <s>` | NATS request timeout (default 60s) |
+| `.md` input | Frontmatter + segments flattened client-side → single `text` field sent to satellite (V1, no per-segment multi-language) |
+
+Requires `NATS_URL` + `NATS_NKEY_SEED_PATH` env (same as STT client).
+
 ### Container deployment (Quadlet)
 
 Production hosts can run voiceCLI as a Podman container managed by systemd via Quadlet. Unit files in `deploy/quadlet/` define TTS and STT NATS satellites with GPU passthrough.

--- a/docs/NATS-SERVE.md
+++ b/docs/NATS-SERVE.md
@@ -33,6 +33,45 @@ Both subcommands are now available: `nats-serve tts` (Slice 1) and `nats-serve s
 
 ---
 
+## Client side — synthesize from any host
+
+For consumers on a host **without** the model loaded (e.g. M₂, laptop, any tailnet member), `voicecli generate` can route through the hub satellite instead of loading models locally.
+
+```bash
+# Synthesize via NATS → WAV lands in ~/.voicecli/TTS/voices_out/
+voicecli generate --via-nats "Bonjour le monde"
+
+# Env-driven (same effect)
+VOICECLI_VIA_NATS=1 voicecli generate "Bonjour le monde"
+
+# Specify engine + voice + language
+voicecli generate --via-nats "Bonjour" -e qwen-fast --lang French --voice anna
+
+# Custom timeout (default 60s)
+voicecli generate --via-nats --timeout 90 "..."
+
+# Markdown input (frontmatter + segments flattened client-side, single text sent)
+voicecli generate --via-nats path/to/script.md
+```
+
+| Flag / env | Default | Effect |
+|---|---|---|
+| `--via-nats` / `VOICECLI_VIA_NATS=1` | off | route through NATS instead of socket-daemon/standalone |
+| `--timeout <s>` | 60 | NATS request timeout (one-shot reply, no streaming) |
+| `--engine`, `--voice`, `--lang` | satellite defaults | mapped to `TtsRequest` fields |
+
+Requires `NATS_URL` set (e.g. `tls://hub:4222`) and an NKey seed at the path declared in `voicecli.toml` `[nats].nkey_seed_path` (default `~/.voicecli/nkeys/voice-client.seed`). The client uses `inbox_prefix=_inbox.voice-client` (ACL-aligned with the STT client).
+
+**V1 non-goals** (use local socket daemon for these):
+- Per-segment multi-language synthesis — `TtsRequest.text` is a single string
+- Streaming audio — one-shot reply only
+- Voice cloning over NATS — only `generate`; use local `voicecli clone` for cloning
+- Auto-routing when `NATS_URL` is set — flag/env is always explicit
+
+Underlying adapter: [`src/voicecli/adapters/nats/synthesize_client.py`](../src/voicecli/adapters/nats/synthesize_client.py).
+
+---
+
 ## Environment variables
 
 Precedence: `CLI flag > env var > voicecli.toml > hardcoded default`

--- a/plugins/voice-cli/skills/voice/SKILL.md
+++ b/plugins/voice-cli/skills/voice/SKILL.md
@@ -252,7 +252,11 @@ voicecli generate "text" --fast                       # 0.6B model (faster, lowe
 voicecli generate "Long text" --chunked               # progressive output (separate files)
 voicecli generate "Long text" --chunked --chunk-size 300  # smaller chunks (~20s each)
 voicecli generate article.txt --chunked               # long plain text file → chunks
+voicecli generate "Bonjour" --via-nats                # route through hub TTS satellite (no local model load)
+voicecli generate script.md --via-nats --timeout 90   # ditto, with custom NATS request timeout
 ```
+
+`--via-nats` (or `VOICECLI_VIA_NATS=1`) sends the request to the hub satellite over NATS and writes the returned WAV locally — useful from hosts without GPU/model. Requires `NATS_URL` + an NKey seed. Full guide: [`docs/NATS-SERVE.md#client-side`](../../../../../docs/NATS-SERVE.md#client-side--synthesize-from-any-host).
 
 ### Clone (voice cloning)
 

--- a/src/voicecli/adapters/nats/synthesize_client.py
+++ b/src/voicecli/adapters/nats/synthesize_client.py
@@ -1,0 +1,114 @@
+"""One-shot NATS TTS client for CLI synthesis.
+
+Connects to NATS, sends a synthesis request, and returns the result.
+No daemon, no heartbeats — just request/reply.
+
+Mirror of ``transcribe_client.py`` (STT side).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+from roxabi_contracts.envelope import CONTRACT_VERSION
+from roxabi_contracts.voice import SUBJECTS as VOICE_SUBJECTS
+from roxabi_contracts.voice.models import TtsRequest, TtsResponse
+from roxabi_nats import nats_connect
+
+log = logging.getLogger(__name__)
+
+SUBJECT = VOICE_SUBJECTS.tts_request
+DEFAULT_TIMEOUT = 60.0
+
+
+async def synthesize_via_nats(
+    text: str,
+    *,
+    engine: str | None = None,
+    voice: str | None = None,
+    language: str | None = None,
+    chunked: bool = True,
+    chunk_size: int | None = None,
+    segment_gap: float | None = None,
+    crossfade: float | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> dict[str, Any]:
+    """Send text to NATS TTS satellite, return synthesized audio.
+
+    Args:
+        text: Text to synthesize.
+        engine: TTS engine name (e.g., ``qwen-fast``). ``None`` → satellite default.
+        voice: Voice name. ``None`` → satellite default.
+        language: Language name (e.g., ``French``). ``None`` → satellite default.
+        chunked: Whether to enable chunked synthesis (satellite-side).
+        chunk_size: Target chunk size in characters.
+        segment_gap: Silence between segments (seconds).
+        crossfade: Fade between segments (seconds).
+        timeout: NATS request timeout in seconds.
+
+    Returns:
+        On success: ``{"audio": bytes, "mime_type": str, "duration_ms": int}``.
+        On failure: ``{"error": str}``.
+    """
+    nats_url = os.environ.get("NATS_URL")
+    if not nats_url:
+        return {"error": "NATS_URL environment variable not set"}
+
+    try:
+        nc = await nats_connect(nats_url, inbox_prefix="_inbox.voice-client")
+    except Exception as e:
+        log.error("NATS connection failed: %s", e)
+        return {"error": f"Cannot connect to NATS: {e}"}
+
+    try:
+        request_id = str(uuid4())
+
+        request = TtsRequest(
+            contract_version=CONTRACT_VERSION,
+            trace_id=request_id,
+            issued_at=datetime.now(timezone.utc),
+            request_id=request_id,
+            text=text,
+            engine=engine,
+            voice=voice,
+            language=language,
+            chunked=chunked,
+            chunk_size=chunk_size,
+            segment_gap=segment_gap,
+            crossfade=crossfade,
+        )
+
+        payload = request.model_dump_json(exclude_none=True).encode("utf-8")
+        reply = await nc.request(SUBJECT, payload, timeout=timeout)
+        tts_response = TtsResponse.model_validate_json(reply.data)
+
+        if tts_response.ok:
+            assert tts_response.audio_b64 is not None
+            assert tts_response.mime_type is not None
+            assert tts_response.duration_ms is not None
+            return {
+                "audio": base64.b64decode(tts_response.audio_b64),
+                "mime_type": tts_response.mime_type,
+                "duration_ms": tts_response.duration_ms,
+            }
+        else:
+            return {"error": tts_response.error or "synthesis failed"}
+
+    except asyncio.TimeoutError:
+        log.warning("NATS TTS request timed out after %ss", timeout)
+        return {"error": f"request timed out after {timeout}s"}
+    except Exception as e:
+        log.exception("NATS TTS request failed")
+        return {"error": str(e)}
+    finally:
+        try:
+            await nc.drain()
+            await nc.close()
+        except Exception:
+            pass

--- a/src/voicecli/cli/main.py
+++ b/src/voicecli/cli/main.py
@@ -145,8 +145,39 @@ def generate(
         Optional[Path],
         typer.Option("--config", help="Explicit path to voicecli.toml (overrides walk-up search)"),
     ] = None,
+    via_nats: Annotated[
+        bool,
+        typer.Option(
+            "--via-nats",
+            envvar="VOICECLI_VIA_NATS",
+            help="Route synthesis through the hub TTS satellite over NATS (request/reply).",
+        ),
+    ] = False,
+    timeout: Annotated[
+        float,
+        typer.Option(
+            "--timeout",
+            help="NATS request timeout in seconds (only with --via-nats)",
+        ),
+    ] = 60.0,
 ):
     """Generate speech from text or a markdown file using a built-in voice."""
+    if via_nats:
+        _generate_via_nats(
+            text=text,
+            engine="qwen-fast" if fast else engine,
+            voice=voice,
+            output=output,
+            language=language,
+            chunked=chunked,
+            chunk_size=chunk_size,
+            segment_gap=segment_gap,
+            crossfade=crossfade,
+            plain=plain,
+            timeout=timeout,
+        )
+        return
+
     from voicecli.api import generate as api_generate
 
     extra: dict = {}
@@ -190,6 +221,93 @@ def generate(
     except RuntimeError as e:
         _print_cuda_error(str(e))
         raise typer.Exit(1)
+
+
+def _resolve_text_for_nats(
+    text: str, *, plain: bool
+) -> tuple[str, str | None, str | None, str | None]:
+    """Resolve CLI text arg to plain text for the satellite.
+
+    `.md` ⇒ parse frontmatter + directives, flatten segments → plain text.
+    Returns ``(plain_text, language, voice, engine)`` where language/voice/engine come
+    from the markdown frontmatter (None if absent or input is raw text).
+    """
+    text_path = Path(text)
+    if text_path.suffix == ".md" and text_path.exists():
+        from voicecli.api.input import _flatten_doc
+        from voicecli.api.markdown import parse_md_file
+
+        doc = parse_md_file(text_path)
+        _flatten_doc(doc)
+        return doc.text, doc.language, doc.voice, doc.engine
+    if text_path.suffix == ".txt" and text_path.exists():
+        return text_path.read_text(encoding="utf-8"), None, None, None
+    return text, None, None, None
+
+
+def _generate_via_nats(
+    *,
+    text: str,
+    engine: str | None,
+    voice: str | None,
+    output: Optional[Path],
+    language: str | None,
+    chunked: bool,
+    chunk_size: int | None,
+    segment_gap: int | None,
+    crossfade: int | None,
+    plain: bool,
+    timeout: float,
+) -> None:
+    """Synthesize via NATS TTS satellite, write WAV to ``output`` or default path."""
+    import asyncio
+
+    from voicecli.adapters.nats.synthesize_client import synthesize_via_nats
+    from voicecli.core.utils import build_output_prefix, default_output_path
+
+    text_path = Path(text)
+    script_stem = (
+        text_path.stem if text_path.suffix in {".md", ".txt"} and text_path.exists() else None
+    )
+
+    plain_text, md_lang, md_voice, md_engine = _resolve_text_for_nats(text, plain=plain)
+
+    resolved_engine = engine or md_engine or "qwen-fast"
+    resolved_voice = voice or md_voice
+    resolved_language = language or md_lang
+
+    result = asyncio.run(
+        synthesize_via_nats(
+            plain_text,
+            engine=resolved_engine,
+            voice=resolved_voice,
+            language=resolved_language,
+            chunked=chunked,
+            chunk_size=chunk_size,
+            segment_gap=float(segment_gap) if segment_gap is not None else None,
+            crossfade=float(crossfade) if crossfade is not None else None,
+            timeout=timeout,
+        )
+    )
+
+    if "error" in result:
+        typer.echo(f"Error: {result['error']}", err=True)
+        raise typer.Exit(1)
+
+    if output is not None:
+        out_path = output
+    else:
+        prefix = build_output_prefix(
+            resolved_engine,
+            script=script_stem,
+            voice=resolved_voice,
+            language=resolved_language,
+        )
+        out_path = default_output_path(prefix=prefix, fmt="wav")
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_bytes(result["audio"])
+    typer.echo(f"Saved to {out_path}")
 
 
 @app.command()

--- a/tests/nats/test_synthesize_client.py
+++ b/tests/nats/test_synthesize_client.py
@@ -1,0 +1,149 @@
+"""Tests for ``synthesize_via_nats`` — the client-side NATS TTS helper.
+
+Mirror of ``test_stt_adapter`` style — pin happy + 4 error paths.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+
+import pytest
+
+from voicecli.adapters.nats import synthesize_client
+
+
+class _FakeReply:
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+
+
+class _FakeNc:
+    def __init__(
+        self, reply_payload: bytes | None = None, raise_on_request: BaseException | None = None
+    ) -> None:
+        self._reply_payload = reply_payload
+        self._raise_on_request = raise_on_request
+        self.drained = False
+        self.closed = False
+        self.requests: list[tuple[str, bytes, float]] = []
+
+    async def request(self, subject: str, payload: bytes, timeout: float):
+        self.requests.append((subject, payload, timeout))
+        if self._raise_on_request is not None:
+            raise self._raise_on_request
+        assert self._reply_payload is not None
+        return _FakeReply(self._reply_payload)
+
+    async def drain(self) -> None:
+        self.drained = True
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _tts_response_ok(audio: bytes, request_id: str = "rid-1") -> bytes:
+    return json.dumps(
+        {
+            "contract_version": "1.0",
+            "trace_id": request_id,
+            "issued_at": "2026-01-01T00:00:00Z",
+            "ok": True,
+            "request_id": request_id,
+            "audio_b64": base64.b64encode(audio).decode("ascii"),
+            "mime_type": "audio/wav",
+            "duration_ms": 1234,
+        }
+    ).encode("utf-8")
+
+
+def _tts_response_err(error: str, request_id: str = "rid-1") -> bytes:
+    return json.dumps(
+        {
+            "contract_version": "1.0",
+            "trace_id": request_id,
+            "issued_at": "2026-01-01T00:00:00Z",
+            "ok": False,
+            "request_id": request_id,
+            "error": error,
+        }
+    ).encode("utf-8")
+
+
+def test_happy_path_returns_decoded_audio(monkeypatch: pytest.MonkeyPatch) -> None:
+    audio = b"RIFF\x00\x00\x00\x00WAVEfake-wav-bytes"
+    fake_nc = _FakeNc(reply_payload=_tts_response_ok(audio))
+
+    async def fake_connect(url: str, **kwargs):
+        assert url == "nats://example:4222"
+        assert kwargs.get("inbox_prefix") == "_inbox.voice-client"
+        return fake_nc
+
+    monkeypatch.setenv("NATS_URL", "nats://example:4222")
+    monkeypatch.setattr(synthesize_client, "nats_connect", fake_connect)
+
+    result = asyncio.run(synthesize_client.synthesize_via_nats("Bonjour", engine="qwen-fast"))
+
+    assert result["audio"] == audio
+    assert result["mime_type"] == "audio/wav"
+    assert result["duration_ms"] == 1234
+    assert fake_nc.drained and fake_nc.closed
+    subject, payload, timeout = fake_nc.requests[0]
+    assert subject == "lyra.voice.tts.request"
+    assert timeout == 60.0
+    sent = json.loads(payload)
+    assert sent["text"] == "Bonjour"
+    assert sent["engine"] == "qwen-fast"
+
+
+def test_error_response_from_satellite_surfaces(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_nc = _FakeNc(reply_payload=_tts_response_err("engine OOM"))
+
+    async def fake_connect(url: str, **kwargs):
+        return fake_nc
+
+    monkeypatch.setenv("NATS_URL", "nats://example:4222")
+    monkeypatch.setattr(synthesize_client, "nats_connect", fake_connect)
+
+    result = asyncio.run(synthesize_client.synthesize_via_nats("Bonjour"))
+
+    assert result == {"error": "engine OOM"}
+    assert fake_nc.drained and fake_nc.closed
+
+
+def test_timeout_returns_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_nc = _FakeNc(raise_on_request=asyncio.TimeoutError())
+
+    async def fake_connect(url: str, **kwargs):
+        return fake_nc
+
+    monkeypatch.setenv("NATS_URL", "nats://example:4222")
+    monkeypatch.setattr(synthesize_client, "nats_connect", fake_connect)
+
+    result = asyncio.run(synthesize_client.synthesize_via_nats("Bonjour", timeout=5.0))
+
+    assert "timed out" in result["error"]
+    assert "5.0" in result["error"]
+    assert fake_nc.drained and fake_nc.closed
+
+
+def test_missing_nats_url_returns_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NATS_URL", raising=False)
+
+    result = asyncio.run(synthesize_client.synthesize_via_nats("Bonjour"))
+
+    assert result == {"error": "NATS_URL environment variable not set"}
+
+
+def test_connect_failure_returns_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_connect(url: str, **kwargs):
+        raise ConnectionRefusedError("nats unreachable")
+
+    monkeypatch.setenv("NATS_URL", "nats://example:4222")
+    monkeypatch.setattr(synthesize_client, "nats_connect", fake_connect)
+
+    result = asyncio.run(synthesize_client.synthesize_via_nats("Bonjour"))
+
+    assert "Cannot connect to NATS" in result["error"]
+    assert "nats unreachable" in result["error"]


### PR DESCRIPTION
## Summary
- Add `voicecli generate --via-nats` (env `VOICECLI_VIA_NATS=1`) to route synthesis through the hub TTS satellite over NATS — caller no longer needs the model loaded locally. Mirror of the STT side (`transcribe_client.py` → `voicecli dictate nats`).
- New `src/voicecli/adapters/nats/synthesize_client.py::synthesize_via_nats()` — one-shot request/reply on `lyra.voice.tts.request`, decodes WAV from `TtsResponse.audio_b64`, returns `{"audio": bytes, "mime_type": str, "duration_ms": int}` on success or `{"error": str}` on any failure path.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #177: feat(nats): TTS NATS client — voicecli generate --via-nats | Open |
| Implementation | 1 commit on `feat/177-tts-nats-client` | Complete |
| Verification | Lint ✅ · Typecheck ✅ · Tests ✅ (5 new + 244 existing NATS pass) | Passed |

S-tier — no analysis/spec artifacts; the issue body served as the spec.

## What changed

| File | Change |
|---|---|
| `src/voicecli/adapters/nats/synthesize_client.py` | new — async one-shot NATS client |
| `src/voicecli/cli/main.py::generate()` | adds `--via-nats`, `--timeout`, routes to NATS path when set |
| `tests/nats/test_synthesize_client.py` | new — happy + 4 error paths |
| `CLAUDE.md` | adds "NATS client — synthesize from any host" section |
| `docs/NATS-SERVE.md` | adds "Client side" section with examples |
| `plugins/voice-cli/skills/voice/SKILL.md` | adds `--via-nats` flag reference |

## Test Plan
- [ ] On M₂ (or any non-M₁ host) with `NATS_URL` set + `voice-client.seed` present: `voicecli generate --via-nats "Bonjour"` → WAV lands in `~/.voicecli/TTS/voices_out/`
- [ ] `VOICECLI_VIA_NATS=1 voicecli generate "Bonjour"` (env equivalence)
- [ ] Default behavior unchanged: `voicecli generate "Bonjour"` still goes through local socket-daemon/standalone
- [ ] Markdown input: `voicecli generate --via-nats path/to/script.md` → frontmatter stripped client-side, plain text reaches satellite
- [ ] Timeout: `voicecli generate --via-nats --timeout 1 "long text"` → exits non-zero with "request timed out after 1.0s"

## Non-goals (V1)
- Per-segment multi-language synthesis — `TtsRequest.text` is a single string
- Streaming audio — one-shot reply only
- Voice clone over NATS — only `generate`
- Auto-routing when `NATS_URL` is set — flag/env is always explicit

Closes #177

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`