### PR TITLE
fix(runtime): replace removed roxabi_nats.sanitize_for_wire

### DIFF
--- a/src/voicecli/runtime/transcribe_daemon.py
+++ b/src/voicecli/runtime/transcribe_daemon.py
@@ -14,10 +14,8 @@ import threading
 from enum import Enum
 from pathlib import Path
 
-from roxabi_nats import sanitize_for_wire
-
 from voicecli.core.config import load_stt_config
-from voicecli.runtime.wire_protocol import recv_json
+from voicecli.runtime.wire_protocol import _sanitize_for_wire, recv_json
 from voicecli.runtime.wire_protocol import send_json as _send_json
 from voicecli.core.paths import STT_SOCKET_PATH as SOCKET_PATH
 from voicecli.ui.sounds import play_ui_sound
@@ -218,7 +216,7 @@ class SttDaemon:
                 handle_unknown(self, conn, action)
         except Exception as exc:
             try:
-                _send_json(conn, {"status": "error", "message": sanitize_for_wire(exc)})
+                _send_json(conn, {"status": "error", "message": _sanitize_for_wire(exc)})
             except Exception:
                 pass
         finally:

--- a/src/voicecli/runtime/wire_protocol.py
+++ b/src/voicecli/runtime/wire_protocol.py
@@ -12,14 +12,22 @@ import math
 import socket
 from pathlib import Path
 
-from roxabi_nats import sanitize_for_wire
-
 from voicecli.engines.engine import QWEN_ENGINES
 
 
 _STR_MAX = 256
 _TEXT_MAX = 100_000
 DEFAULT_MAX_MSG = 262_144  # 256 KB — covers _TEXT_MAX 100k + envelope
+
+
+def _sanitize_for_wire(exc: BaseException) -> str:
+    """Render an exception as a one-line wire-safe string.
+
+    Replaces the removed ``roxabi_nats.sanitize_for_wire`` so the local
+    daemon's error-reply contract stays stable across upstream changes.
+    """
+    return repr(exc)[:512].replace("\n", " ").replace("\r", " ")
+
 
 # Patchable in tests — must stay in sync with daemon._OUTPUT_BASE
 _OUTPUT_BASE = Path.home()
@@ -316,7 +324,7 @@ def handle_job(
 
     except Exception as exc:
         try:
-            send_json(conn, {"status": "error", "message": sanitize_for_wire(exc)})
+            send_json(conn, {"status": "error", "message": _sanitize_for_wire(exc)})
         except Exception as send_exc:
             print(
                 f"[voicecli daemon] warning: failed to send error response: {send_exc}",

--- a/uv.lock
+++ b/uv.lock
@@ -2185,7 +2185,7 @@ wheels = [
 
 [[package]]
 name = "voicecli"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "lameenc" },
@@ -2204,6 +2204,7 @@ all = [
     { name = "nkeys" },
     { name = "nvidia-ml-py" },
     { name = "qwen-tts" },
+    { name = "roxabi-contracts" },
     { name = "roxabi-nats" },
     { name = "torch" },
     { name = "torchaudio" },
@@ -2215,6 +2216,7 @@ nats = [
     { name = "nats-py" },
     { name = "nkeys" },
     { name = "nvidia-ml-py" },
+    { name = "roxabi-contracts" },
     { name = "roxabi-nats" },
 ]
 overlay = [
@@ -2263,6 +2265,7 @@ requires-dist = [
     { name = "pygobject", marker = "extra == 'overlay'", specifier = ">=3.42" },
     { name = "pynput", marker = "extra == 'hotkey'", specifier = ">=1.7" },
     { name = "qwen-tts", marker = "extra == 'tts'" },
+    { name = "roxabi-contracts", marker = "extra == 'nats'", git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-contracts&branch=staging" },
     { name = "roxabi-nats", marker = "extra == 'nats'", git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-nats&branch=staging" },
     { name = "scipy", marker = "extra == 'voxtral'" },
     { name = "soundfile" },


### PR DESCRIPTION
## Summary
- `roxabi-nats` (lyra subpackage on `staging`) dropped the `sanitize_for_wire` export → 2 voiceCLI modules failed at import → 3 test files errored during pytest collection → CI Test job exit code 2 on every PR against staging.
- Replace the upstream import with a local private helper `_sanitize_for_wire(exc) -> str` in `wire_protocol.py`, reused from `transcribe_daemon.py`. Same wire contract: one-line string capped at 512 chars, suitable for the daemon's JSON `{"status": "error", "message": ...}` reply.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #179: fix(runtime): staging CI broken — sanitize_for_wire removed from roxabi-nats | Open |
| Implementation | 1 commit on `fix/179-sanitize-for-wire` | Complete |
| Verification | Lint ✅ · Typecheck ✅ · Tests ✅ (600 passed, 3 skipped — incl. the 3 previously-broken modules) | Passed |

S-tier — no spec/plan artifacts; the issue body served as the spec.

## What changed

| File | Change |
|---|---|
| `src/voicecli/runtime/wire_protocol.py` | drop `from roxabi_nats import sanitize_for_wire`; add local `_sanitize_for_wire`; update callsite at line 319 |
| `src/voicecli/runtime/transcribe_daemon.py` | drop upstream import; reuse local helper from `wire_protocol`; update callsite at line 221 |
| `uv.lock` | sync (voicecli `0.2.1 → 0.2.2` + `roxabi-contracts` added to `all` extras — picked up from latest staging) |

## Test Plan
- [x] `uv run --extra nats pytest tests/test_daemon_protocol.py tests/test_overlay.py tests/test_vram_lifecycle.py` — collects and runs (21 passed, 1 skipped)
- [x] `uv run --extra nats pytest tests/ --ignore=tests/e2e` — 600 passed, 3 skipped
- [x] Lint + format + typecheck clean on changed files
- [ ] CI Test job green on this PR
- [ ] Once merged → re-run CI on PR #178 → expected green

## Why a local helper instead of restoring the upstream export

This PR keeps voiceCLI independent of future roxabi-nats churn around private wire-serialization helpers. The function is tiny (1 line of logic) and its only callers are voiceCLI's two AF_UNIX daemons — no cross-repo contract benefit to keeping it upstream.

## Unblocks

- PR #178 (TTS NATS client) — currently blocked-by #179

Closes #179

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`