### PR TITLE
refactor(blobs): adopt roxabi_contracts.BlobRef.from_store_ref

### DIFF
--- a/src/voicecli/adapters/nats/blobs.py
+++ b/src/voicecli/adapters/nats/blobs.py
@@ -18,19 +18,20 @@ fail fast.
 from __future__ import annotations
 
 import os
-import re
 import threading
 from typing import Any
 
+from pydantic import ValidationError
 from roxabi_blobs import HttpBlobStore
 from roxabi_contracts.blob_ref import BlobRef as ContractsBlobRef
 
 _INSTANCE: HttpBlobStore | None = None
 _LOCK = threading.Lock()
 
-# Producer-only fields on roxabi_blobs.BlobRef that the contract BlobRef rejects
-# (extra="forbid"). Drop them when bridging to the wire payload.
-_PRODUCER_ONLY_FIELDS: frozenset[str] = frozenset({"id", "is_sentinel"})
+# Sentinel store_key emitted by adapters before BlobStore ingest lands.
+# Workers receiving a BlobRef with this store_key must fall back to the
+# legacy platform fetch path instead of calling blob_store.get(store_key).
+_PENDING_STORE_KEY = "__pending__"
 
 
 class BlobstoreConfigError(RuntimeError):
@@ -91,12 +92,19 @@ def reset_blobstore_for_tests() -> None:
 def blob_ref_to_contract(ref: Any) -> ContractsBlobRef:
     """Bridge ``roxabi_blobs.BlobRef`` → ``roxabi_contracts.BlobRef``.
 
-    The two packages publish distinct Pydantic models with overlapping fields.
-    The contract model has ``extra="forbid"`` so producer-only fields (``id``,
-    ``is_sentinel``) must be stripped before validation. Centralized here so a
-    field rename or addition upstream is a one-place fix instead of N callsites.
+    Canonical converter via ``roxabi_contracts.BlobRef.from_store_ref`` —
+    drops storage-only fields (``id``, ``is_sentinel``) and carries every
+    wire field (incl. ``created_at``) through verbatim.
+
+    A ``pydantic.ValidationError`` from ``from_store_ref`` signals field-set
+    drift between the storage and wire schemas.  It is re-raised as a typed
+    ``BlobRefValidationError`` so callers can distinguish contract-level
+    mismatches from generic runtime errors.
     """
     store_key = getattr(ref, "store_key", "")
-    if not re.match(r"^sha256:[a-f0-9]{64}$", store_key):
-        raise BlobRefValidationError(f"Invalid store_key: {store_key!r}")
-    return ContractsBlobRef.model_validate(ref.model_dump(exclude=set(_PRODUCER_ONLY_FIELDS)))
+    if store_key == _PENDING_STORE_KEY:
+        raise BlobRefValidationError(f"Pending store_key not allowed: {store_key!r}")
+    try:
+        return ContractsBlobRef.from_store_ref(ref)
+    except ValidationError as e:
+        raise BlobRefValidationError(str(e)) from e

--- a/tests/nats/test_blobs_factory.py
+++ b/tests/nats/test_blobs_factory.py
@@ -213,20 +213,33 @@ class TestMissingEnvVars:
 
 
 class TestBlobRefToContract:
-    def test_rejects_invalid_store_key(self) -> None:
-        """Invalid store_key raises BlobRefValidationError."""
+    def test_rejects_pending_store_key(self) -> None:
+        """Pending store_key (sentinel) raises BlobRefValidationError."""
         from dataclasses import dataclass
 
         @dataclass
         class FakeRef:
             store_key: str
 
-        ref = FakeRef(store_key="sha256:bad")
-        with pytest.raises(blobs.BlobRefValidationError, match="Invalid store_key"):
+            def model_dump(self, *, exclude: set | None = None) -> dict:
+                return {
+                    "store_key": self.store_key,
+                    "mime": "audio/wav",
+                    "size": 16,
+                    "source": "voicecli",
+                    "content_hash": "",
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "filename": None,
+                    "platform_ref": None,
+                    "platform_message_id": None,
+                }
+
+        ref = FakeRef(store_key="__pending__")
+        with pytest.raises(blobs.BlobRefValidationError, match="Pending store_key"):
             blobs.blob_ref_to_contract(ref)
 
     def test_accepts_valid_store_key(self) -> None:
-        """Valid store_key passes through to model_dump."""
+        """Valid store_key passes through to from_store_ref."""
         from dataclasses import dataclass
         from datetime import datetime, timezone
 

--- a/tests/nats/test_blobs_factory.py
+++ b/tests/nats/test_blobs_factory.py
@@ -227,7 +227,7 @@ class TestBlobRefToContract:
                     "mime": "audio/wav",
                     "size": 16,
                     "source": "voicecli",
-                    "content_hash": "",
+                    "content_hash": "pending-dummy",
                     "created_at": "2026-01-01T00:00:00+00:00",
                     "filename": None,
                     "platform_ref": None,
@@ -266,3 +266,28 @@ class TestBlobRefToContract:
         # Does not raise — contract validation is the only gate
         result = blobs.blob_ref_to_contract(ref)
         assert result.store_key == ref.store_key
+
+    def test_rejects_validation_error_as_blob_ref_validation_error(self) -> None:
+        """pydantic.ValidationError from from_store_ref is re-raised as BlobRefValidationError."""
+        from dataclasses import dataclass
+
+        @dataclass
+        class FakeRef:
+            store_key: str
+
+            def model_dump(self, *, exclude: set | None = None) -> dict:
+                # Missing required field 'content_hash' triggers ValidationError
+                return {
+                    "store_key": self.store_key,
+                    "mime": "audio/wav",
+                    "size": 16,
+                    "source": "voicecli",
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "filename": None,
+                    "platform_ref": None,
+                    "platform_message_id": None,
+                }
+
+        ref = FakeRef(store_key="sha256:validstorekey")
+        with pytest.raises(blobs.BlobRefValidationError, match="content_hash"):
+            blobs.blob_ref_to_contract(ref)

--- a/uv.lock
+++ b/uv.lock
@@ -1710,7 +1710,7 @@ wheels = [
 [[package]]
 name = "roxabi-blobs"
 version = "0.1.2"
-source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-blobs&branch=staging#62a4c5e3255896254507267f2d399841f32ed53f" }
+source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-blobs&branch=staging#5d1abe25e95f723d405212668de41bf527dfbb54" }
 dependencies = [
     { name = "aiosqlite" },
     { name = "httpx" },
@@ -1719,8 +1719,8 @@ dependencies = [
 
 [[package]]
 name = "roxabi-contracts"
-version = "0.4.0"
-source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-contracts&branch=staging#62a4c5e3255896254507267f2d399841f32ed53f" }
+version = "0.6.0"
+source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-contracts&branch=staging#5d1abe25e95f723d405212668de41bf527dfbb54" }
 dependencies = [
     { name = "pydantic" },
 ]
@@ -1728,7 +1728,7 @@ dependencies = [
 [[package]]
 name = "roxabi-nats"
 version = "0.4.1"
-source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-nats&branch=staging#62a4c5e3255896254507267f2d399841f32ed53f" }
+source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-nats&branch=staging#5d1abe25e95f723d405212668de41bf527dfbb54" }
 dependencies = [
     { name = "nats-py" },
     { name = "nkeys" },


### PR DESCRIPTION
## Summary
Replace the hand-rolled storage→wire `BlobRef` converter in `blobs.py` with the canonical upstream classmethod `roxabi_contracts.BlobRef.from_store_ref`. The old implementation used a `sha256:` regex to validate `store_key` (treating it as non-opaque); the new path rejects only the `__pending__` sentinel semantically, matching the upstream contract.

Secondary: refresh `uv.lock` to pull `roxabi-contracts` v0.6.0 (staging branch commit `5d1abe25`) which ships `from_store_ref`.

## Lifecycle

| Phase | Artifact | Status |
|-------|----------|--------|
| Intent | #187: refactor(blobs): adopt roxabi_contracts.BlobRef.from_store_ref | OPEN |
| Analysis | — | Absent (S-tier) |
| Spec | — | Absent (S-tier) |
| Implementation | 2 commits on `feat/187-refactor-blobs-adopt-roxabi-contracts-blobref-from-store-ref` | Complete |
| Verification | Lint ✅ Typecheck ✅ Tests ✅ (633 passed, 3 skipped) | Passed |

## Test Plan
- [ ] `blob_ref_to_contract` rejects `__pending__` store_key
- [ ] `blob_ref_to_contract` accepts valid storage refs via `from_store_ref`
- [ ] All existing blob tests pass (10/10)
- [ ] Full suite passes (633 passed, 3 skipped)

Closes #187

---
Generated with [Claude Code](https://claude.com/claude-code) via `/pr`