### PR TITLE
feat(fleet): roxabi-obs reporter for STT/TTS workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ voicecli nats-serve stt --model large-v3   # STT satellite with specific model
 
 ```toml
 [nats]
-max_cached_engines = 2  # keep N engines hot
+max_cached_engines = 1  # engines kept hot in VRAM (LRU). Default: 1. Loads on first request.
 ```
 
 See [docs/NATS-SERVE.md](docs/NATS-SERVE.md) for full deployment guide.

--- a/deploy/quadlet/voicecli-stt.container
+++ b/deploy/quadlet/voicecli-stt.container
@@ -9,6 +9,8 @@ StartLimitBurst=5
 Image=ghcr.io/roxabi/voicecli-stt:staging
 Label=io.containers.autoupdate=registry
 ContainerName=voicecli-stt
+Environment=CONTAINER_NAME=voicecli-stt
+Environment=IMAGE_REF=ghcr.io/roxabi/voicecli-stt:staging
 Network=roxabi.network
 Volume=%h/.cache/huggingface:/home/voicecli/.cache/huggingface
 Volume=%h/.cache/voicecli:/home/voicecli/.cache/voicecli

--- a/deploy/quadlet/voicecli-tts.container
+++ b/deploy/quadlet/voicecli-tts.container
@@ -9,6 +9,8 @@ StartLimitBurst=5
 Image=ghcr.io/roxabi/voicecli-tts:staging
 Label=io.containers.autoupdate=registry
 ContainerName=voicecli-tts
+Environment=CONTAINER_NAME=voicecli-tts
+Environment=IMAGE_REF=ghcr.io/roxabi/voicecli-tts:staging
 Network=roxabi.network
 Volume=%h/.cache/huggingface:/home/voicecli/.cache/huggingface
 Volume=%h/.cache/voicecli:/home/voicecli/.cache/voicecli

--- a/docs/NATS-SERVE.md
+++ b/docs/NATS-SERVE.md
@@ -26,8 +26,12 @@ dependency on voicecli, enabling each service to be deployed and restarted indep
 1. Validate env vars and file permissions (seed file `0600`).
 2. Run the VRAM-sequencing guard (probe local socket daemon).
 3. Connect to NATS and join the queue group (`tts_workers` / `stt_workers`).
-4. Load the TTS/STT engine model into VRAM.
-5. Begin accepting requests and publishing heartbeats.
+4. Configure `model_registry` (`max_cached_engines`, default **1**) — **no model is loaded yet**.
+5. Begin accepting requests and publishing heartbeats (`model_loaded` is empty until the first inference).
+
+Models load **lazily on the first request** (VRAM lifecycle #36/#37, ADR-095): TTS via
+`model_registry.get(engine)` inside the synthesis executor; STT via idempotent `warmup_model()`
+on the first transcription. See [Model loading and VRAM cache](#model-loading-and-vram-cache).
 
 Both subcommands are now available: `nats-serve tts` (Slice 1) and `nats-serve stt` (Slice 2).
 
@@ -204,7 +208,8 @@ loop-restarts on exit 78. `stopwaitsecs=35` must exceed `VOICECLI_DRAIN_TIMEOUT`
 |---|---|---|
 | Process exits 78 immediately on startup | Live socket daemon (`tts-serve` / `stt-serve`) detected | Stop the socket daemon (`systemctl --user stop voicecli-tts` or `pkill -f 'voicecli serve'`), then restart; or pass `--allow-coexist` if coexistence is intentional |
 | `PermissionError` referencing the seed file path | NKey seed file is not `0600` | `chmod 600 ~/.roxabi/voicecli/nkeys/voice-tts.seed` |
-| Replies never arrive at the hub / requests time out | Wrong `NATS_URL`, network partition, or mismatched queue group name | Verify `NATS_URL` is reachable from the satellite host; queue group names are `tts_workers` (TTS) and `stt_workers` (STT) |
+| Replies never arrive at the hub / requests time out | Wrong `NATS_URL`, network partition, mismatched queue group, or **worker crash loop** | Verify `NATS_URL` is reachable; queue groups are `tts_workers` / `stt_workers`. On the hub: `systemctl --user is-active voicecli-stt voicecli-tts` and `podman logs voicecli-stt`. Stale images missing `roxabi-contracts` updates crash at import (`VoiceLifecycleRequest`) — `podman pull ghcr.io/roxabi/voicecli-{stt,tts}:staging && systemctl --user restart voicecli-{stt,tts}` |
+| `dictate nats` records but transcribe times out (60 s) | STT satellite down while NATS TCP probe still passes | Client records locally; failure is on stop+transcribe. Restart `voicecli-stt` on the hub (see above) |
 | Heartbeats stop arriving during a synthesis | Concurrency contract violated (bug) | Report it — the spec guarantees heartbeats continue independently of in-flight synthesis |
 | Hub logs `payload_too_large` | Reply WAV exceeds NATS server `max_payload` | Increase `max_payload` in the NATS server config, or shorten the synthesis text |
 | Satellite starts but produces no output; logs show CUDA OOM | VRAM exhausted by coexisting processes | Stop other GPU-heavy daemons, reduce `VOICECLI_MAX_CONCURRENT`, or move to a host with more VRAM |
@@ -216,11 +221,14 @@ loop-restarts on exit 78. `stopwaitsecs=35` must exceed `VOICECLI_DRAIN_TIMEOUT`
 The satellite logs its startup sequence to stdout. A healthy start looks like:
 
 ```
-INFO  vram-guard: no live socket daemon detected — proceeding
-INFO  nats: connected to nats://127.0.0.1:4222
-INFO  engine: model loaded in 12.3s (qwen-fast)
+INFO  model_registry configured: max_cached=1
+INFO  nats: connected to nats://factory-nats:4222
 INFO  nats-serve: joined queue group tts_workers — ready
 ```
+
+Heartbeats before the first request show `"model_loaded": []` (TTS) or `"model_loaded": null`
+(STT). After the first successful inference, `model_loaded` reflects the warm engine(s).
+Cold-load latency (~10–30 s TTS, ~5–15 s STT) is paid on that first request, not at boot.
 
 If the process exits before the "ready" line, check `stderr_logfile` for the Python
 traceback. The most common causes are: missing env vars, seed file permission error, NATS
@@ -280,6 +288,22 @@ ADR-044 freezes the TTS request envelope in `lyra/artifacts/plans/688-voicecli-c
 
 ---
 
+## Model loading and VRAM cache
+
+NATS satellites intentionally **do not preload** ML weights at boot. This keeps startup
+fast (<1 s after NATS connect) and avoids pinning VRAM before any request arrives.
+
+| Modality | When the model loads | What stays in VRAM |
+|---|---|---|
+| TTS | First `api.generate` / `api.clone` for a given `engine` | Up to `max_cached_engines` engines in `model_registry` (LRU + VRAM eviction) |
+| STT | First `warmup_model()` inside `run_transcription` | One whisper model for the process lifetime |
+
+**Contrast with socket daemons** (`voicecli serve --engine qwen`): optional eager preload at
+daemon start for local low-latency CLI use. Do not run socket daemons alongside NATS
+satellites on the same GPU — the VRAM-sequencing guard (exit 78) enforces this.
+
+---
+
 ## Engine hot-swapping
 
 The TTS satellite supports **per-request engine switching** — a single satellite can serve
@@ -300,11 +324,13 @@ In `voicecli.toml`:
 
 ```toml
 [nats]
-max_cached_engines = 2  # keep N engines hot (default: 2)
+max_cached_engines = 1  # engines kept hot in VRAM (LRU). Default: 1.
 ```
 
-Higher values keep more engines hot but require more VRAM. On a 10 GB GPU, 2 engines
-is the practical limit (qwen-fast ~3.5 GB + chatterbox ~1.8 GB = ~5.3 GB steady-state).
+With the default of **1**, only the **most recently used** engine stays loaded; switching
+engines evicts the previous one (VRAM-aware). Raise to `2` only when the GPU has headroom —
+on a 10 GB RTX 3080, `qwen-fast` (~7.4 GB) alone nearly fills the budget; a second slot
+is only realistic for smaller engines (e.g. `chatterbox` ~2 GB + another small model).
 
 ### Heartbeat visibility
 
@@ -439,7 +465,7 @@ Error codes:
 | `malformed_request` | Missing or invalid `request_id`, missing `audio_b64`, or `request_id` fails format validation |
 | `audio_decode_failed` | `audio_b64` is not valid base64 |
 | `transcription_failed` | faster-whisper raised an exception during inference |
-| `model_load_failed` | Model could not be loaded into VRAM at startup |
+| `model_load_failed` | faster-whisper model could not be loaded into VRAM on the **first** transcription request (STT lazy warmup) |
 | `capacity_exceeded` | All semaphore slots busy and `VOICECLI_REJECT_WHEN_FULL=1` |
 | `payload_too_large` | Reply payload exceeds the NATS server `max_payload` limit |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,12 +94,12 @@ For distributed TTS/STT deployment via NATS. The satellite supports **per-reques
 
 ```toml
 [nats]
-max_cached_engines = 2   # engines to keep hot (LRU cache). Default: 2.
+max_cached_engines = 1   # engines kept hot in VRAM (LRU cache). Default: 1.
 ```
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `max_cached_engines` | `2` | Maximum engines cached in VRAM. Evicts LRU when full. |
+| `max_cached_engines` | `1` | Maximum engines cached in VRAM (LRU). Evicts oldest when full; models load on first request, not at satellite boot. |
 
 **How per-request switching works:**
 

--- a/docs/dictation-setup.md
+++ b/docs/dictation-setup.md
@@ -345,6 +345,32 @@ still functions normally.
 
 ## Troubleshooting
 
+### NATS dictate (`voicecli dictate nats` / Ctrl+Space wrapper)
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Notification **"Hub injoignable: host:port"** | Hub offline, Tailscale down, or wrong `[nats] url` | `nc -z -w2 <host> 4222`; fix `voicecli.toml` or `NATS_URL` |
+| Notification **"Dictate failed: request timed out after 60s"** | `voicecli-stt` not running on the hub, or crash loop | On the hub: `systemctl --user is-active voicecli-stt` → `podman pull ghcr.io/roxabi/voicecli-stt:staging && systemctl --user restart voicecli-stt` |
+| First dictation slow (~5–15 s) after worker restart | Cold-load whisper on first NATS request (lazy VRAM) | Normal — subsequent dictations are faster |
+| Empty clipboard / no text | Silence or VAD removed all audio | Speak closer to the mic; check `~/.local/state/voicecli/recorder.log` |
+| **"Dictate failed: …"** with `ImportError` / `No such command 'nats'` | Stale local checkout or missing `[nats]` extra | Wrapper auto-heals when possible; else `cd ~/projects/voiceCLI && git checkout staging && uv sync --extra nats` |
+
+The wrapper only probes **TCP reachability** of the NATS port (2 s). A reachable hub with a
+down STT worker still accepts the recording; the failure appears on the **second** Ctrl+Space
+(stop + transcribe), not the first.
+
+Verify the hub worker from the satellite host:
+
+```bash
+ssh hub 'systemctl --user is-active voicecli-stt && podman ps --filter name=voicecli-stt'
+```
+
+See [NATS-SERVE.md](./NATS-SERVE.md) for satellite startup, lazy model loading, and image
+pinning (`roxabi-contracts` must match the container tag — stale `:staging` images can
+crash-loop with `ImportError: VoiceLifecycleRequest`).
+
+### Socket daemon (`voicecli dictate` without `nats`)
+
 **"STT daemon not running"**
 
 Start the daemon:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ pkuseg = ["numpy"]
 voxtral-tts = { git = "https://github.com/Roxabi/voxtral-tts.git", branch = "main" }
 roxabi-contracts = { git = "https://github.com/Roxabi/roxabi-factory.git", subdirectory = "packages/roxabi-contracts", branch = "staging" }
 roxabi-nats = { git = "https://github.com/Roxabi/roxabi-factory.git", subdirectory = "packages/roxabi-nats", branch = "staging" }
+roxabi-obs = { git = "https://github.com/Roxabi/roxabi-factory.git", subdirectory = "packages/roxabi-obs", branch = "staging" }
 roxabi-otel = { git = "https://github.com/Roxabi/roxabi-factory.git", subdirectory = "packages/roxabi-otel", branch = "staging" }
 roxabi-satellite = { git = "https://github.com/Roxabi/roxabi-factory.git", subdirectory = "packages/roxabi-satellite", branch = "staging" }
 
@@ -86,6 +87,7 @@ nats = [
     "roxabi-satellite",
     "roxabi-nats",
     "roxabi-otel",
+    "roxabi-obs",
     "nats-py>=2.6,<3",
     "nkeys>=0.1",
     "nvidia-ml-py>=12,<14",

--- a/src/voicecli/adapters/nats/_fleet_runner.py
+++ b/src/voicecli/adapters/nats/_fleet_runner.py
@@ -1,0 +1,35 @@
+"""Wire roxabi-obs fleet reporter alongside NATS satellite adapters."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from roxabi_nats.adapter_base import NatsAdapterBase
+
+
+async def run_adapter_with_fleet_reporter(
+    adapter: NatsAdapterBase,
+    nats_url: str,
+) -> None:
+    from roxabi_nats import nats_connect
+    from roxabi_obs import cancel_fleet_reporter, start_fleet_reporter
+
+    nc = await nats_connect(
+        nats_url,
+        identity_name=adapter._identity_name,
+        inbox_prefix=adapter._inbox_prefix,
+    )
+    fleet_task = await start_fleet_reporter(nc)
+    try:
+        await adapter.run_embedded(nc)
+    finally:
+        await cancel_fleet_reporter(fleet_task)
+
+
+def run_adapter_with_fleet_reporter_sync(
+    adapter: NatsAdapterBase,
+    nats_url: str,
+) -> None:
+    asyncio.run(run_adapter_with_fleet_reporter(adapter, nats_url))

--- a/src/voicecli/cli/nats.py
+++ b/src/voicecli/cli/nats.py
@@ -47,8 +47,6 @@ def nats_serve_tts(
     ] = False,
 ) -> None:
     """Subscribe to the TTS request subject and reply with synthesized audio."""
-    import asyncio
-
     from voicecli.core.config import apply_nats_env_from_config, load_nats_config
     from voicecli.runtime.model_registry import model_registry
     from voicecli.adapters.nats.config import _probe_socket_daemon, _resolve_engine
@@ -95,7 +93,9 @@ def nats_serve_tts(
         lifecycle_hooks=build_lifecycle_hooks("voicecli-tts"),
     )
 
-    asyncio.run(adapter.run(nats_url))
+    from voicecli.adapters.nats._fleet_runner import run_adapter_with_fleet_reporter_sync
+
+    run_adapter_with_fleet_reporter_sync(adapter, nats_url)
 
 
 @nats_app.command("stt")
@@ -118,8 +118,6 @@ def nats_serve_stt(
     ] = False,
 ) -> None:
     """Subscribe to the STT request subject and reply with transcription."""
-    import asyncio
-
     from voicecli.core.config import apply_nats_env_from_config
     from voicecli.adapters.nats.config import _probe_socket_daemon, _resolve_model
     from voicecli.adapters.nats.transcribe_adapter import SttNatsAdapter
@@ -161,4 +159,6 @@ def nats_serve_stt(
         lifecycle_hooks=build_lifecycle_hooks("voicecli-stt"),
     )
 
-    asyncio.run(adapter.run(nats_url))
+    from voicecli.adapters.nats._fleet_runner import run_adapter_with_fleet_reporter_sync
+
+    run_adapter_with_fleet_reporter_sync(adapter, nats_url)

--- a/tests/nats/test_connect.py
+++ b/tests/nats/test_connect.py
@@ -68,16 +68,14 @@ class TestNkeyEnvVarResolution:
         with (
             patch("voicecli.adapters.nats.config._probe_socket_daemon", return_value="absent"),
             patch(
-                "voicecli.adapters.nats.synthesize_adapter.TtsNatsAdapter.run",
-                new_callable=AsyncMock,
+                "voicecli.adapters.nats._fleet_runner.run_adapter_with_fleet_reporter_sync",
             ) as mock_run,
         ):
             result = CliRunner().invoke(app, ["nats-serve", "tts", "--engine", "qwen-fast"])
 
         assert result.exit_code == 0, result.output
         assert mock_run.call_count == 1
-        # SDK's run() takes nats_url positionally; nkey seed is read from env by SDK
-        assert mock_run.call_args.args == ("nats://localhost:4222",)
+        assert mock_run.call_args.args[1] == "nats://localhost:4222"
 
     def test_cli_connects_without_nkey_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """CLI successfully starts adapter even without NATS_NKEY_SEED_PATH (dev mode)."""
@@ -93,8 +91,7 @@ class TestNkeyEnvVarResolution:
         with (
             patch("voicecli.adapters.nats.config._probe_socket_daemon", return_value="absent"),
             patch(
-                "voicecli.adapters.nats.synthesize_adapter.TtsNatsAdapter.run",
-                new_callable=AsyncMock,
+                "voicecli.adapters.nats._fleet_runner.run_adapter_with_fleet_reporter_sync",
             ) as mock_run,
         ):
             result = CliRunner().invoke(app, ["nats-serve", "tts", "--engine", "qwen-fast"])
@@ -134,8 +131,7 @@ class TestVramGuard:
         with (
             patch("voicecli.adapters.nats.config._probe_socket_daemon", return_value="stale"),
             patch(
-                "voicecli.adapters.nats.synthesize_adapter.TtsNatsAdapter.run",
-                new_callable=AsyncMock,
+                "voicecli.adapters.nats._fleet_runner.run_adapter_with_fleet_reporter_sync",
             ),
         ):
             result = CliRunner().invoke(app, ["nats-serve", "tts"])
@@ -165,15 +161,14 @@ class TestSttConnect:
         with (
             patch("voicecli.adapters.nats.config._probe_socket_daemon", return_value="absent"),
             patch(
-                "voicecli.adapters.nats.transcribe_adapter.SttNatsAdapter.run",
-                new_callable=AsyncMock,
+                "voicecli.adapters.nats._fleet_runner.run_adapter_with_fleet_reporter_sync",
             ) as mock_run,
         ):
             result = CliRunner().invoke(app, ["nats-serve", "stt", "--model", "base"])
 
         assert result.exit_code == 0, result.output
         assert mock_run.call_count == 1
-        assert mock_run.call_args.args == ("nats://localhost:4222",)
+        assert mock_run.call_args.args[1] == "nats://localhost:4222"
 
 
 class TestMissingNatsUrl:
@@ -286,8 +281,7 @@ class TestNatsUrlSchemeValidation:
             caplog.at_level(logging.WARNING, logger="voicecli.nats-serve.tts"),
             patch("voicecli.adapters.nats.config._probe_socket_daemon", return_value="absent"),
             patch(
-                "voicecli.adapters.nats.synthesize_adapter.TtsNatsAdapter.run",
-                new_callable=AsyncMock,
+                "voicecli.adapters.nats._fleet_runner.run_adapter_with_fleet_reporter_sync",
             ) as mock_run,
         ):
             result = CliRunner().invoke(app, ["nats-serve", "tts"])
@@ -316,8 +310,7 @@ class TestNatsUrlSchemeValidation:
             caplog.at_level(logging.WARNING, logger="voicecli.nats-serve.tts"),
             patch("voicecli.adapters.nats.config._probe_socket_daemon", return_value="absent"),
             patch(
-                "voicecli.adapters.nats.synthesize_adapter.TtsNatsAdapter.run",
-                new_callable=AsyncMock,
+                "voicecli.adapters.nats._fleet_runner.run_adapter_with_fleet_reporter_sync",
             ) as mock_run,
         ):
             result = CliRunner().invoke(app, ["nats-serve", "tts"])
@@ -346,8 +339,7 @@ class TestNatsUrlSchemeValidation:
             caplog.at_level(logging.WARNING, logger="voicecli.nats-serve.stt"),
             patch("voicecli.adapters.nats.config._probe_socket_daemon", return_value="absent"),
             patch(
-                "voicecli.adapters.nats.transcribe_adapter.SttNatsAdapter.run",
-                new_callable=AsyncMock,
+                "voicecli.adapters.nats._fleet_runner.run_adapter_with_fleet_reporter_sync",
             ) as mock_run,
         ):
             result = CliRunner().invoke(app, ["nats-serve", "stt"])
@@ -430,8 +422,7 @@ class TestNatsUrlSchemeValidation:
             caplog.at_level(logging.WARNING, logger="voicecli.nats-serve.stt"),
             patch("voicecli.adapters.nats.config._probe_socket_daemon", return_value="absent"),
             patch(
-                "voicecli.adapters.nats.transcribe_adapter.SttNatsAdapter.run",
-                new_callable=AsyncMock,
+                "voicecli.adapters.nats._fleet_runner.run_adapter_with_fleet_reporter_sync",
             ) as mock_run,
         ):
             result = CliRunner().invoke(app, ["nats-serve", "stt"])

--- a/uv.lock
+++ b/uv.lock
@@ -1862,7 +1862,7 @@ wheels = [
 [[package]]
 name = "roxabi-blobs"
 version = "0.1.2"
-source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-blobs&branch=staging#0bebd39b7228eb2fd5353406ea8e7b3f4fcfbd91" }
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-blobs&branch=staging#f717d8aecffb2be80a3e67e6db5089de25dd7625" }
 dependencies = [
     { name = "aiosqlite" },
     { name = "httpx" },
@@ -1872,7 +1872,7 @@ dependencies = [
 [[package]]
 name = "roxabi-contracts"
 version = "0.13.0"
-source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-contracts&branch=staging#0bebd39b7228eb2fd5353406ea8e7b3f4fcfbd91" }
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-contracts&branch=staging#f717d8aecffb2be80a3e67e6db5089de25dd7625" }
 dependencies = [
     { name = "pydantic" },
 ]
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "roxabi-nats"
 version = "0.4.2"
-source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-nats&branch=staging#0bebd39b7228eb2fd5353406ea8e7b3f4fcfbd91" }
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-nats&branch=staging#f717d8aecffb2be80a3e67e6db5089de25dd7625" }
 dependencies = [
     { name = "nats-py" },
     { name = "nkeys" },
@@ -1890,7 +1890,7 @@ dependencies = [
 [[package]]
 name = "roxabi-obs"
 version = "0.1.0"
-source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-obs&branch=staging#0bebd39b7228eb2fd5353406ea8e7b3f4fcfbd91" }
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-obs&branch=staging#f717d8aecffb2be80a3e67e6db5089de25dd7625" }
 dependencies = [
     { name = "roxabi-contracts" },
     { name = "roxabi-nats" },
@@ -1899,7 +1899,7 @@ dependencies = [
 [[package]]
 name = "roxabi-otel"
 version = "0.1.0"
-source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-otel&branch=staging#0bebd39b7228eb2fd5353406ea8e7b3f4fcfbd91" }
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-otel&branch=staging#f717d8aecffb2be80a3e67e6db5089de25dd7625" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
@@ -1910,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "roxabi-satellite"
 version = "0.1.0"
-source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-satellite&branch=staging#0bebd39b7228eb2fd5353406ea8e7b3f4fcfbd91" }
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-satellite&branch=staging#f717d8aecffb2be80a3e67e6db5089de25dd7625" }
 dependencies = [
     { name = "pydantic" },
     { name = "roxabi-blobs" },

--- a/uv.lock
+++ b/uv.lock
@@ -1888,6 +1888,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxabi-obs"
+version = "0.1.0"
+source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-obs&branch=staging#0bebd39b7228eb2fd5353406ea8e7b3f4fcfbd91" }
+dependencies = [
+    { name = "roxabi-contracts" },
+    { name = "roxabi-nats" },
+]
+
+[[package]]
 name = "roxabi-otel"
 version = "0.1.0"
 source = { git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-otel&branch=staging#0bebd39b7228eb2fd5353406ea8e7b3f4fcfbd91" }
@@ -2403,6 +2412,7 @@ all = [
     { name = "nvidia-ml-py" },
     { name = "qwen-tts" },
     { name = "roxabi-nats" },
+    { name = "roxabi-obs" },
     { name = "roxabi-otel" },
     { name = "roxabi-satellite" },
     { name = "torch" },
@@ -2416,6 +2426,7 @@ nats = [
     { name = "nkeys" },
     { name = "nvidia-ml-py" },
     { name = "roxabi-nats" },
+    { name = "roxabi-obs" },
     { name = "roxabi-otel" },
     { name = "roxabi-satellite" },
 ]
@@ -2468,6 +2479,7 @@ requires-dist = [
     { name = "pynput", marker = "extra == 'hotkey'", specifier = ">=1.7" },
     { name = "qwen-tts", marker = "extra == 'tts'" },
     { name = "roxabi-nats", marker = "extra == 'nats'", git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-nats&branch=staging" },
+    { name = "roxabi-obs", marker = "extra == 'nats'", git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-obs&branch=staging" },
     { name = "roxabi-otel", marker = "extra == 'nats'", git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-otel&branch=staging" },
     { name = "roxabi-satellite", marker = "extra == 'nats'", git = "https://github.com/Roxabi/roxabi-factory.git?subdirectory=packages%2Froxabi-satellite&branch=staging" },
     { name = "scipy", marker = "extra == 'voxtral'" },

--- a/voicecli.example.toml
+++ b/voicecli.example.toml
@@ -15,7 +15,7 @@ engine = "qwen"
 
 # ── NATS satellite settings ───────────────────────────────────────────────────
 # [nats]
-# max_cached_engines = 2   # engines to keep hot (LRU cache). Default: 2.
+# max_cached_engines = 1   # engines kept hot in VRAM (LRU cache). Default: 1. Loads on first request.
 #                          # Per-request engine switching is supported — the satellite
 #                          # hot-swaps engines via LRU eviction with VRAM awareness.
 


### PR DESCRIPTION
## Summary

Block 8 from fleet container observability — wire `roxabi-obs` fleet reporter into NATS serve workers.

- Pin `roxabi-obs` + `roxabi-contracts` from `roxabi-factory` `staging`
- `run_adapter_with_fleet_reporter` uses `run_embedded` + background `ContainerReport` publish
- Quadlets: `CONTAINER_NAME` + `IMAGE_REF` env for `voicecli-stt` / `voicecli-tts`

Depends on Roxabi/roxabi-factory#2065 (merged) + ACL publish grants (factory PR post-MVP).

## Test plan

- [x] pre-commit (lint, typecheck)
- [ ] rebuild `ghcr.io/roxabi/voicecli-{stt,tts}:staging` + M₁ pull/restart
- [ ] `/fleet` shows voiceCLI rows OK after deploy