### PR TITLE
fix(quadlet): add HealthStartPeriod grace to STT/TTS GPU workers (D-14)

### DIFF
--- a/deploy/quadlet/voicecli-stt.container
+++ b/deploy/quadlet/voicecli-stt.container
@@ -25,6 +25,8 @@ Environment=BLOBSTORE_URL=http://factory-blobstore:8449
 EnvironmentFile=%h/.roxabi/voicecli/env/blobstore.env
 HealthCmd=pgrep -f voicecli
 HealthInterval=30s
+# Grace for STT model cold-load (weights + CUDA init) before health failures count.
+HealthStartPeriod=120s
 NoNewPrivileges=true
 # Drop everything; GPU/CDI device access is granted via AddDevice= directive above.
 DropCapability=all

--- a/deploy/quadlet/voicecli-tts.container
+++ b/deploy/quadlet/voicecli-tts.container
@@ -24,6 +24,8 @@ Environment=BLOBSTORE_URL=http://factory-blobstore:8449
 EnvironmentFile=%h/.roxabi/voicecli/env/blobstore.env
 HealthCmd=pgrep -f voicecli
 HealthInterval=30s
+# Grace for TTS model cold-load (weights + CUDA init) before health failures count.
+HealthStartPeriod=120s
 NoNewPrivileges=true
 DropCapability=all
 


### PR DESCRIPTION
## Change

Adds `HealthStartPeriod=120s` to both `voicecli-stt.container` and `voicecli-tts.container`.

GPU model load (weight transfer + CUDA initialisation) can take well over the default 0 s grace period on a cold container start. Without the start-period, systemd's health-check can declare the container unhealthy and cycle it before inference is ready, causing a restart loop under GPU memory pressure.

Unchanged: `pgrep` probe command, `HealthInterval`, `DropCapability`.

## CI note

**quadlet-lint on this PR will be RED** until PR #198 (`ci/revive-quadlet-lint` — gate revive) merges to staging and this branch is updated onto the new base. The plucky leak-detector false-positive blocks the Podman install step before the dryrun runs; the working dryrun lives in #198.

Merge order: #198 first → rebase this PR → CI green → merge.

## Out of scope

- D-6 `ReadOnly=true` — needs host validation (bind-mount layout)
- D-7 memory caps — needs host validation (GPU cgroup hierarchy)

Supersedes bundled PR #197 (split for clean history).