### PR TITLE
feat(voice): echo job_id through TTS/STT NATS adapters + bump contracts 0.9.0 (#1840)

### DIFF
--- a/.github/workflows/contracts-bump-caller.yml
+++ b/.github/workflows/contracts-bump-caller.yml
@@ -1,0 +1,16 @@
+# .github/workflows/contracts-bump-caller.yml  (in Roxabi/voiceCLI)
+name: Bump contracts lock
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"   # Every Monday 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  bump:
+    uses: Roxabi/roxabi-factory/.github/workflows/contracts-bump.yml@staging
+    with:
+      satellite_repo: ${{ github.repository }}
+      packages: "roxabi-contracts roxabi-nats roxabi-blobs"
+    secrets:
+      PAT: ${{ secrets.PAT }}

--- a/src/voicecli/adapters/nats/synthesize_adapter.py
+++ b/src/voicecli/adapters/nats/synthesize_adapter.py
@@ -34,7 +34,14 @@ def _engine_available(engine: str) -> bool:
     return engine in _get_registry()
 
 
-def _err_tts(trace_id: str, request_id: str, worker_error: WorkerError) -> bytes:
+def _err_tts(
+    trace_id: str, request_id: str, worker_error: WorkerError, job_id: str | None = None
+) -> bytes:
+    # job_id=None must NOT be passed to TtsResponse — _validate_job_id raises TypeError on None.
+    # Let the default_factory shim synthesise a fresh UUID when job_id is absent.
+    extra: dict[str, str] = {}
+    if job_id:
+        extra["job_id"] = job_id
     if not request_id:
         # model_construct bypasses validation for the malformed-request edge case
         # where request_id is empty (which normally fails min_length=1).
@@ -46,6 +53,7 @@ def _err_tts(trace_id: str, request_id: str, worker_error: WorkerError) -> bytes
             request_id="",
             error=worker_error.code,
             worker_error=worker_error,
+            **extra,
         )
     else:
         m = TtsResponse(
@@ -56,6 +64,7 @@ def _err_tts(trace_id: str, request_id: str, worker_error: WorkerError) -> bytes
             request_id=request_id,
             error=worker_error.code,
             worker_error=worker_error,
+            **extra,
         )
     return m.model_dump_json(exclude_none=True).encode()
 
@@ -147,8 +156,11 @@ class TtsNatsAdapter(NatsAdapterBase):
     async def handle(self, msg: Any, payload: dict) -> None:  # type: ignore[override]
         trace_id = payload.get("trace_id") or "unknown"
         request_id = payload.get("request_id", "")
+        job_id: str | None = payload.get("job_id") or None
         if not request_id:
-            await self.reply(msg, _err_tts(trace_id, "", _VALIDATION_ERRORS["malformed_request"]))
+            await self.reply(
+                msg, _err_tts(trace_id, "", _VALIDATION_ERRORS["malformed_request"], job_id)
+            )
             return
 
         outcome = validate_tts_request(
@@ -165,7 +177,7 @@ class TtsNatsAdapter(NatsAdapterBase):
                     retryable=False,
                 ),
             )
-            await self.reply(msg, _err_tts(trace_id, request_id, we))
+            await self.reply(msg, _err_tts(trace_id, request_id, we, job_id))
             return
         text = outcome.cleaned_text
         engine = outcome.engine
@@ -176,7 +188,8 @@ class TtsNatsAdapter(NatsAdapterBase):
                 await asyncio.wait_for(self._sem.acquire(), timeout=0)
             except asyncio.TimeoutError:
                 await self.reply(
-                    msg, _err_tts(trace_id, request_id, _VALIDATION_ERRORS["capacity_exceeded"])
+                    msg,
+                    _err_tts(trace_id, request_id, _VALIDATION_ERRORS["capacity_exceeded"], job_id),
                 )
                 return
             try:
@@ -197,6 +210,7 @@ class TtsNatsAdapter(NatsAdapterBase):
         *,
         trace_id: str,
     ) -> None:
+        job_id: str | None = payload.get("job_id") or None
         out_path = scoped_path(request_id, "wav")
         try:
             try:
@@ -226,15 +240,20 @@ class TtsNatsAdapter(NatsAdapterBase):
                             message=type(exc).__name__,
                             retryable=False,
                         ),
+                        job_id,
                     ),
                 )
                 return
             if not ok:
                 # result is a WorkerError
-                await self.reply(msg, _err_tts(trace_id, request_id, result))  # type: ignore[arg-type]
+                await self.reply(msg, _err_tts(trace_id, request_id, result, job_id))  # type: ignore[arg-type]
                 return
             # result is the fields dict
             fields = result  # type: ignore[assignment]
+            # job_id=None must NOT be passed explicitly — let default_factory shim fire instead.
+            job_id_kwarg: dict[str, str] = {}
+            if job_id:
+                job_id_kwarg["job_id"] = job_id
             await self.reply(
                 msg,
                 TtsResponse(
@@ -247,6 +266,7 @@ class TtsNatsAdapter(NatsAdapterBase):
                     mime_type=fields["mime_type"],
                     duration_ms=fields["duration_ms"],
                     waveform_b64=fields.get("waveform_b64"),
+                    **job_id_kwarg,
                 )
                 .model_dump_json(exclude_none=True)
                 .encode(),

--- a/src/voicecli/adapters/nats/transcribe_adapter.py
+++ b/src/voicecli/adapters/nats/transcribe_adapter.py
@@ -50,7 +50,7 @@ __all__ = [
 ]
 
 
-def _err_stt(trace_id: str, request_id: str, error: str) -> bytes:
+def _err_stt(trace_id: str, request_id: str, error: str, job_id: str | None = None) -> bytes:
     fields: dict[str, Any] = {
         "contract_version": CONTRACT_VERSION,
         "trace_id": trace_id,
@@ -59,6 +59,10 @@ def _err_stt(trace_id: str, request_id: str, error: str) -> bytes:
         "request_id": request_id or "",
         "error": error,
     }
+    # job_id=None must NOT be set — _validate_job_id raises TypeError on None.
+    # Let default_factory shim fire when job_id is absent.
+    if job_id:
+        fields["job_id"] = job_id
     # Skip validation only when request_id is empty (otherwise the contract requires it).
     m = SttResponse.model_construct(**fields) if not request_id else SttResponse(**fields)
     return m.model_dump_json(exclude_none=True).encode()
@@ -124,13 +128,14 @@ class SttNatsAdapter(NatsAdapterBase):
     async def handle(self, msg: Any, payload: dict) -> None:  # type: ignore[override]
         trace_id = payload.get("trace_id") or "unknown"
         request_id = payload.get("request_id", "")
+        job_id: str | None = payload.get("job_id") or None
         if not request_id:
-            await self.reply(msg, _err_stt(trace_id, "", "malformed_request"))
+            await self.reply(msg, _err_stt(trace_id, "", "malformed_request", job_id))
             return
 
         outcome = validate_stt_request(payload)
         if outcome.error_code is not None:
-            await self.reply(msg, _err_stt(trace_id, request_id, outcome.error_code))
+            await self.reply(msg, _err_stt(trace_id, request_id, outcome.error_code, job_id))
             return
         req = outcome.request
 
@@ -139,7 +144,9 @@ class SttNatsAdapter(NatsAdapterBase):
             try:
                 await asyncio.wait_for(self._sem.acquire(), timeout=0)
             except asyncio.TimeoutError:
-                await self.reply(msg, _err_stt(trace_id, req.request_id, "capacity_exceeded"))
+                await self.reply(
+                    msg, _err_stt(trace_id, req.request_id, "capacity_exceeded", job_id)
+                )
                 return
             try:
                 await self._run_transcription(
@@ -148,6 +155,7 @@ class SttNatsAdapter(NatsAdapterBase):
                     req.blob_ref,
                     req.to_overrides(),
                     trace_id=trace_id,
+                    job_id=job_id,
                 )
             finally:
                 self._sem.release()
@@ -159,6 +167,7 @@ class SttNatsAdapter(NatsAdapterBase):
                     req.blob_ref,
                     req.to_overrides(),
                     trace_id=trace_id,
+                    job_id=job_id,
                 )
 
     async def _run_transcription(
@@ -169,6 +178,7 @@ class SttNatsAdapter(NatsAdapterBase):
         overrides: dict,
         *,
         trace_id: str,
+        job_id: str | None = None,
     ) -> None:
         out_path = None
         try:
@@ -182,9 +192,13 @@ class SttNatsAdapter(NatsAdapterBase):
                 trace_id=trace_id,
             )
             if not ok:
-                await self.reply(msg, _err_stt(trace_id, request_id, result))  # type: ignore[arg-type]
+                await self.reply(msg, _err_stt(trace_id, request_id, result, job_id))  # type: ignore[arg-type]
                 return
             fields = result  # type: ignore[assignment]
+            # job_id=None must NOT be passed explicitly — let default_factory shim fire instead.
+            job_id_kwarg: dict[str, str] = {}
+            if job_id:
+                job_id_kwarg["job_id"] = job_id
             await self.reply(
                 msg,
                 SttResponse(
@@ -196,6 +210,7 @@ class SttNatsAdapter(NatsAdapterBase):
                     text=fields["text"],
                     language=fields["language"],
                     duration_seconds=fields["duration_seconds"],
+                    **job_id_kwarg,
                 )
                 .model_dump_json(exclude_none=True)
                 .encode(),

--- a/tests/nats/test_golden_wire_compat.py
+++ b/tests/nats/test_golden_wire_compat.py
@@ -228,6 +228,16 @@ def test_golden_wire_compat(golden_path: Path, case_name: str) -> None:
     golden_obj.pop("issued_at", None)
     branch_obj.pop("issued_at", None)
 
+    # When the inbound payload carries no job_id, the default_factory shim in
+    # roxabi-contracts 0.9.0 synthesises a fresh UUID on every response — value
+    # varies per-run and cannot be golden-captured.  Strip it from both sides so
+    # the comparison stays meaningful for the remaining fields.  Echo behaviour
+    # (payload WITH job_id → reply echoes it verbatim) is covered by the
+    # dedicated test_job_id_echoed_in_* tests in test_tts_adapter / test_stt_adapter.
+    if "job_id" not in payload:
+        golden_obj.pop("job_id", None)
+        branch_obj.pop("job_id", None)
+
     # Re-serialize both with canonical formatting for deterministic comparison
     golden_canonical = json.dumps(golden_obj, sort_keys=True, indent=2)
     branch_canonical = json.dumps(branch_obj, sort_keys=True, indent=2)

--- a/tests/nats/test_stt_adapter.py
+++ b/tests/nats/test_stt_adapter.py
@@ -840,3 +840,61 @@ class TestSttNatsAdapter:
             assert reply["ok"] is False
             assert reply["error"] == "malformed_request"
             mock_transcribe.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # job_id echo (#1840)
+    # ------------------------------------------------------------------
+
+    def test_job_id_echoed_in_success_reply(self, tmp_path: Path) -> None:
+        """job_id from inbound payload is echoed in the STT success reply."""
+        _require_imports()
+        adapter = _make_adapter(max_concurrent=1)
+        msg = MockMsg()
+        _setup_adapter(adapter, msg)
+        payload = _valid_payload(request_id="req-jid-ok") | {"job_id": "job-stt-abc"}
+
+        with _patch_blobstore():
+            with _patch_transcribe(_fake_result()):
+                with _patch_temp_root(tmp_path):
+                    asyncio.run(adapter.handle(msg, payload))
+
+        reply = msg.last_reply()
+        assert reply["ok"] is True
+        assert reply["job_id"] == "job-stt-abc"
+
+    def test_job_id_absent_not_in_reply(self, tmp_path: Path) -> None:
+        """When job_id is absent, the shim (default_factory=new_job_id) generates a fresh UUID.
+        The reply always carries a job_id — we verify it is present and non-empty."""
+        _require_imports()
+        adapter = _make_adapter(max_concurrent=1)
+        msg = MockMsg()
+        _setup_adapter(adapter, msg)
+        payload = _valid_payload(request_id="req-nojid")
+        assert "job_id" not in payload  # sanity-check the fixture
+
+        with _patch_blobstore():
+            with _patch_transcribe(_fake_result()):
+                with _patch_temp_root(tmp_path):
+                    asyncio.run(adapter.handle(msg, payload))
+
+        reply = msg.last_reply()
+        assert reply["ok"] is True
+        # default_factory shim fires — reply always carries a job_id UUID
+        assert "job_id" in reply
+        assert reply["job_id"]  # non-empty shim-generated UUID
+
+    def test_job_id_echoed_in_error_reply(self, tmp_path: Path) -> None:
+        """job_id is echoed even when the adapter returns an error response."""
+        _require_imports()
+        adapter = _make_adapter(max_concurrent=1)
+        msg = MockMsg()
+        _setup_adapter(adapter, msg)
+        # blob_ref missing → malformed_request, easiest to trigger without extra patches
+        payload = {"contract_version": "1", "request_id": "req-err-jid", "job_id": "job-err-stt"}
+
+        asyncio.run(adapter.handle(msg, payload))
+
+        reply = msg.last_reply()
+        assert reply["ok"] is False
+        assert reply["error"] == "malformed_request"
+        assert reply["job_id"] == "job-err-stt"

--- a/tests/nats/test_tts_adapter.py
+++ b/tests/nats/test_tts_adapter.py
@@ -1746,3 +1746,81 @@ class TestTtsNatsAdapter:
         assert reply["error"] == "engine_unavailable"
         assert "worker_error" in reply
         assert reply["worker_error"]["code"] == "engine_unavailable"
+
+    # ------------------------------------------------------------------
+    # job_id echo (#1840)
+    # ------------------------------------------------------------------
+
+    def test_job_id_echoed_in_success_reply(self, tmp_path: Path) -> None:
+        """job_id from inbound payload is echoed in the TTS success reply."""
+        _require_imports()
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        _setup_adapter(adapter, msg)
+        payload = _valid_payload(request_id="req-jid-ok") | {"job_id": "job-abc-123"}
+
+        def _patched_scoped_path(rid: str, ext: str) -> Path:
+            return tmp_path / f"{rid}.{ext}"
+
+        with patch(
+            "voicecli.engines.engine._get_registry",
+            return_value={"mock": _stub_engine_factory(tmp_path)},
+        ):
+            with patch(
+                "voicecli.adapters.nats.synthesize_adapter.scoped_path",
+                side_effect=_patched_scoped_path,
+            ):
+                asyncio.run(adapter.handle(msg, payload))
+
+        reply = msg.last_reply()
+        assert reply["ok"] is True
+        assert reply["job_id"] == "job-abc-123"
+
+    def test_job_id_absent_not_in_reply(self, tmp_path: Path) -> None:
+        """When job_id is absent, the shim (default_factory=new_job_id) generates a fresh UUID.
+        The reply always carries a job_id — we verify it is present and non-empty."""
+        _require_imports()
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        _setup_adapter(adapter, msg)
+        payload = _valid_payload(request_id="req-nojid")
+        assert "job_id" not in payload  # sanity-check the fixture
+
+        def _patched_scoped_path(rid: str, ext: str) -> Path:
+            return tmp_path / f"{rid}.{ext}"
+
+        with patch(
+            "voicecli.engines.engine._get_registry",
+            return_value={"mock": _stub_engine_factory(tmp_path)},
+        ):
+            with patch(
+                "voicecli.adapters.nats.synthesize_adapter.scoped_path",
+                side_effect=_patched_scoped_path,
+            ):
+                asyncio.run(adapter.handle(msg, payload))
+
+        reply = msg.last_reply()
+        assert reply["ok"] is True
+        # default_factory shim fires — reply always carries a job_id UUID
+        assert "job_id" in reply
+        assert reply["job_id"]  # non-empty shim-generated UUID
+
+    def test_job_id_echoed_in_error_reply(self, tmp_path: Path) -> None:
+        """job_id is echoed even when the adapter returns an error response."""
+        _require_imports()
+        adapter = TtsNatsAdapter(default_engine="mock", max_concurrent=1)
+        msg = MockMsg()
+        _setup_adapter(adapter, msg)
+        # engine_unavailable path — easiest error to trigger without patching blobstore
+        payload = _valid_payload(engine="ghost-engine") | {"job_id": "job-err-xyz"}
+
+        with patch(
+            "voicecli.engines.engine._get_registry",
+            return_value={"mock": _stub_engine_factory(tmp_path)},
+        ):
+            asyncio.run(adapter.handle(msg, payload))
+
+        reply = msg.last_reply()
+        assert reply["ok"] is False
+        assert reply["error"] == "engine_unavailable"
+        assert reply["job_id"] == "job-err-xyz"

--- a/uv.lock
+++ b/uv.lock
@@ -1735,7 +1735,7 @@ wheels = [
 [[package]]
 name = "roxabi-blobs"
 version = "0.1.2"
-source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-blobs&branch=staging#e8578e52c818dbfe46676566a032409a1345efa0" }
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-blobs&branch=staging#da2ebebd52dcd7cf1e564ee3c72f234caeb9e4b2" }
 dependencies = [
     { name = "aiosqlite" },
     { name = "httpx" },
@@ -1744,8 +1744,8 @@ dependencies = [
 
 [[package]]
 name = "roxabi-contracts"
-version = "0.7.0"
-source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-contracts&branch=staging#e8578e52c818dbfe46676566a032409a1345efa0" }
+version = "0.9.0"
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-contracts&branch=staging#da2ebebd52dcd7cf1e564ee3c72f234caeb9e4b2" }
 dependencies = [
     { name = "pydantic" },
 ]
@@ -1753,7 +1753,7 @@ dependencies = [
 [[package]]
 name = "roxabi-nats"
 version = "0.4.2"
-source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-nats&branch=staging#e8578e52c818dbfe46676566a032409a1345efa0" }
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-nats&branch=staging#da2ebebd52dcd7cf1e564ee3c72f234caeb9e4b2" }
 dependencies = [
     { name = "nats-py" },
     { name = "nkeys" },


### PR DESCRIPTION
## Summary

- Echo `job_id` from inbound payload into `TtsResponse` and `SttResponse` on all code paths (success + all error variants)
- Conditional kwarg pattern prevents `job_id=None` from reaching `_validate_job_id` (would raise `TypeError` in contracts 0.9.0)
- Bump `roxabi-contracts` 0.7.0 → 0.9.0 (introduces `WorkEnvelope.job_id` with `default_factory=new_job_id` shim); update `roxabi-nats` + `roxabi-blobs` SHAs
- Add `contracts-bump-caller.yml`: weekly cron (Mon 06:00 UTC) + `workflow_dispatch` calling `roxabi-factory/contracts-bump.yml@staging`
- Tests: 3 new cases each for TTS + STT (echo present, absent/shim, error path); golden wire compat updated to strip shim-generated UUID when payload has no `job_id`

## Test plan

- [ ] `uv run pytest` passes (653 passed, 1 skipped)
- [ ] `uv run pyright` — 0 errors
- [ ] All pre-commit hooks pass (lint, format, typecheck, file-length, folder-size, duplicate-test-basenames)
- [ ] Golden wire compat: 15 error-path cases pass with `job_id` stripped from both sides when payload has none
- [ ] `test_job_id_echoed_in_success_reply` + `test_job_id_absent_not_in_reply` + `test_job_id_echoed_in_error_reply` for TTS and STT

Closes Roxabi/roxabi-factory#1840 (voiceCLI lane — lane #1841 hard-require is blocked until all 3 satellite PRs land)

🤖 Generated with [Claude Code](https://claude.com/claude-code)