### PR TITLE
ci(contracts-bump): stop passing secrets.PAT to factory reusable workflow

### DIFF
--- a/.github/workflows/contracts-bump-caller.yml
+++ b/.github/workflows/contracts-bump-caller.yml
@@ -12,5 +12,3 @@ jobs:
     with:
       satellite_repo: ${{ github.repository }}
       packages: "roxabi-contracts roxabi-nats roxabi-blobs"
-    secrets:
-      PAT: ${{ secrets.PAT }}


### PR DESCRIPTION
## Summary
- Drop the `secrets: PAT` pass-through in `contracts-bump-caller.yml` — the factory reusable workflow stopped using it (roxabi-factory#1850) and its interface is optional since roxabi-factory#1855 (same change as Roxabi/llmCLI#120).
- Unblocks the org PAT revocation (Part of Roxabi/roxabi-factory#1852).

---
Generated with [Claude Code](https://claude.com/claude-code)