### PR TITLE
fix(nats): re-pin voiceCLI to factory.* wire (#189)

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -101,7 +101,7 @@ blobstore_env="${HOME}/.roxabi/voicecli/env/blobstore.env"
 if [[ ! -f "$blobstore_env" ]]; then
     run bash -c "cat > '${blobstore_env}'" <<'EOF'
 # voiceCLI blobstore credentials (ADR-068)
-# Fill in the bearer token issued by the lyra blobstore service.
+# Fill in the bearer token issued by the factory-blobstore service.
 BLOBSTORE_BEARER_TOKEN=
 EOF
     run chmod 600 "$blobstore_env"
@@ -123,7 +123,7 @@ if [[ "$DRY_RUN" -eq 0 ]]; then
     token_value=$(grep -E '^BLOBSTORE_BEARER_TOKEN=' "$blobstore_env" | head -1 | cut -d= -f2-)
     if [[ -z "$token_value" ]]; then
         echo "ERROR: BLOBSTORE_BEARER_TOKEN is empty in $blobstore_env" >&2
-        echo "  Fill in the token issued by the lyra blobstore service, then re-run." >&2
+        echo "  Fill in the token issued by the factory-blobstore service, then re-run." >&2
         exit 1
     fi
 fi

--- a/deploy/quadlet/voicecli-stt.container
+++ b/deploy/quadlet/voicecli-stt.container
@@ -1,7 +1,7 @@
 [Unit]
 Description=voiceCLI STT NATS worker
-Wants=lyra-nats.service
-After=lyra-nats.service
+Wants=factory-nats.service
+After=factory-nats.service
 StartLimitIntervalSec=60
 StartLimitBurst=5
 
@@ -17,11 +17,11 @@ Secret=voicecli-nats-stt,type=mount,target=voicecli-nats-stt.seed,mode=0400,uid=
 AddDevice=nvidia.com/gpu=all
 # UID 1501 fixed in image; anchor mapping so secret mount (uid=1501) is readable inside.
 UserNS=keep-id:uid=1501,gid=1501
-# Big-bang NATS consolidation: connect to shared lyra-nats on roxabi.network.
-Environment=NATS_URL=nats://lyra-nats:4222
+# Connect to factory-nats on roxabi.network (factory.* wire, #1670 lockstep).
+Environment=NATS_URL=nats://factory-nats:4222
 Environment=NATS_NKEY_SEED_PATH=/run/secrets/voicecli-nats-stt.seed
 Environment=BLOBSTORE_BACKEND=http
-Environment=BLOBSTORE_URL=http://lyra-hub:8080
+Environment=BLOBSTORE_URL=http://factory-blobstore:8449
 EnvironmentFile=%h/.roxabi/voicecli/env/blobstore.env
 HealthCmd=pgrep -f voicecli
 HealthInterval=30s

--- a/deploy/quadlet/voicecli-tts.container
+++ b/deploy/quadlet/voicecli-tts.container
@@ -1,7 +1,7 @@
 [Unit]
 Description=voiceCLI TTS NATS worker
-Wants=lyra-nats.service
-After=lyra-nats.service
+Wants=factory-nats.service
+After=factory-nats.service
 StartLimitIntervalSec=60
 StartLimitBurst=5
 
@@ -16,11 +16,11 @@ Secret=voicecli-nats-tts,type=mount,target=voicecli-nats-tts.seed,mode=0400,uid=
 AddDevice=nvidia.com/gpu=all
 # UID 1501 fixed in image; anchor mapping so secret mount (uid=1501) is readable inside.
 UserNS=keep-id:uid=1501,gid=1501
-# Big-bang NATS consolidation: connect to shared lyra-nats on roxabi.network.
-Environment=NATS_URL=nats://lyra-nats:4222
+# Connect to factory-nats on roxabi.network (factory.* wire, #1670 lockstep).
+Environment=NATS_URL=nats://factory-nats:4222
 Environment=NATS_NKEY_SEED_PATH=/run/secrets/voicecli-nats-tts.seed
 Environment=BLOBSTORE_BACKEND=http
-Environment=BLOBSTORE_URL=http://lyra-hub:8080
+Environment=BLOBSTORE_URL=http://factory-blobstore:8449
 EnvironmentFile=%h/.roxabi/voicecli/env/blobstore.env
 HealthCmd=pgrep -f voicecli
 HealthInterval=30s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,9 @@ pkuseg = ["numpy"]
 
 [tool.uv.sources]
 voxtral-tts = { git = "https://github.com/Roxabi/voxtral-tts.git", branch = "main" }
-roxabi-nats = { git = "https://github.com/Roxabi/lyra.git", subdirectory = "packages/roxabi-nats", branch = "staging" }
-roxabi-contracts = { git = "https://github.com/Roxabi/lyra.git", subdirectory = "packages/roxabi-contracts", branch = "staging" }
-roxabi-blobs = { git = "https://github.com/Roxabi/lyra.git", subdirectory = "packages/roxabi-blobs", branch = "staging" }
+roxabi-nats = { git = "https://github.com/Roxabi/roxabi-factory.git", subdirectory = "packages/roxabi-nats", branch = "staging" }
+roxabi-contracts = { git = "https://github.com/Roxabi/roxabi-factory.git", subdirectory = "packages/roxabi-contracts", branch = "staging" }
+roxabi-blobs = { git = "https://github.com/Roxabi/roxabi-factory.git", subdirectory = "packages/roxabi-blobs", branch = "staging" }
 
 [tool.pytest.ini_options]
 # src layout: expose src/ to pytest without relying on editable install

--- a/tests/nats/test_stt_adapter.py
+++ b/tests/nats/test_stt_adapter.py
@@ -55,8 +55,8 @@ except ImportError as _e:
     _ext_from_mime = None  # type: ignore[assignment]
     TranscriptionResult = None  # type: ignore[assignment]
     DEFAULT_MODEL = "large-v3-turbo"  # type: ignore[assignment]
-    SUBJECT = "lyra.voice.stt.request"  # type: ignore[assignment]
-    HEARTBEAT_SUBJECT = "lyra.voice.stt.heartbeat"  # type: ignore[assignment]
+    SUBJECT = "factory.voice.stt.request"  # type: ignore[assignment]
+    HEARTBEAT_SUBJECT = "factory.voice.stt.heartbeat"  # type: ignore[assignment]
     STT_WORKERS = "stt-workers"  # type: ignore[assignment]
 
 

--- a/tests/nats/test_synthesize_client.py
+++ b/tests/nats/test_synthesize_client.py
@@ -118,7 +118,7 @@ def test_happy_path_returns_decoded_audio(monkeypatch: pytest.MonkeyPatch) -> No
     assert fake_nc.drained and fake_nc.closed
     assert len(fake_blobstore.get_calls) == 1, "client must fetch bytes via BlobStore.get"
     subject, payload, timeout = fake_nc.requests[0]
-    assert subject == "lyra.voice.tts.request"
+    assert subject == "factory.voice.tts.request"
     assert timeout == 60.0
     sent = json.loads(payload)
     assert sent["text"] == "Bonjour"

--- a/uv.lock
+++ b/uv.lock
@@ -1735,7 +1735,7 @@ wheels = [
 [[package]]
 name = "roxabi-blobs"
 version = "0.1.2"
-source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-blobs&branch=staging#5d1abe25e95f723d405212668de41bf527dfbb54" }
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-blobs&branch=staging#e8578e52c818dbfe46676566a032409a1345efa0" }
 dependencies = [
     { name = "aiosqlite" },
     { name = "httpx" },
@@ -1744,16 +1744,16 @@ dependencies = [
 
 [[package]]
 name = "roxabi-contracts"
-version = "0.6.0"
-source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-contracts&branch=staging#5d1abe25e95f723d405212668de41bf527dfbb54" }
+version = "0.7.0"
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-contracts&branch=staging#e8578e52c818dbfe46676566a032409a1345efa0" }
 dependencies = [
     { name = "pydantic" },
 ]
 
 [[package]]
 name = "roxabi-nats"
-version = "0.4.1"
-source = { git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-nats&branch=staging#5d1abe25e95f723d405212668de41bf527dfbb54" }
+version = "0.4.2"
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-nats&branch=staging#e8578e52c818dbfe46676566a032409a1345efa0" }
 dependencies = [
     { name = "nats-py" },
     { name = "nkeys" },
@@ -2317,9 +2317,9 @@ requires-dist = [
     { name = "pygobject", marker = "extra == 'overlay'", specifier = ">=3.42" },
     { name = "pynput", marker = "extra == 'hotkey'", specifier = ">=1.7" },
     { name = "qwen-tts", marker = "extra == 'tts'" },
-    { name = "roxabi-blobs", marker = "extra == 'nats'", git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-blobs&branch=staging" },
-    { name = "roxabi-contracts", marker = "extra == 'nats'", git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-contracts&branch=staging" },
-    { name = "roxabi-nats", marker = "extra == 'nats'", git = "https://github.com/Roxabi/lyra.git?subdirectory=packages%2Froxabi-nats&branch=staging" },
+    { name = "roxabi-blobs", marker = "extra == 'nats'", git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-blobs&branch=staging" },
+    { name = "roxabi-contracts", marker = "extra == 'nats'", git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-contracts&branch=staging" },
+    { name = "roxabi-nats", marker = "extra == 'nats'", git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-nats&branch=staging" },
     { name = "scipy", marker = "extra == 'voxtral'" },
     { name = "soundfile" },
     { name = "torch", marker = "extra == 'stt'", specifier = ">=2.7" },


### PR DESCRIPTION
## Summary

- Re-pins , ,  from  to  (repo rename); contracts 0.6.0→0.7.0 (factory.voice.* subjects), nats 0.4.1→0.4.2
- Updates Quadlet units: →, → in both stt/tts containers
- Pure re-pin — zero subject literal changes in src/ (all subjects come from roxabi_contracts)

Part of roxabi-factory #1670 lockstep. Fixes #189

## Test plan

- [ ] CI publish workflow builds new voicecli-stt/tts images with contracts 0.7.0
- [ ] M1 workers pull new image and restart cleanly with NRestarts=0
- [ ] factory-nats shows 0 lyra.voice/stt/tts violations in journalctl after redeploy
- [ ] M2 client venv synced to contracts 0.7.0 via uv sync

Generated with [Claude Code](https://claude.com/claude-code)