### PR TITLE
chore: gitignore repo-root .worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ voicecli.vocab
 .env
 .claude/settings.local.json
 .claude/worktrees/
+.worktrees/
 
 .claude/dev-core.yml
 # CocoIndex Code (ccc)


### PR DESCRIPTION
Adds `.worktrees/` to `.gitignore` (local worktree checkouts, same intent as `.claude/worktrees/`).