### PR TITLE
feat(deploy): secrets-policy registry + bidirectional manifest↔install gate (#1901)

### DIFF
--- a/.claude/stack.yml
+++ b/.claude/stack.yml
@@ -67,3 +67,8 @@ quality_gates:
     enabled: true
     script: tools/check_duplicate_test_basenames.sh
     source: pyproject.toml [tool.pytest.ini_options].testpaths
+  quadlet_manifest_install:
+    enabled: true
+    stage: pre-push
+    script: tools/check_quadlet_manifest_install.sh
+    description: bidirectional manifest↔install — every [component.*] container in deploy/quadlet.toml has a source file installed by the deploy/quadlet/*.container glob (Makefile + install.sh), and every on-disk *.container is declared (orphan-install guard, #1901). Also enforced in CI via quadlet-lint.yml.

--- a/.github/workflows/quadlet-lint.yml
+++ b/.github/workflows/quadlet-lint.yml
@@ -8,6 +8,10 @@ on:
     branches: [main, staging]
     paths:
       - "deploy/quadlet/**"
+      - "deploy/quadlet.toml"
+      - "deploy/install.sh"
+      - "Makefile"
+      - "tools/check_quadlet_manifest_install.sh"
   workflow_dispatch: {}
 
 concurrency:
@@ -109,3 +113,11 @@ jobs:
             exit 1
           fi
           echo "No inline comments on value lines — OK"
+
+      - name: Manifest↔install gate (#1901)
+        # Bidirectional: every declared [component.*] container has a source file
+        # installed by the deploy/quadlet/*.container glob, and every on-disk
+        # *.container is declared in quadlet.toml (orphan-install guard). Mirrors
+        # the pre-push hook so the gate also blocks in CI. Needs python3+tomllib
+        # (ubuntu-latest ships 3.12) and git (checkout above) — no Podman.
+        run: bash tools/check_quadlet_manifest_install.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,3 +59,9 @@ repos:
       language: system
       pass_filenames: false
       stages: [pre-push]
+    - id: quadlet-manifest-install
+      name: quadlet manifest↔install gate
+      entry: tools/check_quadlet_manifest_install.sh
+      language: system
+      pass_filenames: false
+      stages: [pre-push]

--- a/deploy/secrets-policy.toml
+++ b/deploy/secrets-policy.toml
@@ -1,0 +1,33 @@
+# deploy/secrets-policy.toml — voiceCLI secret policy registry
+#
+# Sibling to deploy/quadlet.toml (per the Roxabi container-deployment-standard):
+#   - quadlet.toml          required_secrets: which secrets each component needs
+#   - secrets-policy.toml:                    what each Podman secret IS and where it comes from
+#
+# source: path relative to the tool data dir (~/.roxabi/voicecli/)
+#         use literal "n/a" for secrets with no file-based source (generated at runtime)
+#
+# policy values:
+#   nats-seed   NKey seed file — provisioned per host identity (factory NKey tooling / nsc);
+#               treat as required (hard-fail if the source file is missing).
+#   required    Vital external credential — hard-fail if source missing; not recreatable in-band.
+#   optional    External credential — provisioned manually; missing = skip, not error.
+#
+# NOTE: the blobstore bearer token (deploy/quadlet.toml [secrets].blobstore_bearer_token)
+# is an EnvironmentFile credential (~/.roxabi/voicecli/env/blobstore.env), NOT a Podman
+# secret, so it is intentionally absent here — this registry tracks Podman secrets only.
+
+# ── NATS NKey seeds (one per voiceCLI container identity) ─────────────────────
+
+[secret.voicecli-nats-stt]
+policy = "nats-seed"
+source = "nkeys/voice-stt.seed"
+# Mounted for voicecli-stt; created by `make quadlet-secrets-install` from
+# $(VOICECLI_NKEYS_DIR)/voice-stt.seed (VOICECLI_NKEYS_DIR = ~/.roxabi/voicecli/nkeys).
+# voice-worker hosts only (M₁).
+
+[secret.voicecli-nats-tts]
+policy = "nats-seed"
+source = "nkeys/voice-tts.seed"
+# Mounted for voicecli-tts; created from $(VOICECLI_NKEYS_DIR)/voice-tts.seed.
+# voice-worker hosts only (M₁).

--- a/tools/check_quadlet_manifest_install.sh
+++ b/tools/check_quadlet_manifest_install.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# tools/check_quadlet_manifest_install.sh — bidirectional manifest↔install gate (voiceCLI).
+#
+# deploy/quadlet.toml is the authoritative component manifest. This gate asserts
+# BOTH directions so a declared component is always installed AND no installed
+# unit file is undeclared (the orphan-install class).
+#
+#   Forward:  every [component.*] container in quadlet.toml has its source file in
+#             deploy/quadlet/ AND the install paths (Makefile quadlet-install +
+#             deploy/install.sh) install via a deploy/quadlet/*.container glob, so
+#             any declared unit's file is necessarily installed.
+#   Reverse:  every deploy/quadlet/*.container file is declared in quadlet.toml.
+#
+# voiceCLI has no [volume.*]/[network.*]/[pod.*], no converge.sh, and no
+# quadlet-install-verify UNITS array, so this gate is container-only — cf. the
+# fuller roxabi-factory variant. The [secrets] block (env-file credential) is
+# not a Quadlet unit and is ignored here.
+#
+# EXIT-CODE CONTRACT (roxabi container-deployment-standard): 0 = clean,
+# 1 = violations found (merge-blocking), 2 = script setup error.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)" \
+    || { echo "ERROR: not a git repository" >&2; exit 2; }
+
+# Paths are env-overridable for testing; defaults are the repo-root locations.
+QUADLET_TOML="${QUADLET_TOML:-deploy/quadlet.toml}"
+QUADLET_DIR="${QUADLET_DIR:-deploy/quadlet}"
+MAKEFILE="${MAKEFILE:-Makefile}"
+INSTALL_SH="${INSTALL_SH:-deploy/install.sh}"
+
+for req in "$QUADLET_TOML" "$MAKEFILE" "$INSTALL_SH"; do
+    if [[ ! -f "$req" ]]; then
+        echo "ERROR: required file not found: $req" >&2
+        exit 2
+    fi
+done
+if ! command -v python3 >/dev/null 2>&1 || ! python3 -c 'import tomllib' >/dev/null 2>&1; then
+    echo "ERROR: python3 with tomllib (Python 3.11+) required" >&2
+    exit 2
+fi
+
+fail=0
+
+# Declared container basenames, one per line.
+mapfile -t DECLARED < <(python3 - "$QUADLET_TOML" <<'PYEOF'
+import sys
+import tomllib
+
+with open(sys.argv[1], "rb") as f:
+    data = tomllib.load(f)
+for comp in data.get("component", {}).values():
+    container = comp.get("container")
+    if container:
+        print(container)
+PYEOF
+)
+
+if [[ ${#DECLARED[@]} -eq 0 ]]; then
+    echo "FAIL: no [component.*] containers parsed from $QUADLET_TOML — gate validated nothing" >&2
+    exit 1
+fi
+
+# Install paths must use a dir-glob so any declared unit's file is installed.
+if ! grep -qF 'deploy/quadlet/*.container' "$MAKEFILE"; then
+    echo "FAIL: $MAKEFILE quadlet-install does not glob deploy/quadlet/*.container — install is not manifest-driven" >&2
+    fail=1
+fi
+if ! grep -qF 'quadlet/*.container' "$INSTALL_SH"; then
+    echo "FAIL: $INSTALL_SH does not glob quadlet/*.container — install is not manifest-driven" >&2
+    fail=1
+fi
+
+# Forward: every declared container has its source file on disk (the glob installs it).
+for container in "${DECLARED[@]}"; do
+    if [[ ! -f "$QUADLET_DIR/$container" ]]; then
+        echo "FAIL: $container declared in $QUADLET_TOML but $QUADLET_DIR/$container does not exist (glob cannot install it)" >&2
+        echo "::error file=$QUADLET_TOML::declared container $container has no source file in $QUADLET_DIR/"
+        fail=1
+    fi
+done
+
+# Reverse: every on-disk *.container file is declared in the manifest.
+declared_set=" ${DECLARED[*]} "
+for fpath in "$QUADLET_DIR"/*.container; do
+    [[ -e "$fpath" ]] || continue   # no-match glob guard
+    fname="$(basename "$fpath")"
+    if [[ "$declared_set" != *" $fname "* ]]; then
+        echo "FAIL: $QUADLET_DIR/$fname is installed by the quadlet glob but NOT declared in $QUADLET_TOML (orphan install)" >&2
+        echo "::error file=$QUADLET_DIR/$fname::orphan unit — declare it in $QUADLET_TOML [component.*] or remove the file"
+        fail=1
+    fi
+done
+
+if [[ "$fail" -ne 0 ]]; then
+    echo "" >&2
+    echo "Every [component.*] container in $QUADLET_TOML must have a source file installed by the" >&2
+    echo "deploy/quadlet/*.container glob in $MAKEFILE + $INSTALL_SH, and every on-disk *.container" >&2
+    echo "must be declared in the manifest (#1901)." >&2
+    exit 1
+fi
+
+echo "quadlet manifest install check passed (bidirectional, container-only)"
+exit 0


### PR DESCRIPTION
Refs #1901 (voiceCLI gate — wave 6; protects the #1900 manifest-driven install shipped in #200).

## What
- **`deploy/secrets-policy.toml`** (new): declares voiceCLI's two Podman NKey-seed secrets (`voicecli-nats-stt`/`tts` → `nkeys/voice-*.seed` under `~/.roxabi/voicecli/`). The env-file blobstore bearer token is intentionally excluded (it's an `EnvironmentFile` credential, not a Podman secret). Provides the per-repo policy the security/baseline source↔secret audit (#1901 wave 7) cross-references.
- **`tools/check_quadlet_manifest_install.sh`** (new): bidirectional manifest↔install guard (declared `[component.*]` ↔ on-disk `*.container`), container-only — same pattern as roxabi-factory#1904 / llmCLI#128.
- Wired: `.pre-commit-config.yaml` pre-push hook, `.claude/stack.yml`, and CI via `quadlet-lint.yml` (+ extended path triggers).

## Verify (lead-run)
- gate positive → **0**; reverse-orphan neg → **1** (recovers to 0); `bash -n` clean; `secrets-policy.toml` valid TOML (2 seeds); 3 YAML valid; pre-commit + pre-push hooks green on commit/push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)