### PR TITLE
test(nats): STT mkdir regression guard + conform golden store_key placeholders

### DIFF
--- a/tests/nats/golden/stt_request_v2.json
+++ b/tests/nats/golden/stt_request_v2.json
@@ -3,7 +3,7 @@
   "trace_id": "trace-example",
   "request_id": "req-example",
   "blob_ref": {
-    "store_key": "sha256:deadbeef",
+    "store_key": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "content_hash": "deadbeef",
     "mime": "audio/wav",
     "size": 16384,

--- a/tests/nats/golden/tts_response_v2.json
+++ b/tests/nats/golden/tts_response_v2.json
@@ -4,7 +4,7 @@
   "trace_id": "trace-example",
   "request_id": "req-example",
   "blob_ref": {
-    "store_key": "sha256:cafef00d",
+    "store_key": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "content_hash": "cafef00d",
     "mime": "audio/wav",
     "size": 65536,

--- a/tests/nats/test_golden_wire_compat.py
+++ b/tests/nats/test_golden_wire_compat.py
@@ -38,7 +38,7 @@ GOLDEN_DIR = Path(__file__).parent / "golden"
 # ---------------------------------------------------------------------------
 
 _BLOB_REF_V2 = {
-    "store_key": "sha256:deadbeef",
+    "store_key": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "content_hash": "deadbeef",
     "mime": "audio/wav",
     "size": 16,

--- a/tests/nats/test_stt_runner.py
+++ b/tests/nats/test_stt_runner.py
@@ -316,6 +316,42 @@ class TestRunTranscriptionHappyPath:
         assert scoped_path.parent == tmp_path
         assert scoped_path.name.startswith("req-path")
 
+    def test_write_succeeds_when_scoped_dir_does_not_pre_exist(
+        self, tmp_path: Path, fake_api: _FakeApi, fake_blobstore: _FakeBlobStore
+    ) -> None:
+        """Runner creates scoped_dir (and parents) if it does not exist before writing.
+
+        Regression guard for the FileNotFoundError introduced in PR #180:
+        the runner must call mkdir() itself before write_bytes() because the
+        adapter passes TEMP_ROOT which may not exist in a fresh container.
+        """
+        # Arrange — point scoped_dir at a subdir that does NOT exist yet
+        scoped_dir = tmp_path / "voicecli-nats" / "subdir"
+        assert not scoped_dir.exists(), "precondition: dir must not pre-exist"
+
+        state = _make_state(model_warm=True)
+        blob_ref = _make_blob_ref(mime="audio/wav")
+
+        # Act
+        ok, result, scoped_path = _run(
+            run_transcription(
+                state,
+                "large-v3-turbo",
+                blob_ref,
+                "req-mkdir",
+                scoped_dir,
+                {},
+                trace_id="t-mkdir",
+            )
+        )
+
+        # Assert — write succeeded, file exists, dir was created with tight perms
+        assert ok is True
+        assert scoped_path is not None
+        assert scoped_path.exists(), "WAV file must be written to the non-pre-existing dir"
+        assert scoped_dir.exists(), "runner must have created scoped_dir"
+        assert oct(scoped_dir.stat().st_mode & 0o777) == oct(0o700)
+
     @pytest.mark.parametrize(
         "mime,expected_ext",
         [


### PR DESCRIPTION
## Summary

- Extracts 4 novel test-only items from a pre-#184 stash that were verified absent from `origin/staging` after PR #184 merged.
- Adds `test_write_succeeds_when_scoped_dir_does_not_pre_exist` to `TestRunTranscriptionHappyPath` — regression guard for the `scoped_dir.mkdir(parents=True, mode=0o700)` fix that landed in PR #180 but whose test was never committed.
- Conforms short placeholder `store_key` values (`sha256:deadbeef`, `sha256:cafef00d`) in `tests/nats/golden/stt_request_v2.json`, `tests/nats/golden/tts_response_v2.json`, and `_BLOB_REF_V2` in `test_golden_wire_compat.py` to valid 64-hex sha256 format required by `blobs.blob_ref_to_contract()`.

## Test plan

- [x] `uv run pytest tests/nats/test_stt_runner.py tests/nats/test_golden_wire_compat.py` — 33/33 passed locally
- [x] New test `test_write_succeeds_when_scoped_dir_does_not_pre_exist` passes against existing production code (behavior already present, test was missing)
- [x] Pre-commit hooks (lint, format, typecheck, file-length, folder-size) all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)