### PR TITLE
fix(deploy): derive quadlet-install from quadlet dir glob (#1900)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,9 @@ quadlet-install:  ## install Quadlet units to $(QUADLET_DIR) + reload
 	@mkdir -p "$(QUADLET_DIR)"
 	@mkdir -p "$(HOME)/.cache/huggingface" "$(HOME)/.cache/voicecli"
 	@rm -f "$(QUADLET_DIR)"/voicecli*.{network,container}
-	@cp deploy/quadlet/voicecli-stt.container        "$(QUADLET_DIR)/voicecli-stt.container"
-	@cp deploy/quadlet/voicecli-tts.container        "$(QUADLET_DIR)/voicecli-tts.container"
+	@for f in deploy/quadlet/*.container; do \
+		cp "$$f" "$(QUADLET_DIR)/"; \
+	done
 	@systemctl --user daemon-reload
 	@echo "Quadlet units installed."
 	@echo "Next: run 'make quadlet-secrets-install' to (re)create Podman secrets."

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -128,11 +128,11 @@ if [[ "$DRY_RUN" -eq 0 ]]; then
     fi
 fi
 
-for unit in voicecli-stt.container voicecli-tts.container; do
-    src="${SCRIPT_DIR}/quadlet/${unit}"
+for src in "${SCRIPT_DIR}"/quadlet/*.container; do
+    unit="$(basename "$src")"
     dst="${QUADLET_DIR}/${unit}"
     if [[ ! -f "$src" ]]; then
-        echo "ERROR: Quadlet unit not found: $src" >&2
+        echo "ERROR: no .container units found in ${SCRIPT_DIR}/quadlet/" >&2
         exit 1
     fi
     run cp "$src" "$dst"


### PR DESCRIPTION
Refs Roxabi/roxabi-factory#1900 (voiceCLI slice — final wave of the cross-repo manifest-driven install program; factory = roxabi-factory#1902, llmCLI = Roxabi/llmCLI#127).

## What
Replace the hand-enumerated `voicecli-stt/tts` cp lines with a glob over `deploy/quadlet/*.container` in both install paths:
- `Makefile quadlet-install`: 2 hardcoded `cp` lines → glob loop.
- `deploy/install.sh`: hand-list `for unit in …` → `for src in quadlet/*.container`.

voiceCLI already installed both its units (2/2) — this is **drift-proofing** (a future 3rd unit auto-installs; no hand-list to forget), aligning voiceCLI with the factory/llmCLI manifest-driven pattern.

## Verify
- `make -n quadlet-install` → glob loop installs both (`voicecli-stt`, `voicecli-tts`); `rm -f` wipe + daemon-reload preserved.
- `bash -n deploy/install.sh` clean; glob yields both units.
- Unit **files unchanged** — install-mechanism only; same units already running on M₁ (voice-worker). No VRAM/runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)